### PR TITLE
Update escape link

### DIFF
--- a/app/assets/stylesheets/components/_escape-link.scss
+++ b/app/assets/stylesheets/components/_escape-link.scss
@@ -1,26 +1,28 @@
 .app-c-escape-link {
-  background-color: govuk-colour('white');
-  border-top: 1px solid $govuk-border-colour;
+  @include govuk-width-container;
+
   bottom: 0;
   position: fixed;
   position: sticky; // scss-lint:disable DuplicateProperty
-  text-align: center;
-  width: 100%;
+  right: 0;
+  text-align: right;
 
   .govuk-link {
     @include govuk-font($size: 19, $weight: bold);
-    color: $govuk-error-colour;
-    display: block;
-    padding: govuk-spacing(6) 0;
+
+    display: inline-block;
+    padding: govuk-spacing(4) govuk-spacing(3);
 
     &:link,
     &:visited,
     &:hover,
     &:active {
-      color: darken($govuk-error-colour, 5%);
+      background-color: govuk-colour('black');
+      color: govuk-colour('white');
     }
 
     &:focus {
+      background-color: $govuk-focus-colour;
       color: $govuk-focus-text-colour;
     }
   }


### PR DESCRIPTION
Update the style, reduce the size and reposition it on the right-hand size, aligned with the main container.

### Escape link component

Default
<img width="960" alt="Screenshot 2020-04-10 at 14 59 14" src="https://user-images.githubusercontent.com/788096/78996160-eb593380-7b3b-11ea-9514-2c9e51c309ce.png">

Focus
<img width="960" alt="Screenshot 2020-04-10 at 14 59 22" src="https://user-images.githubusercontent.com/788096/78996167-edbb8d80-7b3b-11ea-9563-fbb90e10c7db.png">

### Example of usage on 'Dow you feel safe where you live' page

<table>
<tr><th>Mobile</th><th>Desktop</th></tr>
<tr><td valign="top">

![localhost_5000_feel-safe](https://user-images.githubusercontent.com/788096/78996011-9a493f80-7b3b-11ea-9a75-2d874df33259.png)


</td><td valign="top">

![localhost_5000_feel-safe (1)](https://user-images.githubusercontent.com/788096/78996017-9d443000-7b3b-11ea-82f0-5c1f24f78b69.png)


</td></tr>
</table>
