### PR TITLE
Expire a user's session if they visit an invalid question

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,6 +67,10 @@ private
     end
   end
 
+  def check_current_question_selected
+    session_expired unless questions_to_ask.include?(controller_name)
+  end
+
   def check_session_exists
     session_expired unless last_question_seen?
   end

--- a/app/controllers/coronavirus_form/afford_food_controller.rb
+++ b/app/controllers/coronavirus_form/afford_food_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::AffordFoodController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/afford_rent_mortgage_bills_controller.rb
+++ b/app/controllers/coronavirus_form/afford_rent_mortgage_bills_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::AffordRentMortgageBillsController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/are_you_off_work_ill_controller.rb
+++ b/app/controllers/coronavirus_form/are_you_off_work_ill_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::AreYouOffWorkIllController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/feel_safe_controller.rb
+++ b/app/controllers/coronavirus_form/feel_safe_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::FeelSafeController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/get_food_controller.rb
+++ b/app/controllers/coronavirus_form/get_food_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::GetFoodController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/have_somewhere_to_live_controller.rb
+++ b/app/controllers/coronavirus_form/have_somewhere_to_live_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::HaveSomewhereToLiveController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/have_you_been_evicted_controller.rb
+++ b/app/controllers/coronavirus_form/have_you_been_evicted_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::HaveYouBeenEvictedController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
+++ b/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::HaveYouBeenMadeUnemployedController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/living_with_vulnerable_controller.rb
+++ b/app/controllers/coronavirus_form/living_with_vulnerable_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::LivingWithVulnerableController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/mental_health_worries_controller.rb
+++ b/app/controllers/coronavirus_form/mental_health_worries_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::MentalHealthWorriesController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/self_employed_controller.rb
+++ b/app/controllers/coronavirus_form/self_employed_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::SelfEmployedController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/still_working_controller.rb
+++ b/app/controllers/coronavirus_form/still_working_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::StillWorkingController < ApplicationController
   before_action :check_filter_question_answered
+  before_action :check_current_question_selected
 
   def submit
     @form_responses = {

--- a/spec/requests/afford_food_spec.rb
+++ b/spec/requests/afford_food_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "afford-food" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get afford_food_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /afford-food" do

--- a/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
+++ b/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "afford-rent-mortgage-bills" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get afford_rent_mortgage_bills_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /afford-rent-mortgage-bills" do

--- a/spec/requests/are_you_off_work_ill_spec.rb
+++ b/spec/requests/are_you_off_work_ill_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "still-working" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get are_you_off_work_ill_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /still-working" do

--- a/spec/requests/feel_safe_spec.rb
+++ b/spec/requests/feel_safe_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "feel-safe" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get feel_safe_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /feel-safe" do

--- a/spec/requests/get_food_spec.rb
+++ b/spec/requests/get_food_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "get-food" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get get_food_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /get-food" do

--- a/spec/requests/have_somewhere_to_live_spec.rb
+++ b/spec/requests/have_somewhere_to_live_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "have-somewhere-to-live" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get have_somewhere_to_live_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /have-somewhere-to-live" do

--- a/spec/requests/have_you_been_evicted_spec.rb
+++ b/spec/requests/have_you_been_evicted_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "have-you-been-evicted" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get have_you_been_evicted_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /have-you-been-evicted" do

--- a/spec/requests/have_you_been_made_unemployed_spec.rb
+++ b/spec/requests/have_you_been_made_unemployed_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "have-you-been-made-unemployed" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get have_you_been_made_unemployed_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /still-working" do

--- a/spec/requests/living_with_vulnerable_spec.rb
+++ b/spec/requests/living_with_vulnerable_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "living-with-vulnerable" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get living_with_vulnerable_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /living-with-vulnerable" do

--- a/spec/requests/mental_health_worries_spec.rb
+++ b/spec/requests/mental_health_worries_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "mental-health-worries" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get mental_health_worries_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /mental-health-worries" do

--- a/spec/requests/self_employed_spec.rb
+++ b/spec/requests/self_employed_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "self-employed" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get self_employed_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /self-employed" do

--- a/spec/requests/still_working_spec.rb
+++ b/spec/requests/still_working_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe "still-working" do
         expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
       end
     end
+
+    context "without this question in the sesion data" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(foo))
+      end
+
+      it "redirects to session expired" do
+        get still_working_path
+
+        expect(response).to redirect_to session_expired_path
+      end
+    end
   end
 
   describe "POST /still-working" do


### PR DESCRIPTION
For questions after the "what do you need help with" question, users will get an ```undefined method `+' for nil:NilClass``` error if they visit a question which is not one they should be seeing (based on their answers to the "what do you need help with question").

This expires their session (and redirects to the appropriate information page) in the event that they visit an invalid question (e.g. if they use a bookmark from a previous journey).

Resolves https://sentry.io/organizations/govuk/issues/1606250671/