### PR TITLE
Add page header component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,4 @@ $app-covid-grey: #272828;
 
 @import 'components/action-link';
 @import 'components/action-panel';
+@import 'components/page-header';

--- a/app/assets/stylesheets/components/_page-header.scss
+++ b/app/assets/stylesheets/components/_page-header.scss
@@ -1,0 +1,22 @@
+.app-c-page-header {
+  @include govuk-font($size: 19);
+
+  background-color: $app-covid-grey;
+  border-top: 10px solid $app-covid-yellow;
+  color: govuk-colour('white');
+  margin-top: -10px;
+  padding: govuk-spacing(7) 0;
+  position: relative;
+
+  .govuk-link {
+    &:link,
+    &:visited,
+    &:hover {
+      color: govuk-colour('white');
+    }
+
+    &:focus {
+      color: $govuk-focus-text-colour;
+    }
+  }
+}

--- a/app/views/application/_breadcrumbs.html.erb
+++ b/app/views/application/_breadcrumbs.html.erb
@@ -1,9 +1,0 @@
-<%= render 'govuk_publishing_components/components/breadcrumbs', {
-  collapse_on_mobile: true,
-  breadcrumbs: [
-    {
-      title: "Home",
-      url: "https://www.gov.uk"
-    },
-  ]
-} %>

--- a/app/views/components/_page-header.html.erb
+++ b/app/views/components/_page-header.html.erb
@@ -1,0 +1,9 @@
+<div class="app-c-page-header">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= yield %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/components/docs/page-header.yml
+++ b/app/views/components/docs/page-header.yml
@@ -1,0 +1,12 @@
+name: Page header
+description: COVID-19 header
+accessibility_criteria: |
+  Elements must have sufficient color contrast
+examples:
+  default:
+    data:
+      block: |
+        <div class="gem-c-title gem-c-title--inverse">
+            <p class="gem-c-title__context">Coronavirus (COVID-19)</p>
+            <h1 class="gem-c-title__text">Information based on your answers</h1>
+          </div>

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -1,20 +1,13 @@
-<div class="covid">
-  <%= render "govuk_publishing_components/components/inverse_header", {
-    full_width: true
-  } do %>
-    <div class="gem-c-title gem-c-title--inverse gem-c-title--bottom-margin">
-      <p class="gem-c-title__context">
-        <%= t("results.header.context") %>
-      </p>
-      <h1 class="gem-c-title__text">
-        <%= t("results.header.title") %>
-      </h1>
-      <a href="<%= clear_session_path %>" class="covid__page-start-again">
-        <%= t("results.header.start_again_text") %>
-      </a>
-    </div>
-  <% end %>
-</div>
+<% content_for :page_header do %>
+  <%= render "govuk_publishing_components/components/title", {
+    context: t("results.header.context"),
+    title: t("results.header.title"),
+    inverse: true,
+    margin_top: 0,
+    margin_bottom: 6,
+  } %>
+  <%= link_to t("results.header.start_again_text"), clear_session_path, class: "govuk-link" %>
+<% end %>
 
 <% if no_results?(@form_responses) %>
   <%= render partial: "no_results"  %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,8 +26,6 @@
     <div class="govuk-width-container">
       <% if yield(:back_link).present? %>
         <%= yield(:back_link) %>
-      <% else %>
-        <%= render "breadcrumbs" %>
       <% end %>
       <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
         <div class="govuk-grid-row">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,11 @@
     </script>
     <%= render "govuk_publishing_components/components/skip_link" %>
     <%= render "govuk_publishing_components/components/layout_header", { environment: "public" } %>
+    <% if yield(:page_header).present? %>
+      <%= render "components/page-header" do %>
+        <%= yield(:page_header) %>
+      <% end %>
+    <% end %>
     <div class="govuk-width-container">
       <% if yield(:back_link).present? %>
         <%= yield(:back_link) %>


### PR DESCRIPTION
Add page header component and use it on the results page.

**Note to reviewer**
Beware, this is raised against `results-page`, not `master`.

<table>
<tr><th>Mobile</th><th>Desktop</th></tr>
<tr><td valign="top">

![localhost_5000_results (1)](https://user-images.githubusercontent.com/788096/78827526-25f78a80-79db-11ea-9d83-90866843d2b7.png)

</td><td valign="top">

![localhost_5000_results](https://user-images.githubusercontent.com/788096/78827560-2f80f280-79db-11ea-8592-05a611612e19.png)


</td></tr>
</table>

[Trello card](https://trello.com/c/qNCSEEHy)
