### PR TITLE
Results page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,4 @@ $app-covid-grey: #272828;
 @import 'components/action-panel';
 @import 'cookies-settings';
 @import 'components/page-header';
+@import 'components/actions-group';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,5 +27,6 @@ $app-covid-grey: #272828;
 @import 'components/action-link';
 @import 'components/action-panel';
 @import 'cookies-settings';
+@import 'components/callout';
 @import 'components/page-header';
 @import 'components/actions-group';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,3 +27,4 @@ $app-covid-grey: #272828;
 @import 'components/action-link';
 @import 'components/action-panel';
 @import 'cookies-settings';
+@import 'components/page-header';

--- a/app/assets/stylesheets/components/_actions-group.scss
+++ b/app/assets/stylesheets/components/_actions-group.scss
@@ -1,0 +1,24 @@
+.app-c-actions-group {
+  @include govuk-font($size: 19);
+
+  border-top: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(6);
+  padding-top: govuk-spacing(3);
+
+  @include govuk-media-query($from: desktop) {
+    padding-top: govuk-spacing(6);
+  }
+
+  &:first-of-type {
+    border-top: 0;
+    padding-top: 0;
+  }
+
+  .govuk-heading-m {
+    margin-bottom: govuk-spacing(3);
+  }
+
+  .govuk-list > li {
+    margin-bottom: govuk-spacing(3);
+  }
+}

--- a/app/assets/stylesheets/components/_callout.scss
+++ b/app/assets/stylesheets/components/_callout.scss
@@ -1,0 +1,12 @@
+.app-c-callout {
+  @include govuk-font(19);
+  @include govuk-responsive-padding(4);
+
+  background-color: govuk-colour('light-grey');
+  margin-bottom: govuk-spacing(6);
+}
+
+.app-c-callout__title {
+  @extend %govuk-heading-s;
+  margin-bottom: govuk-spacing(2);
+}

--- a/app/assets/stylesheets/components/_page-header.scss
+++ b/app/assets/stylesheets/components/_page-header.scss
@@ -1,0 +1,22 @@
+.app-c-page-header {
+  @include govuk-font($size: 19);
+
+  background-color: $app-covid-grey;
+  border-top: 10px solid $app-covid-yellow;
+  color: govuk-colour('white');
+  margin-top: -10px;
+  padding: govuk-spacing(7) 0;
+  position: relative;
+
+  .govuk-link {
+    &:link,
+    &:visited,
+    &:hover {
+      color: govuk-colour('white');
+    }
+
+    &:focus {
+      color: $govuk-focus-text-colour;
+    }
+  }
+}

--- a/app/controllers/coronavirus_form/session_controller.rb
+++ b/app/controllers/coronavirus_form/session_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::SessionController < ApplicationController
+  skip_before_action :check_first_question
+
+  def delete
+    reset_session
+    redirect_to "/"
+  end
+end

--- a/app/controllers/coronavirus_form/session_controller.rb
+++ b/app/controllers/coronavirus_form/session_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::SessionController < ApplicationController
-  skip_before_action :check_first_question
-
   def delete
     reset_session
     redirect_to "/"

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -1,0 +1,9 @@
+module ResultsHelper
+  def result_groups(form_responses)
+    form_responses
+  end
+
+  def no_results?(form_responses)
+    result_groups(form_responses).empty?
+  end
+end

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -1,11 +1,14 @@
 module ResultsHelper
   def result_groups(session)
     relevant_group_keys.index_with do |group_key|
-      {
-        heading: I18n.t("coronavirus_form.groups.#{group_key}.title"),
-        questions: filter_questions_by_session(group_key, session),
-      }
-    end
+      filtered_questions = filter_questions_by_session(group_key, session)
+      unless filtered_questions.empty?
+        {
+          heading: I18n.t("coronavirus_form.groups.#{group_key}.title"),
+          questions: filtered_questions,
+        }
+      end
+    end.compact
   end
 
   def filter_questions_by_session(group_key, session)

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -1,6 +1,6 @@
 module ResultsHelper
   def result_groups(session)
-    relevant_group_keys.index_with do |group_key|
+    groups = relevant_group_keys.index_with do |group_key|
       filtered_questions = filter_questions_by_session(group_key, session)
       unless filtered_questions.empty?
         {
@@ -8,7 +8,8 @@ module ResultsHelper
           questions: filtered_questions,
         }
       end
-    end.compact
+    end
+    groups.compact
   end
 
   def filter_questions_by_session(group_key, session)
@@ -33,6 +34,6 @@ module ResultsHelper
   end
 
   def selected_groups
-    @selected_groups ||= session["selected_groups"]
+    session["selected_groups"]
   end
 end

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -1,9 +1,35 @@
 module ResultsHelper
-  def result_groups(form_responses)
-    form_responses
+  def result_groups(session)
+    relevant_group_keys.index_with do |group_key|
+      {
+        heading: I18n.t("coronavirus_form.groups.#{group_key}.title"),
+        questions: filter_questions_by_session(group_key, session),
+      }
+    end
   end
 
-  def no_results?(form_responses)
-    result_groups(form_responses).empty?
+  def filter_questions_by_session(group_key, session)
+    I18n.t("results_link.#{group_key}").each_with_object([]) do |question, array|
+      if question[1][:show_options].include?(session[question[0]])
+        array << I18n.t("results_link.#{group_key}.#{question[0]}")
+      end
+    end
+  end
+
+  def relevant_group_keys
+    # If the user selects only "I’m not sure" from /need-help-with, their selected groups will
+    # be blank, but they'll be asked all questions. In this case we should assume all groups are
+    # potentially relevant. We can get all groups from the Locale file, but will need to exclude
+    # :help and :filter_questions which are not really groups
+    # empty.
+    if selected_groups.blank?
+      return I18n.t("coronavirus_form.groups").keys - %i[filter_questions help]
+    end
+
+    selected_groups # Otherwise we can use selected groups
+  end
+
+  def selected_groups
+    @selected_groups ||= session["selected_groups"]
   end
 end

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -23,7 +23,7 @@ module ResultsHelper
     # :help and :filter_questions which are not really groups
     # empty.
     if selected_groups.blank?
-      return I18n.t("coronavirus_form.groups").keys - %i[filter_questions help]
+      return I18n.t("coronavirus_form.groups").keys - %i[filter_questions help leave_home]
     end
 
     selected_groups # Otherwise we can use selected groups

--- a/app/views/application/_breadcrumbs.html.erb
+++ b/app/views/application/_breadcrumbs.html.erb
@@ -1,9 +1,0 @@
-<%= render 'govuk_publishing_components/components/breadcrumbs', {
-  collapse_on_mobile: true,
-  breadcrumbs: [
-    {
-      title: "Home",
-      url: "https://www.gov.uk"
-    },
-  ]
-} %>

--- a/app/views/components/_actions-group.html.erb
+++ b/app/views/components/_actions-group.html.erb
@@ -1,0 +1,25 @@
+<%
+  title ||= nil
+  subsections ||= []
+%>
+<section class="app-c-actions-group">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-m"><%= title %></h2>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <% subsections.each do |subsection| %>
+        <h3 class="govuk-heading-s"><%= subsection[:title] %></h3>
+        <% if subsection[:items].any? %>
+          <ul class="govuk-list">
+            <% subsection[:items].each do |item| %>
+              <li>
+                <%= link_to item[:text], item[:href], class: "govuk-link" %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/app/views/components/_actions-group.html.erb
+++ b/app/views/components/_actions-group.html.erb
@@ -14,7 +14,11 @@
           <ul class="govuk-list">
             <% subsection[:items].each do |item| %>
               <li>
-                <%= link_to item[:text], item[:href], class: "govuk-link" %>
+                <% if item[:href] %>
+                  <%= link_to item[:text], item[:href], class: "govuk-link" %>
+                <% else %>
+                  <%= sanitize(item[:text]) %>
+                <% end %>
               </li>
             <% end %>
           </ul>

--- a/app/views/components/_callout.html.erb
+++ b/app/views/components/_callout.html.erb
@@ -1,0 +1,9 @@
+<%
+  title ||= nil
+%>
+<div class="app-c-callout">
+  <% if title %>
+    <h3 class="app-c-callout__title"><%= title %></h3>
+  <% end %>
+  <%= yield %>
+</div>

--- a/app/views/components/_page-header.html.erb
+++ b/app/views/components/_page-header.html.erb
@@ -1,0 +1,9 @@
+<div class="app-c-page-header">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= yield %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/components/docs/actions-group.yml
+++ b/app/views/components/docs/actions-group.yml
@@ -13,8 +13,7 @@ examples:
           items:
             - text: "Get information on getting referred to a food bank from Citizens Advice"
               href: "#"
-            - text: "Get information on getting support from a food bank from the Trussell Trust"
-              href: "#"
+            - text: 'Get information on getting support from a food bank from the <a href="#" class="govuk-link">Trussell Trust</a>'
         - title: "If you’re you unable to get food:"
           items:
             - text: "Find your local council to contact them for support"

--- a/app/views/components/docs/actions-group.yml
+++ b/app/views/components/docs/actions-group.yml
@@ -1,0 +1,21 @@
+name: Actions group
+description: A set of actions grouped by topic
+body: |
+  Optional markdown providing further detail about the component
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      title: Getting food
+      subsections:
+        - title: "If you’re finding it hard to afford food:"
+          items:
+            - text: "Get information on getting referred to a food bank from Citizens Advice"
+              href: "#"
+            - text: "Get information on getting support from a food bank from the Trussell Trust"
+              href: "#"
+        - title: "If you’re you unable to get food:"
+          items:
+            - text: "Find your local council to contact them for support"
+              href: "#"

--- a/app/views/components/docs/callout.yml
+++ b/app/views/components/docs/callout.yml
@@ -1,0 +1,12 @@
+name: Callout
+description: An excerpt of text that has been pulled out and used as a visual clue to draw the eye to the text.
+body: |
+  They are used to help direct a user's attention to important pieces of information.
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      title: Help us improve
+      block: |
+        <a href="#" class="govuk-link">Give feedback on this service</a>

--- a/app/views/components/docs/page-header.yml
+++ b/app/views/components/docs/page-header.yml
@@ -1,0 +1,12 @@
+name: Page header
+description: COVID-19 header
+accessibility_criteria: |
+  Elements must have sufficient color contrast
+examples:
+  default:
+    data:
+      block: |
+        <div class="gem-c-title gem-c-title--inverse">
+            <p class="gem-c-title__context">Coronavirus (COVID-19)</p>
+            <h1 class="gem-c-title__text">Information based on your answers</h1>
+          </div>

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -1,3 +1,8 @@
+<% content_for :title do %><%= t('coronavirus_form.results.header.title') %><% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('coronavirus_form.results.header.title') %>" />
+<% end %>
+
 <% content_for :page_header do %>
   <%= render "govuk_publishing_components/components/title", {
     context: t("coronavirus_form.results.header.context"),

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -15,7 +15,10 @@
 <% end %>
 
 <% result_groups(session).each do |group| %>
-  <%= render partial: "result_group", locals: { group: group }  %>
+  <%= render "components/actions-group", {
+    title: group[1][:heading],
+    subsections: group[1][:questions]
+  } %>
 <% end %>
 
 <%= render "components/callout", {

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -14,12 +14,8 @@
   <%= link_to t("coronavirus_form.results.header.start_again_text"), clear_session_path, class: "govuk-link" %>
 <% end %>
 
-<% if no_results?(@form_responses) %>
-  <%= render partial: "no_results"  %>
-<% else %>
-  <% result_groups(@form_responses).each do |group| %>
-    <%= render partial: "result_group", locals: { group: group }  %>
-  <% end %>
+<% result_groups(session).each do |group| %>
+  <%= render partial: "result_group", locals: { group: group }  %>
 <% end %>
 
 <%= render "components/callout", {

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -15,3 +15,18 @@
     </div>
   <% end %>
 </div>
+
+<% if no_results?(@form_responses) %>
+  <%= render partial: "no_results"  %>
+<% else %>
+  <% result_groups(@form_responses).each do |group| %>
+    <%= render partial: "result_group", locals: { group: group }  %>
+  <% end %>
+<% end %>
+
+<div>
+  <%= t("coronavirus_form.results.feedback.text") %>
+  <a href="/feedback">
+    <%= t("coronavirus_form.results.feedback.link_text") %>
+  </a>
+</div>

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -1,20 +1,13 @@
-<div class="covid">
-  <%= render "govuk_publishing_components/components/inverse_header", {
-    full_width: true
-  } do %>
-    <div class="gem-c-title gem-c-title--inverse gem-c-title--bottom-margin">
-      <p class="gem-c-title__context">
-        <%= t("results.header.context") %>
-      </p>
-      <h1 class="gem-c-title__text">
-        <%= t("results.header.title") %>
-      </h1>
-      <a href="<%= clear_session_path %>" class="covid__page-start-again">
-        <%= t("results.header.start_again_text") %>
-      </a>
-    </div>
-  <% end %>
-</div>
+<% content_for :page_header do %>
+  <%= render "govuk_publishing_components/components/title", {
+    context: t("coronavirus_form.results.header.context"),
+    title: t("coronavirus_form.results.header.title"),
+    inverse: true,
+    margin_top: 0,
+    margin_bottom: 6,
+  } %>
+  <%= link_to t("coronavirus_form.results.header.start_again_text"), clear_session_path, class: "govuk-link" %>
+<% end %>
 
 <% if no_results?(@form_responses) %>
   <%= render partial: "no_results"  %>

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -1,0 +1,17 @@
+<div class="covid">
+  <%= render "govuk_publishing_components/components/inverse_header", {
+    full_width: true
+  } do %>
+    <div class="gem-c-title gem-c-title--inverse gem-c-title--bottom-margin">
+      <p class="gem-c-title__context">
+        <%= t("results.header.context") %>
+      </p>
+      <h1 class="gem-c-title__text">
+        <%= t("results.header.title") %>
+      </h1>
+      <a href="<%= clear_session_path %>" class="covid__page-start-again">
+        <%= t("results.header.start_again_text") %>
+      </a>
+    </div>
+  <% end %>
+</div>

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -22,9 +22,8 @@
   <% end %>
 <% end %>
 
-<div>
-  <%= t("coronavirus_form.results.feedback.text") %>
-  <a href="/feedback">
-    <%= t("coronavirus_form.results.feedback.link_text") %>
-  </a>
-</div>
+<%= render "components/callout", {
+  title: "Help us improve"
+} do %>
+  <%= link_to t("coronavirus_form.results.feedback.link_text"), t("coronavirus_form.results.feedback.link_href"), class: "govuk-link" %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
       <% end %>
       <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
         <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds-from-desktop">
+          <div class="<%= current_page?(results_path) ? "govuk-grid-column-full" : "govuk-grid-column-two-thirds-from-desktop" %>">
             <%= render "error_summary" %>
             <%= yield %>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,6 +42,11 @@
       },
     } %>
     <%= render "govuk_publishing_components/components/layout_header", { environment: "public" } %>
+    <% if yield(:page_header).present? %>
+      <%= render "components/page-header" do %>
+        <%= yield(:page_header) %>
+      <% end %>
+    <% end %>
     <div class="govuk-width-container">
       <% if yield(:back_link).present? %>
         <%= yield(:back_link) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,8 +50,6 @@
     <div class="govuk-width-container">
       <% if yield(:back_link).present? %>
         <%= yield(:back_link) %>
-      <% else %>
-        <%= render "breadcrumbs" %>
       <% end %>
       <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
         <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -336,7 +336,7 @@ en:
           - "Yes but I’m concerned about the safety of someone else"
           - "No"
           - "Not sure"
-        links:
+        items:
           - text: "If you’re in immediate danger call 999 and ask for the Police."
           - text: "If you’re in danger and unable to talk on the phone, call 999, and then press 55."
           - text: 'Call the National Domestic Abuse Helpline on <a href="tel:0808 2000 247" class="govuk-link">0808 2000 247</a>'
@@ -368,7 +368,7 @@ en:
         show_options:
           - "Yes"
           - "Not sure"
-        links:
+        items:
           - text: "Find out what to do if you're finding it hard to pay rent"
             href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
           - text: "Find information on the policies in place if you're finding it hard to pay energy bills"
@@ -397,7 +397,7 @@ en:
         show_options:
           - "Yes"
           - "Not sure"
-        links:
+        items:
           - text: "Find out if you’re eligible for Universal Credit"
             href: "https://www.gov.uk/universal-credit/eligibility"
           - text: "If you are at least 10 weeks pregnant or have a child under 4, find out if you can apply for Healthy Start vouchers"
@@ -414,7 +414,7 @@ en:
         show_options:
           - "Yes"
           - "Not sure"
-        links:
+        items:
           - text: "If you can, then ask friends, family, or other people in your community to get food for you."
           - text: "You might be able to ask local shops to help you get food or do an online food order."
           - text: "Find your local council to contact them for support"
@@ -429,7 +429,7 @@ en:
           - "I might be soon"
           - "No"
           - "Not sure"
-        links:
+        items:
           - text: "What to do if you have lost your job"
             href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-you-were-employed-and-have-lost-your-job"
           - text: "What to do if you’re laid-off"
@@ -459,7 +459,7 @@ en:
         show_options:
           - "Yes"
           - "Not sure"
-        links:
+        items:
           - text: "Check if you’re eligible for statutory sick pay"
             href: "https://www.gov.uk/statutory-sick-pay"
           - text: "What to do if you’re employed but cannot work"
@@ -473,7 +473,7 @@ en:
         show_options:
           - "Yes"
           - "Not sure"
-        links:
+        items:
           - text: "What to do if you're self-employed and getting less work"
             href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work"
           - text: "Get information on what you can do if you're self employed or a sole trader from the Money Advice Service"
@@ -484,7 +484,7 @@ en:
         show_options:
           - "Yes"
           - "I do not know if I’m a key worker"
-        links:
+        items:
           - text: "Find out if you should be going to work"
             href: "https://www.gov.uk/government/publications/full-guidance-on-staying-at-home-and-away-from-others/full-guidance-on-staying-at-home-and-away-from-others"
           - text: "Find out if you’re a key worker"
@@ -500,7 +500,7 @@ en:
         show_options:
           - "Yes"
           - "Not sure"
-        links:
+        items:
           - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
             href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
     somewhere_to_live:
@@ -510,7 +510,7 @@ en:
           - "I do now but I might lose it"
           - "No"
           - "Not sure"
-        links:
+        items:
           - text: "Get information if you are legally homeless from Shelter"
             href: "https://england.shelter.org.uk/housing_advice/homelessness/rules/legally_homeless"
           - text: 'If you’re in Northern Ireland call the Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
@@ -528,7 +528,7 @@ en:
           - "Yes"
           - "I might be evicted soon"
           - "Not sure"
-        links:
+        items:
           - text: "Get information about your rights as a tenant"
             href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
           - text: "Get coronavirus housing advice from Shelter"
@@ -552,7 +552,7 @@ en:
         show_options:
           - "Yes"
           - "Not sure"
-        links:
+        items:
           - text: "Get information on coronavirus and your wellbeing from Mind"
             href: "https://www.mind.org.uk/information-support/coronavirus/coronavirus-and-your-wellbeing/#collapse838f8"
           - text: "Get information about looking after your mental health during coronavirus"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -319,6 +319,15 @@ en:
               - "I cannot go out because I have a disability"
               - "I’m unable to leave my home for another reason"
             custom_select_error: "Select if you are able to leave your home or not"
+    results:
+      header:
+        context: Coronavirus (COVID-19)
+        title: Information based on your answers
+        start_again_text: Start again
+      feedback:
+        text: Help us improve
+        link_text: Give feedback on this service
+        link_href: "https://www.gov.uk/done/coronavirus-support-from-business"
   results_link:
     feel_unsafe:
       feel_safe:
@@ -565,11 +574,3 @@ en:
           - text: 'If you need urgent help and you’re in Northern Ireland call Lifeline on <a href="tel:+448088088000" class="govuk-link">0808 808 8000</a>'
           - text: 'If you need urgent help and you’re in Wales call <a href="tel:+44800132737" class="govuk-link">0800 132 737</a> or text ‘help’ to 81066'
           - text: "If it’s an emergency, call 999"
-  results:
-    header:
-      context: Coronavirus (COVID-19)
-      title: Information based on your answers
-      start_again_text: Start again
-    feedback:
-      text: Help us improve
-      link_text: Give feedback on this service

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -327,7 +327,7 @@ en:
       feedback:
         text: Help us improve
         link_text: Give feedback on this service
-        link_href: "https://www.gov.uk/done/coronavirus-support-from-business"
+        link_href: "https://www.gov.uk/done/find-coronavirus-support"
   results_link:
     feel_unsafe:
       feel_safe:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,7 +176,7 @@ en:
   coronavirus_form:
     errors:
       page_title_prefix: 'Error: '
-      heading: "There is a problem"
+      title: "There is a problem:"
       radio_field: "Select %{field}"
       checkbox_field: "Select at least one %{field}"
     groups:
@@ -331,7 +331,7 @@ en:
   results_link:
     feeling_unsafe:
       feel_safe:
-        heading: "If you do not feel safe where you live or you’re worried about someone else"
+        title: "If you do not feel safe where you live or you’re worried about someone else:"
         show_options:
           - "Yes but I’m concerned about the safety of someone else"
           - "No"
@@ -364,7 +364,7 @@ en:
             href: "https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales"
     paying_bills:
       afford_rent_mortgage_bills:
-        heading: "If you’re finding it hard to afford rent, your mortgage or bills"
+        title: "If you’re finding it hard to afford rent, your mortgage or bills:"
         show_options:
           - "Yes"
           - "Not sure"
@@ -393,7 +393,7 @@ en:
             href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19#Paying_rent"
     getting_food:
       afford_food:
-        heading: "If you’re finding it hard to afford food"
+        title: "If you’re finding it hard to afford food:"
         show_options:
           - "Yes"
           - "Not sure"
@@ -410,7 +410,7 @@ en:
             href: "https://www.mygov.scot/school-meals/"
           - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email covid19@adviceni.net or text ‘ACTION’ to 81025'
       get_food:
-        heading: "If you are finding it hard to get food"
+        title: "If you are finding it hard to get food:"
         show_options:
           - "Yes"
           - "Not sure"
@@ -424,7 +424,7 @@ en:
             href: "https://www.consumercouncil.org.uk/coronavirus/vulnerable"
     being_unemployed:
       have_you_been_made_unemployed:
-        heading: "If you’ve been made unemployed, or put on temporary leave (furloughed)"
+        title: "If you’ve been made unemployed, or put on temporary leave (furloughed):"
         show_options:
           - "I might be soon"
           - "No"
@@ -455,7 +455,7 @@ en:
           - text: "Find help with benefits if you live in Scotland"
             href: "https://www.mygov.scot/benefits-support/"
       are_you_off_work_ill:
-        heading: "If you’re off work because you’re ill or self isolating"
+        title: "If you’re off work because you’re ill or self isolating:"
         show_options:
           - "Yes"
           - "Not sure"
@@ -469,7 +469,7 @@ en:
           - text: "Get information on the help you can get if you're self-employed or work in the gig economy from the Money Advice Service"
             href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
       self_employed:
-        heading: "If you’re self employed or a sole trader"
+        title: "If you’re self employed or a sole trader:"
         show_options:
           - "Yes"
           - "Not sure"
@@ -480,7 +480,7 @@ en:
             href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
     going_in_to_work:
       still_working:
-        heading: "If you’re still going in to work even though you’re a key worker"
+        title: "If you’re still going in to work even though you’re a key worker:"
         show_options:
           - "Yes"
           - "I do not know if I’m a key worker"
@@ -496,7 +496,7 @@ en:
           - text: "Find out if you're a key worker if you live in Scotland"
             href: "https://www.gov.scot/publications/coronavirus-guide-schools-early-learning-closures/pages/key-workers/"
       living_with_vulnerable:
-        heading: "If you’re worried about going in to work because you live with someone vulnerable to coronavirus"
+        title: "If you’re worried about going in to work because you live with someone vulnerable to coronavirus:"
         show_options:
           - "Yes"
           - "Not sure"
@@ -505,7 +505,7 @@ en:
             href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
     somewhere_to_live:
       do_you_have_somewhere_to_live:
-        heading: "If you do not have somewhere to live"
+        title: "If you do not have somewhere to live:"
         show_options:
           - "I do now but I might lose it"
           - "No"
@@ -523,7 +523,7 @@ en:
           - text: "Get help if you are homeless from Shelter Scotland"
             href: "https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness"
       have_you_been_evicted:
-        heading: "If you’ve been evicted"
+        title: "If you’ve been evicted:"
         show_options:
           - "Yes"
           - "I might be evicted soon"
@@ -548,7 +548,7 @@ en:
             href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
     mental_health:
       mental_health_worries:
-        heading: "If you’re worried about your mental health or someone else’s mental health"
+        title: "If you’re worried about your mental health or someone else’s mental health:"
         show_options:
           - "Yes"
           - "Not sure"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,7 +329,7 @@ en:
         link_text: Give feedback on this service
         link_href: "https://www.gov.uk/done/find-coronavirus-support"
   results_link:
-    feel_unsafe:
+    feeling_unsafe:
       feel_safe:
         heading: "If you do not feel safe where you live or you’re worried about someone else"
         show_options:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,10 +93,10 @@ en:
       <p class="govuk-body">In certain circumstances you have the right to ask for your information to be deleted by contacting the data controller. As the information you are providing is not defined as personal data, these rights are not applicable. If you want to make any of these requests, contact us using the details below.</p>
 
       <h2 class="govuk-heading-m">Questions and complaints</h2>
-      <p class="govuk-body">The contact details for the data controller is: Cabinet Office (Government Digital Service), The White Chapel Building, 10 Whitechapel High Street, London, E1 8QS, or <a href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">gds-privacy-office@digital.cabinet-office.gov.uk</a>.</p>
-      <p class="govuk-body">The contact details for the data controller’s Data Protection Officer are: Stephen Jones, Data Protection Officer, Cabinet Office, 70 Whitehall, London, SW1A 2AS, or <a href="mailto:dpo@cabinetoffice.gov.uk">dpo@cabinetoffice.gov.uk</a>.</p>
+      <p class="govuk-body">The contact details for the data controller is: Cabinet Office (Government Digital Service), The White Chapel Building, 10 Whitechapel High Street, London, E1 8QS, or <a href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk" class="govuk-link">gds-privacy-office@digital.cabinet-office.gov.uk</a>.</p>
+      <p class="govuk-body">The contact details for the data controller’s Data Protection Officer are: Stephen Jones, Data Protection Officer, Cabinet Office, 70 Whitehall, London, SW1A 2AS, or <a href="mailto:dpo@cabinetoffice.gov.uk" class="govuk-link">dpo@cabinetoffice.gov.uk</a>.</p>
       <p class="govuk-body">The Data Protection Officer provides independent advice and monitoring of Cabinet Office’s use of personal information.</p>
-      <p class="govuk-body">If you consider that your personal information has been misused or mishandled, you can make a complaint to the Information Commissioner, who is an independent regulator. The Information Commissioner can be contacted at:  Information Commissioner’s Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF, or 0303 123 1113, or <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a>. Any complaint to the Information Commissioner won’t affect your right to seek redress through the courts.</p>
+      <p class="govuk-body">If you consider that your personal information has been misused or mishandled, you can make a complaint to the Information Commissioner, who is an independent regulator. The Information Commissioner can be contacted at:  Information Commissioner’s Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF, or 0303 123 1113, or <a href="mailto:casework@ico.org.uk" class="govuk-link">casework@ico.org.uk</a>. Any complaint to the Information Commissioner won’t affect your right to seek redress through the courts.</p>
 
       <h2 class="govuk-heading-m">Changes to this notice</h2>
       <p class="govuk-body">We may change this privacy notice. When we make changes to this notice, the ‘last updated’ date at the top of this page will also change. Any changes to this privacy notice will apply to you and your information immediately. If these changes affect how your personal information is processed, the Cabinet Office will take reasonable steps to make sure you know.</p>
@@ -408,7 +408,7 @@ en:
             href: "https://www.mygov.scot/best-start-grant-best-start-foods/"
           - text: "Get information about getting free school meals during coronavirus if you live in Scotland"
             href: "https://www.mygov.scot/school-meals/"
-          - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email covid19@adviceni.net or text ‘ACTION’ to 81025'
+          - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email <a href="mailto:covid19@adviceni.net" class="govuk-link">covid19@adviceni.net</a> or text ‘ACTION’ to 81025'
       get_food:
         title: "If you are finding it hard to get food:"
         show_options:
@@ -419,7 +419,7 @@ en:
           - text: "You might be able to ask local shops to help you get food or do an online food order."
           - text: "Find your local council to contact them for support"
             href: "https://www.gov.uk/find-local-council/"
-          - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email <a href="mailto:covid19@adviceni.net">covid19@adviceni.net</a> or text: ’ACTION’ to 81025'
+          - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email <a href="mailto:covid19@adviceni.net" class="govuk-link">covid19@adviceni.net</a> or text: ’ACTION’ to 81025'
           - text: "Get information on getting food deliveries if you live in Northern Ireland from The Consumer Council"
             href: "https://www.consumercouncil.org.uk/coronavirus/vulnerable"
     being_unemployed:
@@ -569,7 +569,7 @@ en:
             href: "https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing"
           - text: "Find your local loneliness service"
             href: "https://www.redcross.org.uk/get-help/get-help-with-loneliness/find-your-local-loneliness-service"
-          - text: 'If you need urgent help now, call the Samaritans on <a href="tel:03448 920 908" class="govuk-link">116 123</a>116 123</a>'
+          - text: 'If you need urgent help now, call the Samaritans on <a href="tel:116 123" class="govuk-link">116 123</a>'
           - text: "If you need urgent help text ‘Shout’ to 85258"
           - text: 'If you need urgent help and you’re in Northern Ireland call Lifeline on <a href="tel:+448088088000" class="govuk-link">0808 808 8000</a>'
           - text: 'If you need urgent help and you’re in Wales call <a href="tel:+44800132737" class="govuk-link">0800 132 737</a> or text ‘help’ to 81066'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -565,3 +565,11 @@ en:
           - text: 'If you need urgent help and you’re in Northern Ireland call Lifeline on <a href="tel:+448088088000" class="govuk-link">0808 808 8000</a>'
           - text: 'If you need urgent help and you’re in Wales call <a href="tel:+44800132737" class="govuk-link">0800 132 737</a> or text ‘help’ to 81066'
           - text: "If it’s an emergency, call 999"
+  results:
+    header:
+      context: Coronavirus (COVID-19)
+      title: Information based on your answers
+      start_again_text: Start again
+    feedback:
+      text: Help us improve
+      link_text: Give feedback on this service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,8 @@ Rails.application.routes.draw do
     # Results
     get "/results", to: "results#show"
 
+    get "/clear-session", to: "session#delete"
+
     get "/session-expired", to: "session_expired#show"
   end
 

--- a/spec/helpers/result_helper_spec.rb
+++ b/spec/helpers/result_helper_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ResultsHelper, type: :helper do
   end
 
   describe "#result_groups" do
-    it "should return all group questions if all the session responses meet criteria" do
+    it "should return a group data structure with a heading and filtered questions" do
       session.merge!({
         "selected_groups": %i[being_unemployed],
         "have_you_been_made_unemployed": "I might be soon",
@@ -41,23 +41,26 @@ RSpec.describe ResultsHelper, type: :helper do
       )
     end
 
-    it "should return filtered group questions if the session responses do not meet criteria" do
+    it "should filter out empty groups" do
       session.merge!({
-        "selected_groups": %i[being_unemployed],
+        "selected_groups": %i[being_unemployed getting_food],
         "have_you_been_made_unemployed": "I might be soon",
-        "are_you_off_work_ill": "No",
+        "are_you_off_work_ill": "Yes",
         "self_employed": "Yes",
+        "afford_food": "No",
       })
       expect(result_groups(session)).to eq(
         being_unemployed: {
           heading:  I18n.t("coronavirus_form.groups.being_unemployed.title"),
           questions: [
             I18n.t("results_link.being_unemployed.have_you_been_made_unemployed"),
+            I18n.t("results_link.being_unemployed.are_you_off_work_ill"),
             I18n.t("results_link.being_unemployed.self_employed"),
           ],
-        }
+        },
       )
     end
+
   end
 
   describe "#filter_questions_by_session" do

--- a/spec/helpers/result_helper_spec.rb
+++ b/spec/helpers/result_helper_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe ResultsHelper, type: :helper do
           going_in_to_work
           somewhere_to_live
           mental_health
-          leave_home
       ])
     end
 

--- a/spec/helpers/result_helper_spec.rb
+++ b/spec/helpers/result_helper_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe ResultsHelper, type: :helper do
         },
       )
     end
-
   end
 
   describe "#filter_questions_by_session" do

--- a/spec/helpers/result_helper_spec.rb
+++ b/spec/helpers/result_helper_spec.rb
@@ -1,0 +1,92 @@
+require "spec_helper"
+
+RSpec.describe ResultsHelper, type: :helper do
+  describe "#relevant_group_keys" do
+    it "should return all group keys if selected_groups is empty" do
+      session.merge!({ "selected_groups": [] })
+      expect(relevant_group_keys).to eq(%i[
+          feeling_unsafe
+          paying_bills
+          getting_food
+          being_unemployed
+          going_in_to_work
+          somewhere_to_live
+          mental_health
+          leave_home
+      ])
+    end
+
+    it "should return selected_groups if it is not empty" do
+      session.merge!({ "selected_groups": %i[feeling_unsafe paying_bills] })
+      expect(relevant_group_keys).to eq(%i[feeling_unsafe paying_bills])
+    end
+  end
+
+  describe "#result_groups" do
+    it "should return all group questions if all the session responses meet criteria" do
+      session.merge!({
+        "selected_groups": %i[being_unemployed],
+        "have_you_been_made_unemployed": "I might be soon",
+        "are_you_off_work_ill": "Yes",
+        "self_employed": "Yes",
+      })
+      expect(result_groups(session)).to eq(
+        being_unemployed: {
+          heading:  I18n.t("coronavirus_form.groups.being_unemployed.title"),
+          questions: [
+            I18n.t("results_link.being_unemployed.have_you_been_made_unemployed"),
+            I18n.t("results_link.being_unemployed.are_you_off_work_ill"),
+            I18n.t("results_link.being_unemployed.self_employed"),
+          ],
+        },
+      )
+    end
+
+    it "should return filtered group questions if the session responses do not meet criteria" do
+      session.merge!({
+        "selected_groups": %i[being_unemployed],
+        "have_you_been_made_unemployed": "I might be soon",
+        "are_you_off_work_ill": "No",
+        "self_employed": "Yes",
+      })
+      expect(result_groups(session)).to eq(
+        being_unemployed: {
+          heading:  I18n.t("coronavirus_form.groups.being_unemployed.title"),
+          questions: [
+            I18n.t("results_link.being_unemployed.have_you_been_made_unemployed"),
+            I18n.t("results_link.being_unemployed.self_employed"),
+          ],
+        }
+      )
+    end
+  end
+
+  describe "#filter_questions_by_session" do
+    it "should return all group questions if all the session responses meet criteria" do
+      session.merge!({
+        "selected_groups": %i[being_unemployed],
+        "have_you_been_made_unemployed": "I might be soon",
+        "are_you_off_work_ill": "Yes",
+        "self_employed": "Yes",
+      })
+      expect(filter_questions_by_session(:being_unemployed, session)).to eq([
+        I18n.t("results_link.being_unemployed.have_you_been_made_unemployed"),
+        I18n.t("results_link.being_unemployed.are_you_off_work_ill"),
+        I18n.t("results_link.being_unemployed.self_employed"),
+      ])
+    end
+
+    it "should return filtered group questions if the session responses do not meet criteria" do
+      session.merge!({
+        "selected_groups": %i[being_unemployed],
+        "have_you_been_made_unemployed": "I might be soon",
+        "are_you_off_work_ill": "No",
+        "self_employed": "Yes",
+      })
+      expect(filter_questions_by_session(:being_unemployed, session)).to eq([
+        I18n.t("results_link.being_unemployed.have_you_been_made_unemployed"),
+        I18n.t("results_link.being_unemployed.self_employed"),
+      ])
+    end
+  end
+end

--- a/spec/requests/clear_session_spec.rb
+++ b/spec/requests/clear_session_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe "clear-session" do
+  describe "GET /clear-session" do
+    context "with session data" do
+      before do
+        post afford_food_path, params: { afford_food: "Yes" }
+      end
+
+      it "clears the session id" do
+        initial_session_id = session["session_id"]
+        get clear_session_path
+        expect(session["session_id"]).to_not eq(initial_session_id)
+      end
+
+      it "clears responses held in the session" do
+        expect(session["afford_food"]).to eq("Yes")
+        get clear_session_path
+        expect(session["afford_food"]).to be_nil
+      end
+
+      it "redirects the user to root" do
+        get clear_session_path
+        expect(response).to redirect_to("/")
+      end
+    end
+  end
+end

--- a/spec/requests/clear_session_spec.rb
+++ b/spec/requests/clear_session_spec.rb
@@ -1,20 +1,20 @@
 RSpec.describe "clear-session" do
+  let(:selected_no) { I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.options").last }
+
   describe "GET /clear-session" do
     context "with session data" do
-      before do
-        post afford_food_path, params: { afford_food: "Yes" }
-      end
-
       it "clears the session id" do
+        post urgent_medical_help_path, params: { urgent_medical_help: selected_no }
         initial_session_id = session["session_id"]
         get clear_session_path
         expect(session["session_id"]).to_not eq(initial_session_id)
       end
 
       it "clears responses held in the session" do
-        expect(session["afford_food"]).to eq("Yes")
+        post urgent_medical_help_path, params: { urgent_medical_help: selected_no }
+        expect(session[:urgent_medical_help]).to eq(selected_no)
         get clear_session_path
-        expect(session["afford_food"]).to be_nil
+        expect(session[:have_you_been_made_unemployed]).to be_nil
       end
 
       it "redirects the user to root" do


### PR DESCRIPTION
Trello: https://trello.com/c/qNCSEEHy/141-create-the-results-page

## What
- Takes the users responses and filters possible results by their answers
- Ensures empty groups cannot be rendered
- Displays as a mix of links, text and text with inline links

Includes dependent work:
- [Adds a route to clear the session and redirect for the "Start again" link](https://github.com/alphagov/govuk-coronavirus-find-support/pull/46/commits/a2efe31819aa22bf44b42549dc8329a448af0d46)
- [Alex's page header component](https://github.com/alphagov/govuk-coronavirus-find-support/pull/46/commits/ef75592b1d2712321ea670b5feb4ee1f4db62c6f)
- [Removing breadcrumbs](https://github.com/alphagov/govuk-coronavirus-find-support/pull/46/commits/b994e6eeaac7dcb8fc73f6ee48e45244fe61f012)
- [The grouping component for the results page](https://github.com/alphagov/govuk-coronavirus-find-support/pull/46/commits/527359ea9f082161bb85f02c4667f99ecf1cd480)
- [... and tweaks to allow it to take our new data structures](https://github.com/alphagov/govuk-coronavirus-find-support/pull/46/commits/201fdba17e3a76010b79312149c119ee37fe8264)
- [And the callout component](https://github.com/alphagov/govuk-coronavirus-find-support/pull/46/commits/d050202502f8702a27cf011556dc154adcb6995c) that I re-instated for alex after i force pushed over the top... woops...

## Screenshots
![image](https://user-images.githubusercontent.com/3694062/78936082-c7e3a980-7aa5-11ea-9400-f057345d8085.png)

![image](https://user-images.githubusercontent.com/3694062/78936140-e8abff00-7aa5-11ea-91ba-587eeb8c031f.png)
