### PR TITLE
Don't enable basic auth on prod

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -114,7 +114,7 @@ jobs:
           CF_SPACE: production
           INSTANCES: 30
           CF_STARTUP_TIMEOUT: 15 # minutes
-          REQUIRE_BASIC_AUTH: "true"
+          REQUIRE_BASIC_AUTH:
           BASIC_AUTH_PASSWORD: ((basic-auth-password))
           AWS_ACCESS_KEY_ID: ((aws-access-key-id-prod))
           AWS_SECRET_ACCESS_KEY: ((aws-secret-access-key-prod))


### PR DESCRIPTION
Note that this PR won't actually remove the env var, you'll have to run:

```
cf unset-env govuk-coronavirus-find-support REQUIRE_BASIC_AUTH
```

and

```
cf v3-restart govuk-coronavirus-find-support
```