### PR TITLE
Add groups to result links

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,7 +324,7 @@ en:
       title: "Feeling Safe"
       results:
         feel_safe:
-          title: "If you or someone you know are not feeling safe where you live"
+          title: "If you do not feel safe where you live or you’re worried about someone else"
           show_options:
             - "Yes but I’m concerned about the safety of someone else"
             - "No"
@@ -359,7 +359,7 @@ en:
       title: "Paying bills"
       results:
         afford_rent_mortgage_bills:
-          title: "If you're finding it hard to pay rent or bills"
+          title: "If you’re finding it hard to afford rent, your mortgage or bills"
           show_options:
             - "Yes"
             - "Not sure"
@@ -390,7 +390,7 @@ en:
       title: "Getting food"
       results:
         afford_food:
-          title: "If you're finding it hard to afford food"
+          title: "If you’re finding it hard to afford food"
           show_options:
             - "Yes"
             - "Not sure"
@@ -423,7 +423,7 @@ en:
       title: "Being unemployed or not having any work"
       results:
         have_you_been_made_unemployed:
-          title: "If you’ve been made unemployed or put on temporary leave (furloughed)"
+          title: "If you’ve been made unemployed, or put on temporary leave (furloughed)"
           show_options:
             - "I might be soon"
             - "No"
@@ -454,7 +454,7 @@ en:
             - text: "Find help with benefits if you live in Scotland"
               href: "https://www.mygov.scot/benefits-support/"
         are_you_off_work_ill:
-          title: "If you are off work ill"
+          title: "If you’re off work because you’re ill or self isolating"
           show_options:
             - "Yes"
             - "Not sure"
@@ -468,7 +468,7 @@ en:
             - text: "Get information on the help you can get if you're self-employed or work in the gig economy from the Money Advice Service"
               href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
         self_employed:
-          title: "If you are self employed"
+          title: "If you’re self employed or a sole trader"
           show_options:
             - "Yes"
             - "Not sure"
@@ -481,6 +481,7 @@ en:
       title: "Going in to work"
       results:
         still_working:
+          title: "If you’re still going in to work even though you’re a key worker"
           show_options:
             - "Yes"
             - "I do not know if I’m a key worker"
@@ -496,6 +497,7 @@ en:
             - text: "Find out if you're a key worker if you live in Scotland"
               href: "https://www.gov.scot/publications/coronavirus-guide-schools-early-learning-closures/pages/key-workers/"
         living_with_vulnerable:
+          title: "If you’re worried about going in to work because you live with someone vulnerable to coronavirus"
           show_options:
             - "Yes"
             - "Not sure"
@@ -506,6 +508,7 @@ en:
       title: "Having somewhere to live"
       results:
         do_you_have_somewhere_to_live:
+          title: "If you do not have somewhere to live"
           show_options:
             - "I do now but I might lose it"
             - "No"
@@ -523,6 +526,7 @@ en:
             - text: "Get help if you are homeless from Shelter Scotland"
               href: "https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness"
         have_you_been_evicted:
+          title: "If you’ve been evicted"
           show_options:
             - "Yes"
             - "I might be evicted soon"
@@ -549,6 +553,7 @@ en:
       title: "Mental health and wellbeing"
       results:
         mental_health_worries:
+          title: "If you’re worried about your mental health or someone else’s mental health"
           show_options:
             - "Yes"
             - "Not sure"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,6 +320,41 @@ en:
               - "I’m unable to leave my home for another reason"
             custom_select_error: "Select if you are able to leave your home or not"
   results_link:
+    feel_unsafe:
+      title: "Feeling Safe"
+      results:
+        feel_safe:
+          title: "If you or someone you know are not feeling safe where you live"
+          show_options:
+            - "Yes but I’m concerned about the safety of someone else"
+            - "No"
+            - "Not sure"
+          links:
+            - text: 'If you’re in immediate danger call <a href="tel:999" class="govuk-link">999</a> and ask for the Police.'
+            - text: 'If you’re in danger and unable to talk on the phone, call <a href="tel:999" class="govuk-link">999</a>, and then press 55.'
+            - text: 'Call the National Domestic Abuse Helpline on <a href="tel:0808 2000 247" class="govuk-link">0808 2000 247</a>'
+            - text: 'If you’re a child call Childline on <a href="tel:0800 1111" class="govuk-link">0800 1111</a>'
+            - text: 'Find helplines <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse" class="govuk-link">if you’re a victim of domestic abuse or feel at risk of abuse</a>, or if you are a <a href="https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services" class="govuk-link">victim or witness of a crime</a> (these pages have no quick escape)'
+            - text: "Get safety advice for survivors from Woman's Aid"
+              href: "https://www.womensaid.org.uk/covid-19-coronavirus-safety-advice-for-survivors/"
+            - text: "Get information from Nexus NI if you’re in Northern Ireland"
+              href: "https://nexusni.org/domestic-and-sexual-abuse-24-hour-helpline/"
+            - text: "Get help from Live Fear Free if you live in Wales"
+              href: "https://gov.wales/live-fear-free"
+            - text: "Get help from Women's Aid Scotland"
+              href: "https://womensaid.scot/"
+            - text: "Get information for children from Childline"
+              href: "https://www.childline.org.uk/"
+            - text: "Get information if you are in care or leaving care from Coram Voice"
+              href: "https://coramvoice.org.uk/"
+            - text: "Get information if you are child in Wales"
+              href: "https://www.childcomwales.org.uk/coronavirus/"
+            - text: "Contact NSPCC if you are concerned about a child"
+              href: "https://www.nspcc.org.uk/keeping-children-safe/our-services/nspcc-helpline/"
+            - text: "Find helplines if you are an older person living in Wales"
+              href: "https://www.olderpeoplewales.com/en/coronavirus.aspx"
+            - text: "Find victim support helplines if you live in Wales"
+              href: "https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales"
     have_you_been_made_unemployed:
       show_options:
         - "I might be soon"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -321,261 +321,247 @@ en:
             custom_select_error: "Select if you are able to leave your home or not"
   results_link:
     feel_unsafe:
-      title: "Feeling Safe"
-      results:
-        feel_safe:
-          title: "If you do not feel safe where you live or you’re worried about someone else"
-          show_options:
-            - "Yes but I’m concerned about the safety of someone else"
-            - "No"
-            - "Not sure"
-          links:
-            - text: "If you’re in immediate danger call 999 and ask for the Police."
-            - text: "If you’re in danger and unable to talk on the phone, call 999, and then press 55."
-            - text: 'Call the National Domestic Abuse Helpline on <a href="tel:0808 2000 247" class="govuk-link">0808 2000 247</a>'
-            - text: 'If you’re a child call Childline on <a href="tel:0800 1111" class="govuk-link">0800 1111</a>'
-            - text: 'Find helplines <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse" class="govuk-link">if you’re a victim of domestic abuse or feel at risk of abuse</a>, or if you are a <a href="https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services" class="govuk-link">victim or witness of a crime</a> (these pages have no quick escape)'
-            - text: "Get safety advice for survivors from Woman's Aid"
-              href: "https://www.womensaid.org.uk/covid-19-coronavirus-safety-advice-for-survivors/"
-            - text: "Get information from Nexus NI if you’re in Northern Ireland"
-              href: "https://nexusni.org/domestic-and-sexual-abuse-24-hour-helpline/"
-            - text: "Get help from Live Fear Free if you live in Wales"
-              href: "https://gov.wales/live-fear-free"
-            - text: "Get help from Women's Aid Scotland"
-              href: "https://womensaid.scot/"
-            - text: "Get information for children from Childline"
-              href: "https://www.childline.org.uk/"
-            - text: "Get information if you are in care or leaving care from Coram Voice"
-              href: "https://coramvoice.org.uk/"
-            - text: "Get information if you are child in Wales"
-              href: "https://www.childcomwales.org.uk/coronavirus/"
-            - text: "Contact NSPCC if you are concerned about a child"
-              href: "https://www.nspcc.org.uk/keeping-children-safe/our-services/nspcc-helpline/"
-            - text: "Find helplines if you are an older person living in Wales"
-              href: "https://www.olderpeoplewales.com/en/coronavirus.aspx"
-            - text: "Find victim support helplines if you live in Wales"
-              href: "https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales"
+      feel_safe:
+        title: "If you do not feel safe where you live or you’re worried about someone else"
+        show_options:
+          - "Yes but I’m concerned about the safety of someone else"
+          - "No"
+          - "Not sure"
+        links:
+          - text: "If you’re in immediate danger call 999 and ask for the Police."
+          - text: "If you’re in danger and unable to talk on the phone, call 999, and then press 55."
+          - text: 'Call the National Domestic Abuse Helpline on <a href="tel:0808 2000 247" class="govuk-link">0808 2000 247</a>'
+          - text: 'If you’re a child call Childline on <a href="tel:0800 1111" class="govuk-link">0800 1111</a>'
+          - text: 'Find helplines <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse" class="govuk-link">if you’re a victim of domestic abuse or feel at risk of abuse</a>, or if you are a <a href="https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services" class="govuk-link">victim or witness of a crime</a> (these pages have no quick escape)'
+          - text: "Get safety advice for survivors from Woman's Aid"
+            href: "https://www.womensaid.org.uk/covid-19-coronavirus-safety-advice-for-survivors/"
+          - text: "Get information from Nexus NI if you’re in Northern Ireland"
+            href: "https://nexusni.org/domestic-and-sexual-abuse-24-hour-helpline/"
+          - text: "Get help from Live Fear Free if you live in Wales"
+            href: "https://gov.wales/live-fear-free"
+          - text: "Get help from Women's Aid Scotland"
+            href: "https://womensaid.scot/"
+          - text: "Get information for children from Childline"
+            href: "https://www.childline.org.uk/"
+          - text: "Get information if you are in care or leaving care from Coram Voice"
+            href: "https://coramvoice.org.uk/"
+          - text: "Get information if you are child in Wales"
+            href: "https://www.childcomwales.org.uk/coronavirus/"
+          - text: "Contact NSPCC if you are concerned about a child"
+            href: "https://www.nspcc.org.uk/keeping-children-safe/our-services/nspcc-helpline/"
+          - text: "Find helplines if you are an older person living in Wales"
+            href: "https://www.olderpeoplewales.com/en/coronavirus.aspx"
+          - text: "Find victim support helplines if you live in Wales"
+            href: "https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales"
     paying_bills:
-      title: "Paying bills"
-      results:
-        afford_rent_mortgage_bills:
-          title: "If you’re finding it hard to afford rent, your mortgage or bills"
-          show_options:
-            - "Yes"
-            - "Not sure"
-          links:
-            - text: "Find out what to do if you're finding it hard to pay rent"
-              href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
-            - text: "Find information on the policies in place if you're finding it hard to pay energy bills"
-              href: "https://www.gov.uk/government/news/government-agrees-measures-with-energy-industry-to-support-vulnerable-people-through-covid-19"
-            - text: "Get information on what do if you cannot pay your rent or mortgage from Shelter"
-              href: "https://england.shelter.org.uk/housing_advice/coronavirus#Rent_payment_problems"
-            - text: "Get information on what do if you cannot pay your rent, mortgage or bills from Citizens Advice"
-              href: "https://www.citizensadvice.org.uk/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/"
-            - text: "Get help from Housing Rights if you live in Northern Ireland"
-              href: "https://www.housingrights.org.uk/"
-            - text: "Get information if you're finding it hard to pay rent and you live in Wales"
-              href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
-            - text: "Get coronavirus housing information from Shelter Wales"
-              href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-            - text: "Get information about your rights if you have a private landlord in Scotland"
-              href: "https://www.mygov.scot/private-rental-rights/"
-            - text: "Get coronavirus housing information from Shelter Scotland"
-              href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
-            - text: "Get information about your rights if you have a social landlord in Scotland"
-              href: "https://www.mygov.scot/social-rental-rights/"
-            - text: "Get coronavirus housing information from Shelter Scotland"
-              href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19#Paying_rent"
+      afford_rent_mortgage_bills:
+        title: "If you’re finding it hard to afford rent, your mortgage or bills"
+        show_options:
+          - "Yes"
+          - "Not sure"
+        links:
+          - text: "Find out what to do if you're finding it hard to pay rent"
+            href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
+          - text: "Find information on the policies in place if you're finding it hard to pay energy bills"
+            href: "https://www.gov.uk/government/news/government-agrees-measures-with-energy-industry-to-support-vulnerable-people-through-covid-19"
+          - text: "Get information on what do if you cannot pay your rent or mortgage from Shelter"
+            href: "https://england.shelter.org.uk/housing_advice/coronavirus#Rent_payment_problems"
+          - text: "Get information on what do if you cannot pay your rent, mortgage or bills from Citizens Advice"
+            href: "https://www.citizensadvice.org.uk/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/"
+          - text: "Get help from Housing Rights if you live in Northern Ireland"
+            href: "https://www.housingrights.org.uk/"
+          - text: "Get information if you're finding it hard to pay rent and you live in Wales"
+            href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
+          - text: "Get coronavirus housing information from Shelter Wales"
+            href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
+          - text: "Get information about your rights if you have a private landlord in Scotland"
+            href: "https://www.mygov.scot/private-rental-rights/"
+          - text: "Get coronavirus housing information from Shelter Scotland"
+            href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
+          - text: "Get information about your rights if you have a social landlord in Scotland"
+            href: "https://www.mygov.scot/social-rental-rights/"
+          - text: "Get coronavirus housing information from Shelter Scotland"
+            href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19#Paying_rent"
     getting_food:
-      title: "Getting food"
-      results:
-        afford_food:
-          title: "If you’re finding it hard to afford food"
-          show_options:
-            - "Yes"
-            - "Not sure"
-          links:
-            - text: "Find out if you’re eligible for Universal Credit"
-              href: "https://www.gov.uk/universal-credit/eligibility"
-            - text: "If you are at least 10 weeks pregnant or have a child under 4, find out if you can apply for Healthy Start vouchers"
-              href: "https://www.healthystart.nhs.uk/healthy-start-vouchers/do-i-qualify/"
-            - text: "Find out if you're eligible for the Scottish Welfare Fund if you live in Scotland"
-              href: "https://www.mygov.scot/scottish-welfare-fund/"
-            - text: "Find out if you can get a grant if you're a parent or looking after a child in Scotland"
-              href: "https://www.mygov.scot/best-start-grant-best-start-foods/"
-            - text: "Get information about getting free school meals during coronavirus if you live in Scotland"
-              href: "https://www.mygov.scot/school-meals/"
-            - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email covid19@adviceni.net or text ‘ACTION’ to 81025'
-        get_food:
-          title: "If you are finding it hard to get food"
-          show_options:
-            - "Yes"
-            - "Not sure"
-          links:
-            - text: "If you can, then ask friends, family, or other people in your community to get food for you."
-            - text: "You might be able to ask local shops to help you get food or do an online food order."
-            - text: "Find your local council to contact them for support"
-              href: "https://www.gov.uk/find-local-council/"
-            - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email <a href="mailto:covid19@adviceni.net">covid19@adviceni.net</a> or text: ’ACTION’ to 81025'
-            - text: "Get information on getting food deliveries if you live in Northern Ireland from The Consumer Council"
-              href: "https://www.consumercouncil.org.uk/coronavirus/vulnerable"
+      afford_food:
+        title: "If you’re finding it hard to afford food"
+        show_options:
+          - "Yes"
+          - "Not sure"
+        links:
+          - text: "Find out if you’re eligible for Universal Credit"
+            href: "https://www.gov.uk/universal-credit/eligibility"
+          - text: "If you are at least 10 weeks pregnant or have a child under 4, find out if you can apply for Healthy Start vouchers"
+            href: "https://www.healthystart.nhs.uk/healthy-start-vouchers/do-i-qualify/"
+          - text: "Find out if you're eligible for the Scottish Welfare Fund if you live in Scotland"
+            href: "https://www.mygov.scot/scottish-welfare-fund/"
+          - text: "Find out if you can get a grant if you're a parent or looking after a child in Scotland"
+            href: "https://www.mygov.scot/best-start-grant-best-start-foods/"
+          - text: "Get information about getting free school meals during coronavirus if you live in Scotland"
+            href: "https://www.mygov.scot/school-meals/"
+          - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email covid19@adviceni.net or text ‘ACTION’ to 81025'
+      get_food:
+        title: "If you are finding it hard to get food"
+        show_options:
+          - "Yes"
+          - "Not sure"
+        links:
+          - text: "If you can, then ask friends, family, or other people in your community to get food for you."
+          - text: "You might be able to ask local shops to help you get food or do an online food order."
+          - text: "Find your local council to contact them for support"
+            href: "https://www.gov.uk/find-local-council/"
+          - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email <a href="mailto:covid19@adviceni.net">covid19@adviceni.net</a> or text: ’ACTION’ to 81025'
+          - text: "Get information on getting food deliveries if you live in Northern Ireland from The Consumer Council"
+            href: "https://www.consumercouncil.org.uk/coronavirus/vulnerable"
     being_unemployed:
-      title: "Being unemployed or not having any work"
-      results:
-        have_you_been_made_unemployed:
-          title: "If you’ve been made unemployed, or put on temporary leave (furloughed)"
-          show_options:
-            - "I might be soon"
-            - "No"
-            - "Not sure"
-          links:
-            - text: "What to do if you have lost your job"
-              href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-you-were-employed-and-have-lost-your-job"
-            - text: "What to do if you’re laid-off"
-              href: "https://www.gov.uk/lay-offs-short-timeworking"
-            - text: "Find out about your rights if you have been dismissed"
-              href: "https://www.gov.uk/dismissal"
-            - text: "What to do if you’ve been furloughed"
-              href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work"
-            - text: "Get information about what to do if your employer has told you not to work from Citizens Advice"
-              href: "https://www.citizensadvice.org.uk/work/coronavirus-if-your-employer-has-told-you-not-to-work/"
-            - text: "Get information about the financial support you might be able to get from Acas"
-              href: "https://www.acas.org.uk/coronavirus/if-the-employer-needs-to-close-the-workplace"
-            - text: "Get information on applying for Universal Credit from Citizens Advice"
-              href: "https://www.citizensadvice.org.uk/benefits/universal-credit/"
-            - text: "Get advice on benefits if you live in Northern Ireland from Advice NI"
-              href: "https://www.adviceni.net/"
-            - text: "Contact Working Wales if you’ve been made redundant in Wales"
-              href: "https://workingwales.gov.wales/"
-            - text: "Contact Citizens Advice Wales"
-              href: "https://www.citizensadvice.org.uk/wales/about-us/contact-us/contact-us/contact-us/"
-            - text: "Get help if you’ve been made redundant in Scotland"
-              href: "https://www.mygov.scot/help-redundancy/"
-            - text: "Find help with benefits if you live in Scotland"
-              href: "https://www.mygov.scot/benefits-support/"
-        are_you_off_work_ill:
-          title: "If you’re off work because you’re ill or self isolating"
-          show_options:
-            - "Yes"
-            - "Not sure"
-          links:
-            - text: "Check if you’re eligible for statutory sick pay"
-              href: "https://www.gov.uk/statutory-sick-pay"
-            - text: "What to do if you’re employed but cannot work"
-              href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work"
-            - text: "Get information on getting statutory sick pay if you're self-isolating from Acas"
-              href: "https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay"
-            - text: "Get information on the help you can get if you're self-employed or work in the gig economy from the Money Advice Service"
-              href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
-        self_employed:
-          title: "If you’re self employed or a sole trader"
-          show_options:
-            - "Yes"
-            - "Not sure"
-          links:
-            - text: "What to do if you're self-employed and getting less work"
-              href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work"
-            - text: "Get information on what you can do if you're self employed or a sole trader from the Money Advice Service"
-              href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
+      have_you_been_made_unemployed:
+        title: "If you’ve been made unemployed, or put on temporary leave (furloughed)"
+        show_options:
+          - "I might be soon"
+          - "No"
+          - "Not sure"
+        links:
+          - text: "What to do if you have lost your job"
+            href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-you-were-employed-and-have-lost-your-job"
+          - text: "What to do if you’re laid-off"
+            href: "https://www.gov.uk/lay-offs-short-timeworking"
+          - text: "Find out about your rights if you have been dismissed"
+            href: "https://www.gov.uk/dismissal"
+          - text: "What to do if you’ve been furloughed"
+            href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work"
+          - text: "Get information about what to do if your employer has told you not to work from Citizens Advice"
+            href: "https://www.citizensadvice.org.uk/work/coronavirus-if-your-employer-has-told-you-not-to-work/"
+          - text: "Get information about the financial support you might be able to get from Acas"
+            href: "https://www.acas.org.uk/coronavirus/if-the-employer-needs-to-close-the-workplace"
+          - text: "Get information on applying for Universal Credit from Citizens Advice"
+            href: "https://www.citizensadvice.org.uk/benefits/universal-credit/"
+          - text: "Get advice on benefits if you live in Northern Ireland from Advice NI"
+            href: "https://www.adviceni.net/"
+          - text: "Contact Working Wales if you’ve been made redundant in Wales"
+            href: "https://workingwales.gov.wales/"
+          - text: "Contact Citizens Advice Wales"
+            href: "https://www.citizensadvice.org.uk/wales/about-us/contact-us/contact-us/contact-us/"
+          - text: "Get help if you’ve been made redundant in Scotland"
+            href: "https://www.mygov.scot/help-redundancy/"
+          - text: "Find help with benefits if you live in Scotland"
+            href: "https://www.mygov.scot/benefits-support/"
+      are_you_off_work_ill:
+        title: "If you’re off work because you’re ill or self isolating"
+        show_options:
+          - "Yes"
+          - "Not sure"
+        links:
+          - text: "Check if you’re eligible for statutory sick pay"
+            href: "https://www.gov.uk/statutory-sick-pay"
+          - text: "What to do if you’re employed but cannot work"
+            href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work"
+          - text: "Get information on getting statutory sick pay if you're self-isolating from Acas"
+            href: "https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay"
+          - text: "Get information on the help you can get if you're self-employed or work in the gig economy from the Money Advice Service"
+            href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
+      self_employed:
+        title: "If you’re self employed or a sole trader"
+        show_options:
+          - "Yes"
+          - "Not sure"
+        links:
+          - text: "What to do if you're self-employed and getting less work"
+            href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work"
+          - text: "Get information on what you can do if you're self employed or a sole trader from the Money Advice Service"
+            href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
     going_in_to_work:
-      title: "Going in to work"
-      results:
-        still_working:
-          title: "If you’re still going in to work even though you’re a key worker"
-          show_options:
-            - "Yes"
-            - "I do not know if I’m a key worker"
-          links:
-            - text: "Find out if you should be going to work"
-              href: "https://www.gov.uk/government/publications/full-guidance-on-staying-at-home-and-away-from-others/full-guidance-on-staying-at-home-and-away-from-others"
-            - text: "Find out if you’re a key worker"
-              href: "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-educational-provision/guidance-for-schools-colleges-and-local-authorities-on-maintaining-educational-provision"
-            - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
-              href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
-            - text: "Find out if you’re a key worker if you live in Wales"
-              href: "https://gov.wales/coronavirus-key-critical-workers"
-            - text: "Find out if you're a key worker if you live in Scotland"
-              href: "https://www.gov.scot/publications/coronavirus-guide-schools-early-learning-closures/pages/key-workers/"
-        living_with_vulnerable:
-          title: "If you’re worried about going in to work because you live with someone vulnerable to coronavirus"
-          show_options:
-            - "Yes"
-            - "Not sure"
-          links:
-            - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
-              href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
+      still_working:
+        title: "If you’re still going in to work even though you’re a key worker"
+        show_options:
+          - "Yes"
+          - "I do not know if I’m a key worker"
+        links:
+          - text: "Find out if you should be going to work"
+            href: "https://www.gov.uk/government/publications/full-guidance-on-staying-at-home-and-away-from-others/full-guidance-on-staying-at-home-and-away-from-others"
+          - text: "Find out if you’re a key worker"
+            href: "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-educational-provision/guidance-for-schools-colleges-and-local-authorities-on-maintaining-educational-provision"
+          - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
+            href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
+          - text: "Find out if you’re a key worker if you live in Wales"
+            href: "https://gov.wales/coronavirus-key-critical-workers"
+          - text: "Find out if you're a key worker if you live in Scotland"
+            href: "https://www.gov.scot/publications/coronavirus-guide-schools-early-learning-closures/pages/key-workers/"
+      living_with_vulnerable:
+        title: "If you’re worried about going in to work because you live with someone vulnerable to coronavirus"
+        show_options:
+          - "Yes"
+          - "Not sure"
+        links:
+          - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
+            href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
     somewhere_to_live:
-      title: "Having somewhere to live"
-      results:
-        do_you_have_somewhere_to_live:
-          title: "If you do not have somewhere to live"
-          show_options:
-            - "I do now but I might lose it"
-            - "No"
-            - "Not sure"
-          links:
-            - text: "Get information if you are legally homeless from Shelter"
-              href: "https://england.shelter.org.uk/housing_advice/homelessness/rules/legally_homeless"
-            - text: 'If you’re in Northern Ireland call the Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
-            - text: "Get information from Housing Rights if you live in Northern Ireland"
-              href: "https://www.housingadviceni.org/homeless/coronavirus"
-            - text: "Get coronavirus housing information from Shelter Wales"
-              href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-            - text: "Get information if you are homeless in Scotland"
-              href: "https://www.mygov.scot/homelessness/"
-            - text: "Get help if you are homeless from Shelter Scotland"
-              href: "https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness"
-        have_you_been_evicted:
-          title: "If you’ve been evicted"
-          show_options:
-            - "Yes"
-            - "I might be evicted soon"
-            - "Not sure"
-          links:
-            - text: "Get information about your rights as a tenant"
-              href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
-            - text: "Get coronavirus housing advice from Shelter"
-              href: "https://england.shelter.org.uk/housing_advice/coronavirus"
-            - text: 'If you’re in Northern Ireland call the Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
-            - text: "Get information from the Housing Executive if you live in Northern Ireland"
-              href: "https://www.nihe.gov.uk/My-Housing-Executive/Advice-for-Housing-Executive-Tenants/Covid-19-(Coronavirus)"
-            - text: "Get information from Housing Rights if you live in Northern Ireland"
-              href: "https://www.housingadviceni.org/coronavirus"
-            - text: "Get information on evictions if you live in Wales"
-              href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
-            - text: "Get coronavirus housing information from Shelter Wales"
-              href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-            - text: "Find out how to get help if you’re being evicted in Scotland"
-              href: "https://www.mygov.scot/private-tenant-eviction/getting-help/"
-            - text: "Get coronavirus information from Shelter Scotland"
-              href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
+      do_you_have_somewhere_to_live:
+        title: "If you do not have somewhere to live"
+        show_options:
+          - "I do now but I might lose it"
+          - "No"
+          - "Not sure"
+        links:
+          - text: "Get information if you are legally homeless from Shelter"
+            href: "https://england.shelter.org.uk/housing_advice/homelessness/rules/legally_homeless"
+          - text: 'If you’re in Northern Ireland call the Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
+          - text: "Get information from Housing Rights if you live in Northern Ireland"
+            href: "https://www.housingadviceni.org/homeless/coronavirus"
+          - text: "Get coronavirus housing information from Shelter Wales"
+            href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
+          - text: "Get information if you are homeless in Scotland"
+            href: "https://www.mygov.scot/homelessness/"
+          - text: "Get help if you are homeless from Shelter Scotland"
+            href: "https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness"
+      have_you_been_evicted:
+        title: "If you’ve been evicted"
+        show_options:
+          - "Yes"
+          - "I might be evicted soon"
+          - "Not sure"
+        links:
+          - text: "Get information about your rights as a tenant"
+            href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
+          - text: "Get coronavirus housing advice from Shelter"
+            href: "https://england.shelter.org.uk/housing_advice/coronavirus"
+          - text: 'If you’re in Northern Ireland call the Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
+          - text: "Get information from the Housing Executive if you live in Northern Ireland"
+            href: "https://www.nihe.gov.uk/My-Housing-Executive/Advice-for-Housing-Executive-Tenants/Covid-19-(Coronavirus)"
+          - text: "Get information from Housing Rights if you live in Northern Ireland"
+            href: "https://www.housingadviceni.org/coronavirus"
+          - text: "Get information on evictions if you live in Wales"
+            href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
+          - text: "Get coronavirus housing information from Shelter Wales"
+            href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
+          - text: "Find out how to get help if you’re being evicted in Scotland"
+            href: "https://www.mygov.scot/private-tenant-eviction/getting-help/"
+          - text: "Get coronavirus information from Shelter Scotland"
+            href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
     mental_health:
-      title: "Mental health and wellbeing"
-      results:
-        mental_health_worries:
-          title: "If you’re worried about your mental health or someone else’s mental health"
-          show_options:
-            - "Yes"
-            - "Not sure"
-          links:
-            - text: "Get information on coronavirus and your wellbeing from Mind"
-              href: "https://www.mind.org.uk/information-support/coronavirus/coronavirus-and-your-wellbeing/#collapse838f8"
-            - text: "Get information about looking after your mental health during coronavirus"
-              href: "https://www.gov.uk/government/publications/covid-19-guidance-for-the-public-on-mental-health-and-wellbeing"
-            - text: "Get information about looking after your mental health from the NHS"
-              href: "https://www.nhs.uk/oneyou/every-mind-matters"
-            - text: "Get information about supporting the mental health and wellbeing of children and young people"
-              href: "https://www.gov.uk/government/publications/covid-19-guidance-on-supporting-children-and-young-peoples-mental-health-and-wellbeing/guidance-for-parents-and-carers-on-supporting-children-and-young-peoples-mental-health-and-wellbeing-during-the-coronavirus-covid-19-outbreak"
-            - text: "Get information about taking care of your mental health if you live in Northern Ireland"
-              href: "https://www.nidirect.gov.uk/articles/coronavirus-covid-19-taking-care-your-mental-health-and-wellbeing"
-            - text: "Get information about taking care of your mental health if you live in Wales"
-              href: "https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/"
-            - text: "Get information about coronavirus and your mental wellbeing from the Scottish Association for Mental Health"
-              href: "https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing"
-            - text: "Find your local loneliness service"
-              href: "https://www.redcross.org.uk/get-help/get-help-with-loneliness/find-your-local-loneliness-service"
-            - text: 'If you need urgent help now, call the Samaritans on <a href="tel:03448 920 908" class="govuk-link">116 123</a>116 123</a>'
-            - text: "If you need urgent help text ‘Shout’ to 85258"
-            - text: 'If you need urgent help and you’re in Northern Ireland call Lifeline on <a href="tel:+448088088000" class="govuk-link">0808 808 8000</a>'
-            - text: 'If you need urgent help and you’re in Wales call <a href="tel:+44800132737" class="govuk-link">0800 132 737</a> or text ‘help’ to 81066'
-            - text: "If it’s an emergency, call 999"
+      mental_health_worries:
+        title: "If you’re worried about your mental health or someone else’s mental health"
+        show_options:
+          - "Yes"
+          - "Not sure"
+        links:
+          - text: "Get information on coronavirus and your wellbeing from Mind"
+            href: "https://www.mind.org.uk/information-support/coronavirus/coronavirus-and-your-wellbeing/#collapse838f8"
+          - text: "Get information about looking after your mental health during coronavirus"
+            href: "https://www.gov.uk/government/publications/covid-19-guidance-for-the-public-on-mental-health-and-wellbeing"
+          - text: "Get information about looking after your mental health from the NHS"
+            href: "https://www.nhs.uk/oneyou/every-mind-matters"
+          - text: "Get information about supporting the mental health and wellbeing of children and young people"
+            href: "https://www.gov.uk/government/publications/covid-19-guidance-on-supporting-children-and-young-peoples-mental-health-and-wellbeing/guidance-for-parents-and-carers-on-supporting-children-and-young-peoples-mental-health-and-wellbeing-during-the-coronavirus-covid-19-outbreak"
+          - text: "Get information about taking care of your mental health if you live in Northern Ireland"
+            href: "https://www.nidirect.gov.uk/articles/coronavirus-covid-19-taking-care-your-mental-health-and-wellbeing"
+          - text: "Get information about taking care of your mental health if you live in Wales"
+            href: "https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/"
+          - text: "Get information about coronavirus and your mental wellbeing from the Scottish Association for Mental Health"
+            href: "https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing"
+          - text: "Find your local loneliness service"
+            href: "https://www.redcross.org.uk/get-help/get-help-with-loneliness/find-your-local-loneliness-service"
+          - text: 'If you need urgent help now, call the Samaritans on <a href="tel:03448 920 908" class="govuk-link">116 123</a>116 123</a>'
+          - text: "If you need urgent help text ‘Shout’ to 85258"
+          - text: 'If you need urgent help and you’re in Northern Ireland call Lifeline on <a href="tel:+448088088000" class="govuk-link">0808 808 8000</a>'
+          - text: 'If you need urgent help and you’re in Wales call <a href="tel:+44800132737" class="govuk-link">0800 132 737</a> or text ‘help’ to 81066'
+          - text: "If it’s an emergency, call 999"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -419,58 +419,64 @@ en:
             - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email <a href="mailto:covid19@adviceni.net">covid19@adviceni.net</a> or text: ’ACTION’ to 81025'
             - text: "Get information on getting food deliveries if you live in Northern Ireland from The Consumer Council"
               href: "https://www.consumercouncil.org.uk/coronavirus/vulnerable"
-    have_you_been_made_unemployed:
-      show_options:
-        - "I might be soon"
-        - "No"
-        - "Not sure"
-      links:
-        - text: "What to do if you have lost your job"
-          href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-you-were-employed-and-have-lost-your-job"
-        - text: "What to do if you’re laid-off"
-          href: "https://www.gov.uk/lay-offs-short-timeworking"
-        - text: "Find out about your rights if you have been dismissed"
-          href: "https://www.gov.uk/dismissal"
-        - text: "What to do if you’ve been furloughed"
-          href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work"
-        - text: "Get information about what to do if your employer has told you not to work from Citizens Advice"
-          href: "https://www.citizensadvice.org.uk/work/coronavirus-if-your-employer-has-told-you-not-to-work/"
-        - text: "Get information about the financial support you might be able to get from Acas"
-          href: "https://www.acas.org.uk/coronavirus/if-the-employer-needs-to-close-the-workplace"
-        - text: "Get information on applying for Universal Credit from Citizens Advice"
-          href: "https://www.citizensadvice.org.uk/benefits/universal-credit/"
-        - text: "Get advice on benefits if you live in Northern Ireland from Advice NI"
-          href: "https://www.adviceni.net/"
-        - text: "Contact Working Wales if you’ve been made redundant in Wales"
-          href: "https://workingwales.gov.wales/"
-        - text: "Contact Citizens Advice Wales"
-          href: "https://www.citizensadvice.org.uk/wales/about-us/contact-us/contact-us/contact-us/"
-        - text: "Get help if you’ve been made redundant in Scotland"
-          href: "https://www.mygov.scot/help-redundancy/"
-        - text: "Find help with benefits if you live in Scotland"
-          href: "https://www.mygov.scot/benefits-support/"
-    are_you_off_work_ill:
-      show_options:
-        - "Yes"
-        - "Not sure"
-      links:
-        - text: "Check if you’re eligible for statutory sick pay"
-          href: "https://www.gov.uk/statutory-sick-pay"
-        - text: "What to do if you’re employed but cannot work"
-          href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work"
-        - text: "Get information on getting statutory sick pay if you're self-isolating from Acas"
-          href: "https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay"
-        - text: "Get information on the help you can get if you're self-employed or work in the gig economy from the Money Advice Service"
-          href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
-    self_employed:
-      show_options:
-        - "Yes"
-        - "Not sure"
-      links:
-        - text: "What to do if you're self-employed and getting less work"
-          href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work"
-        - text: "Get information on what you can do if you're self employed or a sole trader from the Money Advice Service"
-          href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
+    being_unemployed:
+      title: "Being unemployed or not having any work"
+      results:
+        have_you_been_made_unemployed:
+          title: "If you’ve been made unemployed or put on temporary leave (furloughed)"
+          show_options:
+            - "I might be soon"
+            - "No"
+            - "Not sure"
+          links:
+            - text: "What to do if you have lost your job"
+              href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-you-were-employed-and-have-lost-your-job"
+            - text: "What to do if you’re laid-off"
+              href: "https://www.gov.uk/lay-offs-short-timeworking"
+            - text: "Find out about your rights if you have been dismissed"
+              href: "https://www.gov.uk/dismissal"
+            - text: "What to do if you’ve been furloughed"
+              href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work"
+            - text: "Get information about what to do if your employer has told you not to work from Citizens Advice"
+              href: "https://www.citizensadvice.org.uk/work/coronavirus-if-your-employer-has-told-you-not-to-work/"
+            - text: "Get information about the financial support you might be able to get from Acas"
+              href: "https://www.acas.org.uk/coronavirus/if-the-employer-needs-to-close-the-workplace"
+            - text: "Get information on applying for Universal Credit from Citizens Advice"
+              href: "https://www.citizensadvice.org.uk/benefits/universal-credit/"
+            - text: "Get advice on benefits if you live in Northern Ireland from Advice NI"
+              href: "https://www.adviceni.net/"
+            - text: "Contact Working Wales if you’ve been made redundant in Wales"
+              href: "https://workingwales.gov.wales/"
+            - text: "Contact Citizens Advice Wales"
+              href: "https://www.citizensadvice.org.uk/wales/about-us/contact-us/contact-us/contact-us/"
+            - text: "Get help if you’ve been made redundant in Scotland"
+              href: "https://www.mygov.scot/help-redundancy/"
+            - text: "Find help with benefits if you live in Scotland"
+              href: "https://www.mygov.scot/benefits-support/"
+        are_you_off_work_ill:
+          title: "If you are off work ill"
+          show_options:
+            - "Yes"
+            - "Not sure"
+          links:
+            - text: "Check if you’re eligible for statutory sick pay"
+              href: "https://www.gov.uk/statutory-sick-pay"
+            - text: "What to do if you’re employed but cannot work"
+              href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work"
+            - text: "Get information on getting statutory sick pay if you're self-isolating from Acas"
+              href: "https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay"
+            - text: "Get information on the help you can get if you're self-employed or work in the gig economy from the Money Advice Service"
+              href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
+        self_employed:
+          title: "If you are self employed"
+          show_options:
+            - "Yes"
+            - "Not sure"
+          links:
+            - text: "What to do if you're self-employed and getting less work"
+              href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work"
+            - text: "Get information on what you can do if you're self employed or a sole trader from the Money Advice Service"
+              href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
     still_working:
       show_options:
         - "Yes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -477,28 +477,31 @@ en:
               href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work"
             - text: "Get information on what you can do if you're self employed or a sole trader from the Money Advice Service"
               href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
-    still_working:
-      show_options:
-        - "Yes"
-        - "I do not know if I’m a key worker"
-      links:
-        - text: "Find out if you should be going to work"
-          href: "https://www.gov.uk/government/publications/full-guidance-on-staying-at-home-and-away-from-others/full-guidance-on-staying-at-home-and-away-from-others"
-        - text: "Find out if you’re a key worker"
-          href: "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-educational-provision/guidance-for-schools-colleges-and-local-authorities-on-maintaining-educational-provision"
-        - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
-          href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
-        - text: "Find out if you’re a key worker if you live in Wales"
-          href: "https://gov.wales/coronavirus-key-critical-workers"
-        - text: "Find out if you're a key worker if you live in Scotland"
-          href: "https://www.gov.scot/publications/coronavirus-guide-schools-early-learning-closures/pages/key-workers/"
-    living_with_vulnerable:
-      show_options:
-        - "Yes"
-        - "Not sure"
-      links:
-        - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
-          href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
+    going_in_to_work:
+      title: "Going in to work"
+      results:
+        still_working:
+          show_options:
+            - "Yes"
+            - "I do not know if I’m a key worker"
+          links:
+            - text: "Find out if you should be going to work"
+              href: "https://www.gov.uk/government/publications/full-guidance-on-staying-at-home-and-away-from-others/full-guidance-on-staying-at-home-and-away-from-others"
+            - text: "Find out if you’re a key worker"
+              href: "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-educational-provision/guidance-for-schools-colleges-and-local-authorities-on-maintaining-educational-provision"
+            - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
+              href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
+            - text: "Find out if you’re a key worker if you live in Wales"
+              href: "https://gov.wales/coronavirus-key-critical-workers"
+            - text: "Find out if you're a key worker if you live in Scotland"
+              href: "https://www.gov.scot/publications/coronavirus-guide-schools-early-learning-closures/pages/key-workers/"
+        living_with_vulnerable:
+          show_options:
+            - "Yes"
+            - "Not sure"
+          links:
+            - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
+              href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
     do_you_have_somewhere_to_live:
       show_options:
         - "I do now but I might lose it"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,8 +330,8 @@ en:
             - "No"
             - "Not sure"
           links:
-            - text: 'If you’re in immediate danger call <a href="tel:999" class="govuk-link">999</a> and ask for the Police.'
-            - text: 'If you’re in danger and unable to talk on the phone, call <a href="tel:999" class="govuk-link">999</a>, and then press 55.'
+            - text: "If you’re in immediate danger call 999 and ask for the Police."
+            - text: "If you’re in danger and unable to talk on the phone, call 999, and then press 55."
             - text: 'Call the National Domestic Abuse Helpline on <a href="tel:0808 2000 247" class="govuk-link">0808 2000 247</a>'
             - text: 'If you’re a child call Childline on <a href="tel:0800 1111" class="govuk-link">0800 1111</a>'
             - text: 'Find helplines <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse" class="govuk-link">if you’re a victim of domestic abuse or feel at risk of abuse</a>, or if you are a <a href="https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services" class="govuk-link">victim or witness of a crime</a> (these pages have no quick escape)'
@@ -386,6 +386,39 @@ en:
               href: "https://www.mygov.scot/social-rental-rights/"
             - text: "Get coronavirus housing information from Shelter Scotland"
               href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19#Paying_rent"
+    getting_food:
+      title: "Getting food"
+      results:
+        afford_food:
+          title: "If you're finding it hard to afford food"
+          show_options:
+            - "Yes"
+            - "Not sure"
+          links:
+            - text: "Find out if you’re eligible for Universal Credit"
+              href: "https://www.gov.uk/universal-credit/eligibility"
+            - text: "If you are at least 10 weeks pregnant or have a child under 4, find out if you can apply for Healthy Start vouchers"
+              href: "https://www.healthystart.nhs.uk/healthy-start-vouchers/do-i-qualify/"
+            - text: "Find out if you're eligible for the Scottish Welfare Fund if you live in Scotland"
+              href: "https://www.mygov.scot/scottish-welfare-fund/"
+            - text: "Find out if you can get a grant if you're a parent or looking after a child in Scotland"
+              href: "https://www.mygov.scot/best-start-grant-best-start-foods/"
+            - text: "Get information about getting free school meals during coronavirus if you live in Scotland"
+              href: "https://www.mygov.scot/school-meals/"
+            - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email covid19@adviceni.net or text ‘ACTION’ to 81025'
+        get_food:
+          title: "If you are finding it hard to get food"
+          show_options:
+            - "Yes"
+            - "Not sure"
+          links:
+            - text: "If you can, then ask friends, family, or other people in your community to get food for you."
+            - text: "You might be able to ask local shops to help you get food or do an online food order."
+            - text: "Find your local council to contact them for support"
+              href: "https://www.gov.uk/find-local-council/"
+            - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email <a href="mailto:covid19@adviceni.net">covid19@adviceni.net</a> or text: ’ACTION’ to 81025'
+            - text: "Get information on getting food deliveries if you live in Northern Ireland from The Consumer Council"
+              href: "https://www.consumercouncil.org.uk/coronavirus/vulnerable"
     have_you_been_made_unemployed:
       show_options:
         - "I might be soon"
@@ -460,53 +493,6 @@ en:
       links:
         - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
           href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
-    afford_food:
-      show_options:
-        - "Yes"
-        - "Not sure"
-      links:
-        - text: "Find out if you’re eligible for Universal Credit"
-          href: "https://www.gov.uk/universal-credit/eligibility"
-        - text: "If you are at least 10 weeks pregnant or have a child under 4, find out if you can apply for Healthy Start vouchers"
-          href: "https://www.healthystart.nhs.uk/healthy-start-vouchers/do-i-qualify/"
-        - text: "Find out if you're eligible for the Scottish Welfare Fund if you live in Scotland"
-          href: "https://www.mygov.scot/scottish-welfare-fund/"
-        - text: "Find out if you can get a grant if you're a parent or looking after a child in Scotland"
-          href: "https://www.mygov.scot/best-start-grant-best-start-foods/"
-        - text: "Get information about getting free school meals during coronavirus if you live in Scotland"
-          href: "https://www.mygov.scot/school-meals/"
-        - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email covid19@adviceni.net or text ‘ACTION’ to 81025'
-    feel_safe:
-      show_options:
-        - "Yes but I’m concerned about the safety of someone else"
-        - "No"
-        - "Not sure"
-      links:
-        - text: "If you’re in immediate danger call 999 and ask for the Police."
-        - text: "If you’re in danger and unable to talk on the phone, call 999, and then press 55."
-        - text: 'Call the National Domestic Abuse Helpline on <a href="tel:0808 2000 247" class="govuk-link">0808 2000 247</a>'
-        - text: 'If you’re a child call Childline on <a href="tel:0800 1111" class="govuk-link">0800 1111</a>'
-        - text: 'Find helplines <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse" class="govuk-link">if you’re a victim of domestic abuse or feel at risk of abuse</a>, or if you are a <a href="https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services" class="govuk-link">victim or witness of a crime</a> (these pages have no quick escape)'
-        - text: "Get safety advice for survivors from Woman's Aid"
-          href: "https://www.womensaid.org.uk/covid-19-coronavirus-safety-advice-for-survivors/"
-        - text: "Get information from Nexus NI if you’re in Northern Ireland"
-          href: "https://nexusni.org/domestic-and-sexual-abuse-24-hour-helpline/"
-        - text: "Get help from Live Fear Free if you live in Wales"
-          href: "https://gov.wales/live-fear-free"
-        - text: "Get help from Women's Aid Scotland"
-          href: "https://womensaid.scot/"
-        - text: "Get information for children from Childline"
-          href: "https://www.childline.org.uk/"
-        - text: "Get information if you are in care or leaving care from Coram Voice"
-          href: "https://coramvoice.org.uk/"
-        - text: "Get information if you are child in Wales"
-          href: "https://www.childcomwales.org.uk/coronavirus/"
-        - text: "Contact NSPCC if you are concerned about a child"
-          href: "https://www.nspcc.org.uk/keeping-children-safe/our-services/nspcc-helpline/"
-        - text: "Find helplines if you are an older person living in Wales"
-          href: "https://www.olderpeoplewales.com/en/coronavirus.aspx"
-        - text: "Find victim support helplines if you live in Wales"
-          href: "https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales"
     do_you_have_somewhere_to_live:
       show_options:
         - "I do now but I might lose it"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -545,29 +545,32 @@ en:
               href: "https://www.mygov.scot/private-tenant-eviction/getting-help/"
             - text: "Get coronavirus information from Shelter Scotland"
               href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
-    mental_health_worries:
-      show_options:
-        - "Yes"
-        - "Not sure"
-      links:
-        - text: "Get information on coronavirus and your wellbeing from Mind"
-          href: "https://www.mind.org.uk/information-support/coronavirus/coronavirus-and-your-wellbeing/#collapse838f8"
-        - text: "Get information about looking after your mental health during coronavirus"
-          href: "https://www.gov.uk/government/publications/covid-19-guidance-for-the-public-on-mental-health-and-wellbeing"
-        - text: "Get information about looking after your mental health from the NHS"
-          href: "https://www.nhs.uk/oneyou/every-mind-matters"
-        - text: "Get information about supporting the mental health and wellbeing of children and young people"
-          href: "https://www.gov.uk/government/publications/covid-19-guidance-on-supporting-children-and-young-peoples-mental-health-and-wellbeing/guidance-for-parents-and-carers-on-supporting-children-and-young-peoples-mental-health-and-wellbeing-during-the-coronavirus-covid-19-outbreak"
-        - text: "Get information about taking care of your mental health if you live in Northern Ireland"
-          href: "https://www.nidirect.gov.uk/articles/coronavirus-covid-19-taking-care-your-mental-health-and-wellbeing"
-        - text: "Get information about taking care of your mental health if you live in Wales"
-          href: "https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/"
-        - text: "Get information about coronavirus and your mental wellbeing from the Scottish Association for Mental Health"
-          href: "https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing"
-        - text: "Find your local loneliness service"
-          href: "https://www.redcross.org.uk/get-help/get-help-with-loneliness/find-your-local-loneliness-service"
-        - text: 'If you need urgent help now, call the Samaritans on <a href="tel:03448 920 908" class="govuk-link">116 123</a>116 123</a>'
-        - text: "If you need urgent help text ‘Shout’ to 85258"
-        - text: 'If you need urgent help and you’re in Northern Ireland call Lifeline on <a href="tel:+448088088000" class="govuk-link">0808 808 8000</a>'
-        - text: 'If you need urgent help and you’re in Wales call <a href="tel:+44800132737" class="govuk-link">0800 132 737</a> or text ‘help’ to 81066'
-        - text: "If it’s an emergency, call 999"
+    mental_health:
+      title: "Mental health and wellbeing"
+      results:
+        mental_health_worries:
+          show_options:
+            - "Yes"
+            - "Not sure"
+          links:
+            - text: "Get information on coronavirus and your wellbeing from Mind"
+              href: "https://www.mind.org.uk/information-support/coronavirus/coronavirus-and-your-wellbeing/#collapse838f8"
+            - text: "Get information about looking after your mental health during coronavirus"
+              href: "https://www.gov.uk/government/publications/covid-19-guidance-for-the-public-on-mental-health-and-wellbeing"
+            - text: "Get information about looking after your mental health from the NHS"
+              href: "https://www.nhs.uk/oneyou/every-mind-matters"
+            - text: "Get information about supporting the mental health and wellbeing of children and young people"
+              href: "https://www.gov.uk/government/publications/covid-19-guidance-on-supporting-children-and-young-peoples-mental-health-and-wellbeing/guidance-for-parents-and-carers-on-supporting-children-and-young-peoples-mental-health-and-wellbeing-during-the-coronavirus-covid-19-outbreak"
+            - text: "Get information about taking care of your mental health if you live in Northern Ireland"
+              href: "https://www.nidirect.gov.uk/articles/coronavirus-covid-19-taking-care-your-mental-health-and-wellbeing"
+            - text: "Get information about taking care of your mental health if you live in Wales"
+              href: "https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/"
+            - text: "Get information about coronavirus and your mental wellbeing from the Scottish Association for Mental Health"
+              href: "https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing"
+            - text: "Find your local loneliness service"
+              href: "https://www.redcross.org.uk/get-help/get-help-with-loneliness/find-your-local-loneliness-service"
+            - text: 'If you need urgent help now, call the Samaritans on <a href="tel:03448 920 908" class="govuk-link">116 123</a>116 123</a>'
+            - text: "If you need urgent help text ‘Shout’ to 85258"
+            - text: 'If you need urgent help and you’re in Northern Ireland call Lifeline on <a href="tel:+448088088000" class="govuk-link">0808 808 8000</a>'
+            - text: 'If you need urgent help and you’re in Wales call <a href="tel:+44800132737" class="govuk-link">0800 132 737</a> or text ‘help’ to 81066'
+            - text: "If it’s an emergency, call 999"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -355,6 +355,37 @@ en:
               href: "https://www.olderpeoplewales.com/en/coronavirus.aspx"
             - text: "Find victim support helplines if you live in Wales"
               href: "https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales"
+    paying_bills:
+      title: "Paying bills"
+      results:
+        afford_rent_mortgage_bills:
+          title: "If you're finding it hard to pay rent or bills"
+          show_options:
+            - "Yes"
+            - "Not sure"
+          links:
+            - text: "Find out what to do if you're finding it hard to pay rent"
+              href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
+            - text: "Find information on the policies in place if you're finding it hard to pay energy bills"
+              href: "https://www.gov.uk/government/news/government-agrees-measures-with-energy-industry-to-support-vulnerable-people-through-covid-19"
+            - text: "Get information on what do if you cannot pay your rent or mortgage from Shelter"
+              href: "https://england.shelter.org.uk/housing_advice/coronavirus#Rent_payment_problems"
+            - text: "Get information on what do if you cannot pay your rent, mortgage or bills from Citizens Advice"
+              href: "https://www.citizensadvice.org.uk/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/"
+            - text: "Get help from Housing Rights if you live in Northern Ireland"
+              href: "https://www.housingrights.org.uk/"
+            - text: "Get information if you're finding it hard to pay rent and you live in Wales"
+              href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
+            - text: "Get coronavirus housing information from Shelter Wales"
+              href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
+            - text: "Get information about your rights if you have a private landlord in Scotland"
+              href: "https://www.mygov.scot/private-rental-rights/"
+            - text: "Get coronavirus housing information from Shelter Scotland"
+              href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
+            - text: "Get information about your rights if you have a social landlord in Scotland"
+              href: "https://www.mygov.scot/social-rental-rights/"
+            - text: "Get coronavirus housing information from Shelter Scotland"
+              href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19#Paying_rent"
     have_you_been_made_unemployed:
       show_options:
         - "I might be soon"
@@ -429,33 +460,6 @@ en:
       links:
         - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
           href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
-    afford_rent_mortgage_bills:
-      show_options:
-        - "Yes"
-        - "Not sure"
-      links:
-        - text: "Find out what to do if you're finding it hard to pay rent"
-          href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
-        - text: "Find information on the policies in place if you're finding it hard to pay energy bills"
-          href: "https://www.gov.uk/government/news/government-agrees-measures-with-energy-industry-to-support-vulnerable-people-through-covid-19"
-        - text: "Get information on what do if you cannot pay your rent or mortgage from Shelter"
-          href: "https://england.shelter.org.uk/housing_advice/coronavirus#Rent_payment_problems"
-        - text: "Get information on what do if you cannot pay your rent, mortgage or bills from Citizens Advice"
-          href: "https://www.citizensadvice.org.uk/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/"
-        - text: "Get help from Housing Rights if you live in Northern Ireland"
-          href: "https://www.housingrights.org.uk/"
-        - text: "Get information if you're finding it hard to pay rent and you live in Wales"
-          href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
-        - text: "Get coronavirus housing information from Shelter Wales"
-          href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-        - text: "Get information about your rights if you have a private landlord in Scotland"
-          href: "https://www.mygov.scot/private-rental-rights/"
-        - text: "Get coronavirus housing information from Shelter Scotland"
-          href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
-        - text: "Get information about your rights if you have a social landlord in Scotland"
-          href: "https://www.mygov.scot/social-rental-rights/"
-        - text: "Get coronavirus housing information from Shelter Scotland"
-          href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19#Paying_rent"
     afford_food:
       show_options:
         - "Yes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -322,7 +322,7 @@ en:
   results_link:
     feel_unsafe:
       feel_safe:
-        title: "If you do not feel safe where you live or you’re worried about someone else"
+        heading: "If you do not feel safe where you live or you’re worried about someone else"
         show_options:
           - "Yes but I’m concerned about the safety of someone else"
           - "No"
@@ -355,7 +355,7 @@ en:
             href: "https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales"
     paying_bills:
       afford_rent_mortgage_bills:
-        title: "If you’re finding it hard to afford rent, your mortgage or bills"
+        heading: "If you’re finding it hard to afford rent, your mortgage or bills"
         show_options:
           - "Yes"
           - "Not sure"
@@ -384,7 +384,7 @@ en:
             href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19#Paying_rent"
     getting_food:
       afford_food:
-        title: "If you’re finding it hard to afford food"
+        heading: "If you’re finding it hard to afford food"
         show_options:
           - "Yes"
           - "Not sure"
@@ -401,7 +401,7 @@ en:
             href: "https://www.mygov.scot/school-meals/"
           - text: 'If you are in Northern Ireland call the coronavirus Community Helpline on <a href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email covid19@adviceni.net or text ‘ACTION’ to 81025'
       get_food:
-        title: "If you are finding it hard to get food"
+        heading: "If you are finding it hard to get food"
         show_options:
           - "Yes"
           - "Not sure"
@@ -415,7 +415,7 @@ en:
             href: "https://www.consumercouncil.org.uk/coronavirus/vulnerable"
     being_unemployed:
       have_you_been_made_unemployed:
-        title: "If you’ve been made unemployed, or put on temporary leave (furloughed)"
+        heading: "If you’ve been made unemployed, or put on temporary leave (furloughed)"
         show_options:
           - "I might be soon"
           - "No"
@@ -446,7 +446,7 @@ en:
           - text: "Find help with benefits if you live in Scotland"
             href: "https://www.mygov.scot/benefits-support/"
       are_you_off_work_ill:
-        title: "If you’re off work because you’re ill or self isolating"
+        heading: "If you’re off work because you’re ill or self isolating"
         show_options:
           - "Yes"
           - "Not sure"
@@ -460,7 +460,7 @@ en:
           - text: "Get information on the help you can get if you're self-employed or work in the gig economy from the Money Advice Service"
             href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
       self_employed:
-        title: "If you’re self employed or a sole trader"
+        heading: "If you’re self employed or a sole trader"
         show_options:
           - "Yes"
           - "Not sure"
@@ -471,7 +471,7 @@ en:
             href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
     going_in_to_work:
       still_working:
-        title: "If you’re still going in to work even though you’re a key worker"
+        heading: "If you’re still going in to work even though you’re a key worker"
         show_options:
           - "Yes"
           - "I do not know if I’m a key worker"
@@ -487,7 +487,7 @@ en:
           - text: "Find out if you're a key worker if you live in Scotland"
             href: "https://www.gov.scot/publications/coronavirus-guide-schools-early-learning-closures/pages/key-workers/"
       living_with_vulnerable:
-        title: "If you’re worried about going in to work because you live with someone vulnerable to coronavirus"
+        heading: "If you’re worried about going in to work because you live with someone vulnerable to coronavirus"
         show_options:
           - "Yes"
           - "Not sure"
@@ -496,7 +496,7 @@ en:
             href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
     somewhere_to_live:
       do_you_have_somewhere_to_live:
-        title: "If you do not have somewhere to live"
+        heading: "If you do not have somewhere to live"
         show_options:
           - "I do now but I might lose it"
           - "No"
@@ -514,7 +514,7 @@ en:
           - text: "Get help if you are homeless from Shelter Scotland"
             href: "https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness"
       have_you_been_evicted:
-        title: "If you’ve been evicted"
+        heading: "If you’ve been evicted"
         show_options:
           - "Yes"
           - "I might be evicted soon"
@@ -539,7 +539,7 @@ en:
             href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
     mental_health:
       mental_health_worries:
-        title: "If you’re worried about your mental health or someone else’s mental health"
+        heading: "If you’re worried about your mental health or someone else’s mental health"
         show_options:
           - "Yes"
           - "Not sure"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,46 +502,49 @@ en:
           links:
             - text: "Get information on what to do if you're worried about going to work because of coronavirus from Citizens Advice"
               href: "https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/"
-    do_you_have_somewhere_to_live:
-      show_options:
-        - "I do now but I might lose it"
-        - "No"
-        - "Not sure"
-      links:
-        - text: "Get information if you are legally homeless from Shelter"
-          href: "https://england.shelter.org.uk/housing_advice/homelessness/rules/legally_homeless"
-        - text: 'If you’re in Northern Ireland call the Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
-        - text: "Get information from Housing Rights if you live in Northern Ireland"
-          href: "https://www.housingadviceni.org/homeless/coronavirus"
-        - text: "Get coronavirus housing information from Shelter Wales"
-          href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-        - text: "Get information if you are homeless in Scotland"
-          href: "https://www.mygov.scot/homelessness/"
-        - text: "Get help if you are homeless from Shelter Scotland"
-          href: "https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness"
-    have_you_been_evicted:
-      show_options:
-        - "Yes"
-        - "I might be evicted soon"
-        - "Not sure"
-      links:
-        - text: "Get information about your rights as a tenant"
-          href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
-        - text: "Get coronavirus housing advice from Shelter"
-          href: "https://england.shelter.org.uk/housing_advice/coronavirus"
-        - text: 'If you’re in Northern Ireland call the Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
-        - text: "Get information from the Housing Executive if you live in Northern Ireland"
-          href: "https://www.nihe.gov.uk/My-Housing-Executive/Advice-for-Housing-Executive-Tenants/Covid-19-(Coronavirus)"
-        - text: "Get information from Housing Rights if you live in Northern Ireland"
-          href: "https://www.housingadviceni.org/coronavirus"
-        - text: "Get information on evictions if you live in Wales"
-          href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
-        - text: "Get coronavirus housing information from Shelter Wales"
-          href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-        - text: "Find out how to get help if you’re being evicted in Scotland"
-          href: "https://www.mygov.scot/private-tenant-eviction/getting-help/"
-        - text: "Get coronavirus information from Shelter Scotland"
-          href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
+    somewhere_to_live:
+      title: "Having somewhere to live"
+      results:
+        do_you_have_somewhere_to_live:
+          show_options:
+            - "I do now but I might lose it"
+            - "No"
+            - "Not sure"
+          links:
+            - text: "Get information if you are legally homeless from Shelter"
+              href: "https://england.shelter.org.uk/housing_advice/homelessness/rules/legally_homeless"
+            - text: 'If you’re in Northern Ireland call the Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
+            - text: "Get information from Housing Rights if you live in Northern Ireland"
+              href: "https://www.housingadviceni.org/homeless/coronavirus"
+            - text: "Get coronavirus housing information from Shelter Wales"
+              href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
+            - text: "Get information if you are homeless in Scotland"
+              href: "https://www.mygov.scot/homelessness/"
+            - text: "Get help if you are homeless from Shelter Scotland"
+              href: "https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness"
+        have_you_been_evicted:
+          show_options:
+            - "Yes"
+            - "I might be evicted soon"
+            - "Not sure"
+          links:
+            - text: "Get information about your rights as a tenant"
+              href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
+            - text: "Get coronavirus housing advice from Shelter"
+              href: "https://england.shelter.org.uk/housing_advice/coronavirus"
+            - text: 'If you’re in Northern Ireland call the Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
+            - text: "Get information from the Housing Executive if you live in Northern Ireland"
+              href: "https://www.nihe.gov.uk/My-Housing-Executive/Advice-for-Housing-Executive-Tenants/Covid-19-(Coronavirus)"
+            - text: "Get information from Housing Rights if you live in Northern Ireland"
+              href: "https://www.housingadviceni.org/coronavirus"
+            - text: "Get information on evictions if you live in Wales"
+              href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
+            - text: "Get coronavirus housing information from Shelter Wales"
+              href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
+            - text: "Find out how to get help if you’re being evicted in Scotland"
+              href: "https://www.mygov.scot/private-tenant-eviction/getting-help/"
+            - text: "Get coronavirus information from Shelter Scotland"
+              href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
     mental_health_worries:
       show_options:
         - "Yes"


### PR DESCRIPTION
## What

Previously results were nested under questions, this:
- further nests them under groups
- adds titles to the results questions we can use to render the results page.

## Why

Questions are nested within groups, so we've added the groups to the result data along with the relevant titles.