### PR TITLE
Display session expired page on /results to users without session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,4 +66,8 @@ private
       redirect_to controller: "need_help_with", action: "show"
     end
   end
+
+  def check_session_exists
+    session_expired unless last_question_seen?
+  end
 end

--- a/app/controllers/coronavirus_form/results_controller.rb
+++ b/app/controllers/coronavirus_form/results_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::ResultsController < ApplicationController
-  before_action :check_filter_question_answered
+  before_action :check_session_exists
 end

--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -44,4 +44,8 @@ module QuestionsHelper
   def first_question_seen?
     session[:urgent_medical_help].present?
   end
+
+  def last_question_seen?
+    session[FINAL_QUESTION.to_sym].present?
+  end
 end

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe "results" do
+  describe "GET /results" do
+    it "redirects to the session expired path if a user hasn't seen the last question" do
+      get results_path
+      expect(response).to redirect_to(controller: "session_expired", action: "show")
+    end
+  end
+end


### PR DESCRIPTION
This will stop users who try to navigate directly to /results from seeing confusing data.

Trello - https://trello.com/c/aQJy0zpB/190-handle-the-results-page-when-the-user-doesnt-have-a-session