### PR TITLE
Add medical help question

### DIFF
--- a/app/controllers/coronavirus_form/urgent_medical_help_controller.rb
+++ b/app/controllers/coronavirus_form/urgent_medical_help_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::UrgentMedicalHelpController < ApplicationController
+  skip_before_action :check_first_question
+
+  def submit
+    @form_responses = {
+      urgent_medical_help: strip_tags(params[:urgent_medical_help]).presence,
+    }
+
+    invalid_fields = validate_radio_field(
+      controller_name,
+      radio: @form_responses[:urgent_medical_help],
+    )
+
+    if invalid_fields.any?
+      flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
+      render controller_path
+    else
+      update_session_store
+      # redirect_to nil
+    end
+  end
+
+private
+
+  def update_session_store
+    session[:urgent_medical_help] = @form_responses[:urgent_medical_help]
+  end
+
+  def previous_path
+    "/"
+  end
+end

--- a/app/views/coronavirus_form/urgent_medical_help.html.erb
+++ b/app/views/coronavirus_form/urgent_medical_help.html.erb
@@ -1,0 +1,33 @@
+<% content_for :title do %><%= t("coronavirus_form.questions.urgent_medical_help.title") %><% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t("coronavirus_form.questions.urgent_medical_help.title") %>" />
+<% end %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+<% end %>
+
+<%= form_tag({},
+  "data-module": "track-coronavirus-form-vulnerable-people-urgent_medical_help",
+  "data-question-key": "urgent_medical_help",
+  "id": "urgent_medical_help",
+  "novalidate": "true",
+) do %>
+
+<%= render "govuk_publishing_components/components/radio", {
+  heading: t("coronavirus_form.questions.urgent_medical_help.title"),
+  is_page_heading: true,
+  name: "urgent_medical_help",
+  error_message: error_items("urgent_medical_help"),
+  description: t("coronavirus_form.questions.urgent_medical_help.description"),
+  items: t("coronavirus_form.questions.urgent_medical_help.options").map do |option|
+    {
+      id: "option_#{option.parameterize.underscore}",
+      value: option.parameterize.underscore,
+      text: option,
+      checked: @form_responses[:urgent_medical_help] == option,
+    }
+  end
+} %>
+<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,7 +104,11 @@ en:
 
       <p class="govuk-body">We do this for your security. We've deleted all the details you entered to protect your data.</p>
   coronavirus_form:
-    errors: {}
+    errors:
+      page_title_prefix: 'Error: '
+      heading: "There is a problem"
+      radio_field: "Select %{field}"
+      checkbox_field: "Select at least one %{field}"
     questions:
       still_working:
         title: "Are you still going in to work even though you’re not a key worker?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,10 +109,18 @@ en:
       heading: "There is a problem"
       radio_field: "Select %{field}"
       checkbox_field: "Select at least one %{field}"
-    questions:
+    questions: # These need to be in the order in which they should be asked.
+      urgent_medical_help:
+        title: "Do you need urgent medical help?"
+        description: "You can check if you have coronavirus (COVID-19) symptoms and get medical advice"
+        options:
+          - "Yes"
+          - "No"
+        custom_select_error: "Select yes if you need urgent medical help"
       still_working:
         title: "Are you still going in to work even though you’re not a key worker?"
         options:
           - "Yes"
           - "I do not know if I’m a key worker"
           - "No"
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,11 @@ Rails.application.routes.draw do
     get "/privacy", to: "privacy#show"
     get "/accessibility-statement", to: "accessibility_statement#show"
 
+    # Question: Do you need urgent medical help?
+    get "/urgent-medical-help", to: "urgent_medical_help#show"
+    post "/urgent-medical-help", to: "urgent_medical_help#submit"
+
+    # Question: Are you still going in to work even though you're not a key worker?
     get "/still-working", to: "still_working#show"
     post "/still-working", to: "still_working#submit"
 

--- a/spec/requests/urgent_medical_help_spec.rb
+++ b/spec/requests/urgent_medical_help_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe "urgent-medical-help" do
+  describe "GET /urgent-medical-help" do
+    let(:selected_option) { I18n.t("coronavirus_form.questions.urgent_medical_help.options").sample }
+
+    context "without session data" do
+      it "shows the form" do
+        visit urgent_medical_help_path
+
+        expect(page.body).to have_content(I18n.t("coronavirus_form.questions.urgent_medical_help.title"))
+        I18n.t("coronavirus_form.questions.urgent_medical_help.options").each do |option|
+          expect(page.body).to have_content(option)
+        end
+      end
+    end
+
+    context "with session data" do
+      before do
+        page.set_rack_session(urgent_medical_help: selected_option)
+      end
+
+      it "shows the form with prefilled response" do
+        visit urgent_medical_help_path
+
+        expect(page.body).to have_content(I18n.t("coronavirus_form.questions.urgent_medical_help.title"))
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+      end
+    end
+  end
+
+  describe "POST /still-working" do
+    let(:selected_option) { I18n.t("coronavirus_form.questions.urgent_medical_help.options").sample }
+
+    it "updates the session store" do
+      post urgent_medical_help_path, params: { urgent_medical_help: selected_option }
+
+      expect(session[:urgent_medical_help]).to eq(selected_option)
+    end
+
+    xit "redirects to the next question" do
+      post urgent_medical_help_path, params: { urgent_medical_help: selected_option }
+
+      expect(response).to redirect_to(next_question_path)
+    end
+
+    xit "shows an error when no radio button selected" do
+      post urgent_medical_help_path
+
+      expect(response.body).to have_content(I18n.t("coronavirus_form.questions.urgent_medical_help.title"))
+      expect(response.body).to have_content(I18n.t("coronavirus_form.questions.urgent_medical_help.custom_select_error"))
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds the 'Do you need medical help?' question - [ticket for this work](https://trello.com/c/xtzwLbzn).

This also restores the default form field error messages - this form only needs error messages for checkboxes and radio inputs, as there are no other types of form fields.

![image](https://user-images.githubusercontent.com/1732331/78758411-02e6bf80-7976-11ea-8474-ce0317f9a55d.png)

With error message:
![image](https://user-images.githubusercontent.com/1732331/78758458-15f98f80-7976-11ea-8b13-a0f21c2acb03.png)

