### PR TITLE
Add placeholder test for validation error

### DIFF
--- a/spec/requests/still_working_spec.rb
+++ b/spec/requests/still_working_spec.rb
@@ -41,5 +41,12 @@ RSpec.describe "still-working" do
 
       expect(response).to redirect_to(next_question_path)
     end
+
+    xit "shows an error when no radio button selected" do
+      post still_working_path
+
+      expect(response.body).to have_content(I18n.t("coronavirus_form.questions.still_working.title"))
+      expect(response.body).to have_content(I18n.t("coronavirus_form.questions.still_working.custom_select_error"))
+    end
   end
 end


### PR DESCRIPTION
We don't yet have content for the validation errors.  Adding a placeholder test which can be enabled as soon as the content has been added to the internationalisation file.

Trello card: https://trello.com/c/SdBbChS1