### PR TITLE
Add comma to show options

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,7 +343,7 @@ en:
       feel_safe:
         title: "If you do not feel safe where you live or you’re worried about someone else:"
         show_options:
-          - "Yes but I’m concerned about the safety of someone else"
+          - "Yes, but I’m concerned about the safety of someone else"
           - "No"
           - "Not sure"
         items:


### PR DESCRIPTION
https://github.com/alphagov/govuk-coronavirus-find-support/pull/82 added a comma to the options but it would stop it showing the results if chosen. This fixes that