### PR TITLE
Add escape link component

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,7 @@
 // = require govuk/all.js
+// = require components/escape-link.js
+
 window.GOVUKFrontend.initAll()
+
+var $escapeLink = document.querySelector('[data-module="app-escape-link"]')
+new EscapeLink($escapeLink).init()

--- a/app/assets/javascripts/components/escape-link.js
+++ b/app/assets/javascripts/components/escape-link.js
@@ -1,0 +1,21 @@
+function EscapeLink ($module) {
+  this.$module = $module
+}
+
+EscapeLink.prototype.init = function () {
+  var $module = this.$module
+  if (!$module) {
+    return
+  }
+  $module.addEventListener('click', this.handleClick.bind(this))
+}
+
+/**
+* Click event handler
+*
+* @param {MouseEvent} event - Click event
+*/
+EscapeLink.prototype.handleClick = function (event) {
+  event.preventDefault()
+  window.history.go(-window.history.length + 1)
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,4 @@ $app-covid-grey: #272828;
 
 @import 'components/action-link';
 @import 'components/action-panel';
+@import 'components/escape-link';

--- a/app/assets/stylesheets/components/_escape-link.scss
+++ b/app/assets/stylesheets/components/_escape-link.scss
@@ -1,0 +1,27 @@
+.app-c-escape-link {
+  background-color: govuk-colour('white');
+  border-top: 1px solid $govuk-border-colour;
+  bottom: 0;
+  position: fixed;
+  position: sticky; // scss-lint:disable DuplicateProperty
+  text-align: center;
+  width: 100%;
+
+  .govuk-link {
+    @include govuk-font($size: 19, $weight: bold);
+    color: $govuk-error-colour;
+    display: block;
+    padding: govuk-spacing(6) 0;
+
+    &:link,
+    &:visited,
+    &:hover,
+    &:active {
+      color: darken($govuk-error-colour, 5%);
+    }
+
+    &:focus {
+      color: $govuk-focus-text-colour;
+    }
+  }
+}

--- a/app/views/application/_question_radio_buttons.html.erb
+++ b/app/views/application/_question_radio_buttons.html.erb
@@ -13,22 +13,27 @@
   "id": question,
   "novalidate": "true"
 ) do %>
+  <%= render "govuk_publishing_components/components/radio", {
+    heading: t("coronavirus_form.groups.#{group}.questions.#{question}.title"),
+    heading_caption: t("coronavirus_form.groups.#{group}.title", { default: false }),
+    is_page_heading: true,
+    name: question,
+    error_message: error_items(question),
+    items: t("coronavirus_form.groups.#{group}.questions.#{question}.options").map do |option|
+        {
+          value: option,
+          text: option,
+          id: "option_#{option.parameterize.underscore}",
+          checked: @form_responses[question.to_sym] == option,
+        }
+      end
+  } %>
+  <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<% end %>
 
-<%= render "govuk_publishing_components/components/radio", {
-  heading: t("coronavirus_form.groups.#{group}.questions.#{question}.title"),
-  heading_caption: t("coronavirus_form.groups.#{group}.title", { default: false }),
-  is_page_heading: true,
-  name: question,
-  error_message: error_items(question),
-  items: t("coronavirus_form.groups.#{group}.questions.#{question}.options").map do |option|
-      {
-        value: option,
-        text: option,
-        id: "option_#{option.parameterize.underscore}",
-        checked: @form_responses[question.to_sym] == option,
-      }
-    end
-} %>
-
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<% content_for :escape_link do %>
+  <%= render "components/escape-link", {
+    text: "Leave this site",
+    href: "https://www.gov.uk/",
+  } %>
 <% end %>

--- a/app/views/components/_escape-link.html.erb
+++ b/app/views/components/_escape-link.html.erb
@@ -1,0 +1,7 @@
+<%
+  data_attributes ||= {}
+  data_attributes[:module] = 'app-escape-link'
+%>
+<div class="app-c-escape-link">
+  <%= link_to text, href, class: "govuk-link", data: data_attributes %>
+</div>

--- a/app/views/components/docs/escape-link.yml
+++ b/app/views/components/docs/escape-link.yml
@@ -1,0 +1,15 @@
+name: Escape link
+description: Gives users a quick exit from a website while rolling back the navigation history.
+body: |
+  When JavaScript is disabled the link will point to the passed in reference.
+  When JavaScript is enabled we try to roll them back to the page they visited before starting to use the service.
+  This means no extra requests are needed when trying to hide the current page.
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      text: Leave this site
+      href: 'https://www.gov.uk/'
+      data_attributes:
+        tracking: GT-1234

--- a/app/views/coronavirus_form/need_help_with.html.erb
+++ b/app/views/coronavirus_form/need_help_with.html.erb
@@ -24,3 +24,10 @@
 
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>
+
+<% content_for :escape_link do %>
+  <%= render "components/escape-link", {
+    text: "Leave this site",
+    href: "https://www.gov.uk/",
+  } %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,9 @@
         </div>
       </main>
     </div>
+    <% if yield(:escape_link).present? %>
+      <%= yield(:escape_link) %>
+    <% end %>
     <%= render "govuk_publishing_components/components/layout_footer", {
       meta: {
         items: [


### PR DESCRIPTION
- [x]  add escape link component
- [x]  use the component on question pages
- [x] cross-device testing
- [x] cross-browser testing (aware of the limited support for `sticky`, but has a decent fallback)

## Escape link component
<img width="960" alt="Screenshot 2020-04-08 at 18 28 34" src="https://user-images.githubusercontent.com/788096/78814924-69e09480-79c7-11ea-928c-35a08c603cc6.png">

<img width="960" alt="Screenshot 2020-04-08 at 18 28 49" src="https://user-images.githubusercontent.com/788096/78814935-6d741b80-79c7-11ea-9711-08dbfd0958c0.png">

## Example of usage on 'Dow you feel safe where you live' page
<table>
<tr><th>Mobile</th><th>Desktop</th></tr>
<tr><td valign="top">

![localhost_5000_feel-safe](https://user-images.githubusercontent.com/788096/78814966-7533c000-79c7-11ea-98e6-24036a2f55ea.png)

</td><td valign="top">

![localhost_5000_feel-safe (1)](https://user-images.githubusercontent.com/788096/78814972-76fd8380-79c7-11ea-8192-e1c96f23e34e.png)

</td></tr>
</table>

Known issue:
If users are going back in the history and then press the link it doesn't work as it's currently not possible to detect the current `history.index` only the `history.length`. Further investigation is required to detect this state.

[Trello card](https://trello.com/c/c7UahJby)