### PR TITLE
Add actions group component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,3 +29,4 @@ $app-covid-grey: #272828;
 @import 'components/action-link';
 @import 'components/action-panel';
 @import 'components/page-header';
+@import 'components/actions-group';

--- a/app/assets/stylesheets/components/_actions-group.scss
+++ b/app/assets/stylesheets/components/_actions-group.scss
@@ -1,0 +1,24 @@
+.app-c-actions-group {
+  @include govuk-font($size: 19);
+
+  border-top: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(6);
+  padding-top: govuk-spacing(3);
+
+  @include govuk-media-query($from: desktop) {
+    padding-top: govuk-spacing(6);
+  }
+
+  &:first-of-type {
+    border-top: 0;
+    padding-top: 0;
+  }
+
+  .govuk-heading-m {
+    margin-bottom: govuk-spacing(3);
+  }
+
+  .govuk-list > li {
+    margin-bottom: govuk-spacing(3);
+  }
+}

--- a/app/views/components/_actions-group.html.erb
+++ b/app/views/components/_actions-group.html.erb
@@ -1,0 +1,25 @@
+<%
+  title ||= nil
+  subsections ||= []
+%>
+<section class="app-c-actions-group">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-m"><%= title %></h2>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <% subsections.each do |subsection| %>
+        <h3 class="govuk-heading-s"><%= subsection[:title] %></h3>
+        <% if subsection[:items].any? %>
+          <ul class="govuk-list">
+            <% subsection[:items].each do |item| %>
+              <li>
+                <%= link_to item[:text], item[:href], class: "govuk-link" %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/app/views/components/docs/actions-group.yml
+++ b/app/views/components/docs/actions-group.yml
@@ -1,0 +1,21 @@
+name: Actions group
+description: A set of actions grouped by topic
+body: |
+  Optional markdown providing further detail about the component
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      title: Getting food
+      subsections:
+        - title: "If you’re finding it hard to afford food:"
+          items:
+            - text: "Get information on getting referred to a food bank from Citizens Advice"
+              href: "#"
+            - text: "Get information on getting support from a food bank from the Trussell Trust"
+              href: "#"
+        - title: "If you’re you unable to get food:"
+          items:
+            - text: "Find your local council to contact them for support"
+              href: "#"


### PR DESCRIPTION
Add action group component to be used in the `_result_group` partial.

Usage example (also available in `/component-guide/actions-group`)
```
<%= render "components/actions-group", {
  title: "Paying bills",
  subsections: [
    {
      title: "If you’re finding it hard to afford rent, your mortgage or bills:",
      items: [
        {
          text: "Find out what you should do if you're finding it hard to pay rent",
          href: "#"
        },
        {
          text: "Find information on the policies in place if you're finding it hard to pay energy bills",
          href: "#"
        }
      ]
    }
  ]
} %>
```

For a full-width view on the `results` page we need to edit the [layout](https://github.com/alphagov/govuk-coronavirus-find-support/blob/master/app/views/layouts/application.html.erb#L29) and set a `govuk-grid-column-full` based on a variable passed to the view.

**Note to reviewer**
Beware, this is raised against `results-page`, not `master`.
Screen captures below contain changes introduced in #37 for a final preview.

<table>
<tr><th>Mobile</th><th>Desktop</th></tr>
<tr><td valign="top">

![localhost_5000_results (3)](https://user-images.githubusercontent.com/788096/78834388-6a3c5800-79e6-11ea-9518-176e0234f406.png)

</td><td valign="top">

![localhost_5000_results (2)](https://user-images.githubusercontent.com/788096/78834444-7de7be80-79e6-11ea-94b4-10385eb1725b.png)


</td></tr>
</table>

[Trello card](https://trello.com/c/VGvrcZX1)
