### PR TITLE
Remove links to services

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -356,8 +356,6 @@ en:
             href: "https://womensaid.scot/"
           - text: "Get information for children from Childline"
             href: "https://www.childline.org.uk/"
-          - text: "Get information if you are in care or leaving care from Coram Voice"
-            href: "https://coramvoice.org.uk/"
           - text: "Get information if you are child in Wales"
             href: "https://www.childcomwales.org.uk/coronavirus/"
           - text: "Contact NSPCC if you are concerned about a child"
@@ -571,8 +569,6 @@ en:
             href: "https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/"
           - text: "Get information about coronavirus and your mental wellbeing from the Scottish Association for Mental Health"
             href: "https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing"
-          - text: "Find your local loneliness service"
-            href: "https://www.redcross.org.uk/get-help/get-help-with-loneliness/find-your-local-loneliness-service"
           - text: 'If you need urgent help now, call the Samaritans on <a href="tel:116 123" class="govuk-link">116 123</a>'
           - text: "If you need urgent help text ‘Shout’ to 85258"
           - text: 'If you need urgent help and you’re in Northern Ireland call Lifeline on <a href="tel:+448088088000" class="govuk-link">0808 808 8000</a>'


### PR DESCRIPTION
A couple of services haven't yet confirmed that they have the capacity to receive calls. Can be reverted once they confirm.