### PR TITLE
Make 999 unclickable on mobile

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -365,8 +365,8 @@ en:
         - "No"
         - "Not sure"
       links:
-        - text: 'If you’re in immediate danger call <a href="tel:999" class="govuk-link">999</a> and ask for the Police.'
-        - text: 'If you’re in danger and unable to talk on the phone, call <a href="tel:999" class="govuk-link">999</a>, and then press 55.'
+        - text: "If you’re in immediate danger call 999 and ask for the Police."
+        - text: "If you’re in danger and unable to talk on the phone, call 999, and then press 55."
         - text: 'Call the National Domestic Abuse Helpline on <a href="tel:0808 2000 247" class="govuk-link">0808 2000 247</a>'
         - text: 'If you’re a child call Childline on <a href="tel:0800 1111" class="govuk-link">0800 1111</a>'
         - text: 'Find helplines <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse" class="govuk-link">if you’re a victim of domestic abuse or feel at risk of abuse</a>, or if you are a <a href="https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services" class="govuk-link">victim or witness of a crime</a> (these pages have no quick escape)'
@@ -455,4 +455,4 @@ en:
         - text: "If you need urgent help text ‘Shout’ to 85258"
         - text: 'If you need urgent help and you’re in Northern Ireland call Lifeline on <a href="tel:+448088088000" class="govuk-link">0808 808 8000</a>'
         - text: 'If you need urgent help and you’re in Wales call <a href="tel:+44800132737" class="govuk-link">0800 132 737</a> or text ‘help’ to 81066'
-        - text: 'If it’s an emergency, call <a href="tel:999" class="govuk-link">999</a>'
+        - text: "If it’s an emergency, call 999"


### PR DESCRIPTION
- I'm very uneasy about this being clickable as a telephone number as
  it's way too easy to mean to click another link nearby but click this
  one. And we shouldn't be phoning 999 by accident, ever.
- Discussed in https://github.com/alphagov/govuk-coronavirus-find-support/pull/44#discussion_r406188168.