### PR TITLE
Do not store the session ID or CSRF token for user responses

### DIFF
--- a/app/controllers/coronavirus_form/able_to_leave_controller.rb
+++ b/app/controllers/coronavirus_form/able_to_leave_controller.rb
@@ -34,7 +34,12 @@ private
   end
 
   def write_responses
-    FormResponse.create(form_response: session, created_at: time_hour_floor)
+    redacted_session = session.to_hash.without("session_id", "_csrf_token")
+
+    FormResponse.create(
+      form_response: redacted_session,
+      created_at: time_hour_floor,
+    )
   end
 
   def update_session_store

--- a/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
@@ -19,5 +19,14 @@ RSpec.describe CoronavirusForm::AbleToLeaveController, type: :controller do
       )
       expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
     end
+
+    it "does not save the session id or csrf token to the database" do
+      session[:questions_to_ask] = %w(foo)
+
+      post :submit, params: { able_to_leave: "Yes" }
+
+      expect(FormResponse.first.form_response["session_id"]).to be_nil
+      expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
+    end
   end
 end

--- a/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe CoronavirusForm::AbleToLeaveController, type: :controller do
       post :submit, params: { able_to_leave: "Yes" }
 
       expect(FormResponse.first.form_response).to eq(
-        [["questions_to_ask", %w(foo)], %w(able_to_leave Yes)],
+        "questions_to_ask" => %w(foo),
+        "able_to_leave" => "Yes",
       )
       expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
     end


### PR DESCRIPTION
We are currently storing the entire session store when user finishes the form.  This removes the session ID and CSRF token so the stored data is fully non-personal.

Trello card: https://trello.com/c/H3D7Bbdx