### PR TITLE
Add text for when user has no results

### DIFF
--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -14,11 +14,15 @@
   <%= link_to t("coronavirus_form.results.header.start_again_text"), clear_session_path, class: "govuk-link" %>
 <% end %>
 
-<% result_groups(session).each do |group| %>
-  <%= render "components/actions-group", {
-    title: group[1][:heading],
-    subsections: group[1][:questions]
-  } %>
+<% if result_groups(session).empty? %>
+  <%= sanitize(t("coronavirus_form.results.no_results")) %>
+<% else %>
+  <% result_groups(session).each do |group| %>
+    <%= render "components/actions-group", {
+      title: group[1][:heading],
+      subsections: group[1][:questions]
+    } %>
+  <% end %>
 <% end %>
 
 <%= render "components/callout", {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,6 +332,12 @@ en:
         text: Help us improve
         link_text: Give feedback on this service
         link_href: "https://www.gov.uk/done/find-coronavirus-support"
+      no_results: |
+        <p class="govuk-body">Based on your answers, there’s no specific information for you in this service at the moment. It will be updated regularly.</p>
+
+        <p class="govuk-body"><a href="https://www.gov.uk/coronavirus" class="govuk-link">Find all information on coronavirus, including how to protect yourself and get financial support</a></p>
+
+        <p class="govuk-body"><a href="https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/" class="govuk-link">Find information about what you can do from Citizens Advice</a></p>
   results_link:
     feeling_unsafe:
       feel_safe:


### PR DESCRIPTION
A user may follow a "happy path" which leads to no results.  This adds text notifying them of this, rather than showing an empty results page.

![Screenshot 2020-04-10 at 13 14 14](https://user-images.githubusercontent.com/6329861/78990021-33248e80-7b2d-11ea-8415-a921e8dfc775.png)

Trello card: https://trello.com/c/94ctImaf