### PR TITLE
Add escape link component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@ $app-covid-grey: #272828;
 
 @import 'components/action-link';
 @import 'components/action-panel';
+@import 'components/escape-link';
 @import 'cookies-settings';
 @import 'components/callout';
 @import 'components/page-header';

--- a/app/assets/stylesheets/components/_escape-link.scss
+++ b/app/assets/stylesheets/components/_escape-link.scss
@@ -1,0 +1,27 @@
+.app-c-escape-link {
+  background-color: govuk-colour('white');
+  border-top: 1px solid $govuk-border-colour;
+  bottom: 0;
+  position: fixed;
+  position: sticky; // scss-lint:disable DuplicateProperty
+  text-align: center;
+  width: 100%;
+
+  .govuk-link {
+    @include govuk-font($size: 19, $weight: bold);
+    color: $govuk-error-colour;
+    display: block;
+    padding: govuk-spacing(6) 0;
+
+    &:link,
+    &:visited,
+    &:hover,
+    &:active {
+      color: darken($govuk-error-colour, 5%);
+    }
+
+    &:focus {
+      color: $govuk-focus-text-colour;
+    }
+  }
+}

--- a/app/views/application/_question_radio_buttons.html.erb
+++ b/app/views/application/_question_radio_buttons.html.erb
@@ -30,3 +30,12 @@
   } %>
   <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>
+
+<% unless current_page?(urgent_medical_help_path) %>
+  <% content_for :escape_link do %>
+    <%= render "components/escape-link", {
+      text: t("leave_this_website.link_text"),
+      href: t("leave_this_website.link_href"),
+    } %>
+  <% end %>
+<% end %>

--- a/app/views/components/_escape-link.html.erb
+++ b/app/views/components/_escape-link.html.erb
@@ -1,0 +1,7 @@
+<%
+  data_attributes ||= {}
+  data_attributes[:module] = 'app-escape-link'
+%>
+<div class="app-c-escape-link">
+  <%= link_to text, href, class: "govuk-link", rel: "nofollow", data: data_attributes %>
+</div>

--- a/app/views/components/docs/escape-link.yml
+++ b/app/views/components/docs/escape-link.yml
@@ -1,0 +1,11 @@
+name: Escape link
+description: Gives users a quick exit from a website.
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      text: Leave this site
+      href: 'https://www.gov.uk/'
+      data_attributes:
+        tracking: GT-1234

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -26,3 +26,10 @@
 } do %>
   <%= link_to t("coronavirus_form.results.feedback.link_text"), t("coronavirus_form.results.feedback.link_href"), class: "govuk-link" %>
 <% end %>
+
+<% content_for :escape_link do %>
+  <%= render "components/escape-link", {
+    text: t("leave_this_website.link_text"),
+    href: t("leave_this_website.link_href"),
+  } %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,6 +60,9 @@
         </div>
       </main>
     </div>
+    <% if yield(:escape_link).present? %>
+      <%= yield(:escape_link) %>
+    <% end %>
     <%= render "govuk_publishing_components/components/layout_footer", {
       meta: {
         items: [

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,9 @@ en:
       <p class="govuk-body">Your session has ended because you have not done anything for 4 hours. You'll have to start again.</p>
 
       <p class="govuk-body">We do this for your security. We've deleted all the details you entered to protect your data.</p>
+  leave_this_website:
+    link_text: "Leave this site"
+    link_href: "https://www.bbc.co.uk/"
   get_help_from_nhs:
     title: Get urgent help from the NHS now
     link_text: Go to NHS 111 online


### PR DESCRIPTION
Add escape link component (🎬Take 2 AFS)

Essentially #34 revived but without the JavaScript functionality and only applied to certain question pages (all except for one) as per prototype.

[Trello card](https://trello.com/c/c7UahJby)