### PR TITLE
Store responses

### DIFF
--- a/app/controllers/coronavirus_form/able_to_leave_controller.rb
+++ b/app/controllers/coronavirus_form/able_to_leave_controller.rb
@@ -20,11 +20,22 @@ class CoronavirusForm::AbleToLeaveController < ApplicationController
       render controller_path
     else
       update_session_store
+      write_responses
       redirect_to results_path
     end
   end
 
 private
+
+  # We're using this method to reduce the precision of timekeeping so that
+  # responses cannot be correlated with analytics data
+  def time_hour_floor
+    Time.current.beginning_of_hour
+  end
+
+  def write_responses
+    FormResponse.create(form_response: session, created_at: time_hour_floor)
+  end
 
   def update_session_store
     session[:able_to_leave] = @form_responses[:able_to_leave]

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/form_response.rb
+++ b/app/models/form_response.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class FormResponse < ApplicationRecord
+end

--- a/db/migrate/20200409135543_create_form_responses.rb
+++ b/db/migrate/20200409135543_create_form_responses.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateFormResponses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :form_responses do |t|
+      t.jsonb :form_response, default: {}, null: false
+      t.datetime :created_at, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_04_09_135543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "form_responses", force: :cascade do |t|
+    t.jsonb "form_response", default: {}, null: false
+    t.datetime "created_at", null: false
+  end
 
 end

--- a/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::AbleToLeaveController, type: :controller do
+  describe "POST" do
+    before do
+      Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
+    end
+
+    it "saves the form response to the database" do
+      session[:questions_to_ask] = %w(foo)
+
+      post :submit, params: { able_to_leave: "Yes" }
+
+      expect(FormResponse.first.form_response).to eq(
+        [["questions_to_ask", %w(foo)], %w(able_to_leave Yes)],
+      )
+      expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+    end
+  end
+end


### PR DESCRIPTION
This creates a new table and stores session data in it. 

Trello - https://trello.com/c/f427oVl3/197-store-results-in-postgres

Co-authored-by: Richard Towers <richard.towers@digital.cabinet-office.gov.uk>