### PR TITLE
Enable component guide

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,6 @@ Rails.application.routes.draw do
 
     get "/session-expired", to: "session_expired#show"
   end
+
+  mount GovukPublishingComponents::Engine, at: "/component-guide"
 end


### PR DESCRIPTION
In preparation for the new app-level components – to be able to preview and document them.

[Trello card](https://trello.com/c/toQtV8Ad)