### PR TITLE
Add 'Get urgent help from the NHS now' page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,4 +23,8 @@
 @import 'govuk_publishing_components/components/textarea';
 @import 'govuk_publishing_components/components/title';
 
+$app-covid-yellow: #ffe114;
+$app-covid-grey: #272828;
+
 @import 'components/action-link';
+@import 'components/action-panel';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,3 +22,5 @@
 @import 'govuk_publishing_components/components/skip-link';
 @import 'govuk_publishing_components/components/textarea';
 @import 'govuk_publishing_components/components/title';
+
+@import 'components/action-link';

--- a/app/assets/stylesheets/components/_action-link.scss
+++ b/app/assets/stylesheets/components/_action-link.scss
@@ -1,0 +1,49 @@
+$app-covid-yellow: #ffe114;
+$app-covid-grey: #272828;
+
+.app-c-action-link {
+  @include govuk-font($size: 19, $weight: bold);
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+
+  display: inline-block;
+  text-decoration: none;
+}
+
+.app-c-action-link__icon {
+  margin-right: govuk-spacing(3);
+  vertical-align: middle;
+
+  circle {
+    fill: $app-covid-yellow;
+  }
+
+  path {
+    fill: $app-covid-grey;
+  }
+}
+
+.app-c-action-link__text {
+  line-height: 39px;
+  text-decoration: underline;
+}
+
+.app-c-action-link {
+  &:focus {
+    .app-c-action-link__text {
+      text-decoration: none;
+    }
+  }
+}
+
+.app-c-action-link--inverse {
+  &:link,
+  &:visited,
+  &:hover {
+    color: govuk-colour('white');
+  }
+
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
+}

--- a/app/assets/stylesheets/components/_action-link.scss
+++ b/app/assets/stylesheets/components/_action-link.scss
@@ -1,6 +1,3 @@
-$app-covid-yellow: #ffe114;
-$app-covid-grey: #272828;
-
 .app-c-action-link {
   @include govuk-font($size: 19, $weight: bold);
   @include govuk-link-common;

--- a/app/assets/stylesheets/components/_action-panel.scss
+++ b/app/assets/stylesheets/components/_action-panel.scss
@@ -1,0 +1,14 @@
+.app-c-action-panel {
+  @include govuk-font($size: 19);
+
+  background-color: $app-covid-grey;
+  border: $govuk-border-width solid transparent;
+  box-sizing: border-box;
+  color: govuk-colour('white');
+  margin-bottom: govuk-spacing(3);
+  padding: govuk-spacing(7) - $govuk-border-width;
+
+  @include govuk-media-query($until: tablet) {
+    padding: govuk-spacing(6) - $govuk-border-width;
+  }
+}

--- a/app/controllers/coronavirus_form/get_help_from_nhs_controller.rb
+++ b/app/controllers/coronavirus_form/get_help_from_nhs_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::GetHelpFromNhsController < ApplicationController
+  skip_before_action :check_first_question
+end

--- a/app/views/components/_action-link.html.erb
+++ b/app/views/components/_action-link.html.erb
@@ -1,0 +1,15 @@
+<%
+  data_attributes ||= nil
+  inverse ||= nil
+  target ||= nil
+  css_classes = %w(app-c-action-link)
+  css_classes << "app-c-action-link--inverse" if inverse
+%>
+<%= link_to href, target: target, class: css_classes, data: data_attributes do %>
+  <svg class="app-c-action-link__icon" xmlns="http://www.w3.org/2000/svg" width="39" height="39" viewBox="0 0 39 39" role="presentation" focusable="false">
+    <circle cx="19.5" cy="19.5" r="19.5"/>
+    <path d="M24.0343 20L14.1812 10.1469L17.0096 7.31848L29.6912 20L17.0096 32.6815L14.1812 29.8531L24.0343 20Z"/>
+    <path d="M0.000423781 18L25.1328 18L25.1328 22L0.000423431 22L0.000423781 18Z"/>
+  </svg>
+  <span class="app-c-action-link__text"><%= text %></span>
+<% end %>

--- a/app/views/components/_action-panel.html.erb
+++ b/app/views/components/_action-panel.html.erb
@@ -1,0 +1,3 @@
+<div class="app-c-action-panel">
+  <%= yield %>
+</div>

--- a/app/views/components/docs/action-link.yml
+++ b/app/views/components/docs/action-link.yml
@@ -1,0 +1,21 @@
+name: Action link
+description: Use action links to help users get to the next stage of a journey quickly.
+body: |
+  Currently only used in GOV.UK for COVID-19/NHS-related actions
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      text: Go to NHS 111 online
+      href: '#'
+      data_attributes:
+        tracking: GT-1234
+  inverted:
+    data:
+      text: Go to NHS 111 online
+      href: '#'
+      target: '_blank'
+      inverse: true
+    context:
+      dark_background: true

--- a/app/views/components/docs/action-panel.yml
+++ b/app/views/components/docs/action-panel.yml
@@ -1,0 +1,11 @@
+name: Action panel
+description: Used on triage page to highlight important content.
+body: |
+  Optional markdown providing further detail about the component
+accessibility_criteria: |
+  Elements must have sufficient color contrast
+examples:
+  default:
+    data:
+      block: |
+        Get urgent help from the NHS now

--- a/app/views/coronavirus_form/get_help_from_nhs.html.erb
+++ b/app/views/coronavirus_form/get_help_from_nhs.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title do %><%= t('get_help_from_nhs.title') %><% end %>
+
+<%= render "components/action-panel" do %>
+  <%= render "govuk_publishing_components/components/title", {
+    title:t("get_help_from_nhs.title"),
+    margin_top: 0,
+    margin_bottom: 4,
+    inverse: true
+  } %>
+
+  <%= render "components/action-link", {
+    text: t('get_help_from_nhs.link_text'),
+    href: t('get_help_from_nhs.link_href'),
+    target: "_blank",
+    inverse: true
+  } %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,10 @@ en:
       <p class="govuk-body">Your session has ended because you have not done anything for 4 hours. You'll have to start again.</p>
 
       <p class="govuk-body">We do this for your security. We've deleted all the details you entered to protect your data.</p>
+  get_help_from_nhs:
+    title: Get urgent help from the NHS now
+    link_text: Go to NHS 111 online
+    link_href: "https://111.nhs.uk/"
   coronavirus_form:
     errors:
       page_title_prefix: 'Error: '

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
     get "/urgent-medical-help", to: "urgent_medical_help#show"
     post "/urgent-medical-help", to: "urgent_medical_help#submit"
 
+    # NHS Triage: Get urgent help from the NHS now
+    get "/get-help-from-nhs", to: "get_help_from_nhs#show"
+
     # Question: Are you able to get food?
     get "/get-food", to: "get_food#show"
     post "/get-food", to: "get_food#submit"

--- a/spec/requests/get_help_from_nhs_controller_spec.rb
+++ b/spec/requests/get_help_from_nhs_controller_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe "get-help-from-nhs" do
+  describe "GET /get-help-from-nhs" do
+    it "shows the page" do
+      visit get_help_from_nhs_path
+
+      expect(page.body).to have_content I18n.t("get_help_from_nhs.title")
+      expect(page.body).to have_link I18n.t("get_help_from_nhs.link_text"), href: I18n.t("get_help_from_nhs.link_href")
+    end
+  end
+end


### PR DESCRIPTION
- Add action link (meant to be moved upstream, in the shared library, and be used on the https://www.gov.uk/coronavirus page too)
- Add action panel components
- Add 'Get urgent help from the NHS now' page

Because [the component guide is currently broken for the app-level components](https://github.com/alphagov/govuk_publishing_components/pull/1436) I added a few screen-captures below to ease the review.

## Action link component
### Default

<img width="960" alt="Screenshot 2020-04-08 at 09 49 04" src="https://user-images.githubusercontent.com/788096/78764360-56f5a200-797e-11ea-8dc7-d832d03bba5f.png">

<img width="960" alt="Screenshot 2020-04-08 at 09 49 25" src="https://user-images.githubusercontent.com/788096/78764383-62e16400-797e-11ea-865e-b23dab869dd5.png">

### Inverted

<img width="960" alt="Screenshot 2020-04-08 at 09 49 15" src="https://user-images.githubusercontent.com/788096/78764376-5f4ddd00-797e-11ea-877f-ba85d63147b7.png">

<img width="960" alt="Screenshot 2020-04-08 at 09 49 40" src="https://user-images.githubusercontent.com/788096/78764392-6543be00-797e-11ea-9f60-79ea0bc4ed6e.png">

## Action panel component
<img width="961" alt="Screenshot 2020-04-08 at 11 45 23" src="https://user-images.githubusercontent.com/788096/78775799-bc518f00-798e-11ea-8c5b-ca6fba523742.png">

## 'Get urgent help from the NHS now' page
<table>
<tr><th>Mobile</th><th>Desktop</th></tr>
<tr><td valign="top">

![localhost_5000_get-help-from-nhs](https://user-images.githubusercontent.com/788096/78778924-f96c5000-7993-11ea-9d9c-3d3349436b89.png)

</td><td valign="top">

![localhost_5000_get-help-from-nhs](https://user-images.githubusercontent.com/788096/78775843-cf645f00-798e-11ea-82c3-512b8394a30c.png)


</td></tr>
</table>

[Trello](https://trello.com/c/mJCiv1t4) [cards](https://trello.com/c/toQtV8Ad)