### PR TITLE
Add heading subtitle to still working question

### DIFF
--- a/app/views/coronavirus_form/still_working.html.erb
+++ b/app/views/coronavirus_form/still_working.html.erb
@@ -16,6 +16,7 @@
 
 <%= render "govuk_publishing_components/components/radio", {
   heading: t("coronavirus_form.questions.still_working.title"),
+  heading_caption: t("coronavirus_form.questions.still_working.title_caption"),
   is_page_heading: true,
   name: "still_working",
   error_message: error_items("still_working"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,7 @@ en:
     questions:
       still_working:
         title: "Are you still going in to work even though you’re not a key worker?"
+        title_caption: "Going in to work"
         options:
           - "Yes"
           - "I do not know if I’m a key worker"


### PR DESCRIPTION
The content doc was updated, which meant that the need for a heading subtitle was made clearer. 

This adds it to the question already done 'cos @brucebolt is just super speedy.


## Visual differences

Before:
![image](https://user-images.githubusercontent.com/1732331/78693989-ebff8900-78f3-11ea-9871-d76c5f3540b0.png)

---

After:
![image](https://user-images.githubusercontent.com/1732331/78693790-a773ed80-78f3-11ea-8781-95d38a0461ed.png)
