### PR TITLE
Allow plain text and html for actions-group items

### DIFF
--- a/app/views/components/_actions-group.html.erb
+++ b/app/views/components/_actions-group.html.erb
@@ -14,7 +14,11 @@
           <ul class="govuk-list">
             <% subsection[:items].each do |item| %>
               <li>
-                <%= link_to item[:text], item[:href], class: "govuk-link" %>
+                <% if item[:href] %>
+                  <%= link_to item[:text], item[:href], class: "govuk-link" %>
+                <% else %>
+                  <%= sanitize(item[:text]) %>
+                <% end %>
               </li>
             <% end %>
           </ul>

--- a/app/views/components/docs/actions-group.yml
+++ b/app/views/components/docs/actions-group.yml
@@ -13,8 +13,7 @@ examples:
           items:
             - text: "Get information on getting referred to a food bank from Citizens Advice"
               href: "#"
-            - text: "Get information on getting support from a food bank from the Trussell Trust"
-              href: "#"
+            - text: 'Get information on getting support from a food bank from the <a href="#" class="govuk-link">Trussell Trust</a>'
         - title: "If you’re you unable to get food:"
           items:
             - text: "Find your local council to contact them for support"


### PR DESCRIPTION
Text allows HTML content within – I think this would be quicker and more effective than pulling in govspeak.

### Usage
```
<%= render "components/actions-group", {
  title: "Getting food",
  subsections: [
    {
      title: "If you’re finding it hard to afford food:",
      items: [
        {
          text: "Get information on getting referred to a food bank from Citizens Advice",
          href: "#"
        },
        {
          text: 'Get information on getting support from a food bank from the <a href="#" class="govuk-link">Trussell Trust</a>'
        }
      ]
    },
    {
      title: "If you’re you unable to get food:",
      items: [
        {
          text: "Find your local council to contact them for support",
          href: "#"
        }
      ]
    }
  ]
} %>
```

Example of YAML definition for links and mixed content:
```
items:
  - text: "Get information on getting referred to a food bank from Citizens Advice"
     href: "#"
  - text: 'Get information on getting support from a food bank from the <a href="#" class="govuk-link">Trussell Trust</a>'
```

### Preview
<img width="795" alt="Screenshot 2020-04-09 at 10 25 13" src="https://user-images.githubusercontent.com/788096/78879897-765b0080-7a4c-11ea-9e84-16a80d0b79e4.png">

[Trello card](https://trello.com/c/qNCSEEHy)