### PR TITLE
Prevent escape link from obstructing elements

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,3 +31,7 @@ $app-covid-grey: #272828;
 @import 'components/callout';
 @import 'components/page-header';
 @import 'components/actions-group';
+
+.govuk-footer {
+  clear: both;
+}

--- a/app/assets/stylesheets/components/_escape-link.scss
+++ b/app/assets/stylesheets/components/_escape-link.scss
@@ -1,29 +1,23 @@
 .app-c-escape-link {
-  @include govuk-width-container;
+  @include govuk-font($size: 19, $weight: bold);
 
   bottom: 0;
+  float: right;
+  padding: govuk-spacing(4) govuk-spacing(3);
   position: fixed;
   position: sticky; // scss-lint:disable DuplicateProperty
   right: 0;
-  text-align: right;
 
-  .govuk-link {
-    @include govuk-font($size: 19, $weight: bold);
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
+    background-color: govuk-colour('black');
+    color: govuk-colour('white');
+  }
 
-    display: inline-block;
-    padding: govuk-spacing(4) govuk-spacing(3);
-
-    &:link,
-    &:visited,
-    &:hover,
-    &:active {
-      background-color: govuk-colour('black');
-      color: govuk-colour('white');
-    }
-
-    &:focus {
-      background-color: $govuk-focus-colour;
-      color: $govuk-focus-text-colour;
-    }
+  &:focus {
+    background-color: $govuk-focus-colour;
+    color: $govuk-focus-text-colour;
   }
 }

--- a/app/views/components/_escape-link.html.erb
+++ b/app/views/components/_escape-link.html.erb
@@ -2,6 +2,4 @@
   data_attributes ||= {}
   data_attributes[:module] = 'app-escape-link'
 %>
-<div class="app-c-escape-link">
-  <%= link_to text, href, class: "govuk-link", rel: "nofollow", data: data_attributes %>
-</div>
+<%= link_to text, href, class: "app-c-escape-link govuk-link", rel: "nofollow", data: data_attributes %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,10 +59,10 @@
           </div>
         </div>
       </main>
+      <% if yield(:escape_link).present? %>
+        <%= yield(:escape_link) %>
+      <% end %>
     </div>
-    <% if yield(:escape_link).present? %>
-      <%= yield(:escape_link) %>
-    <% end %>
     <%= render "govuk_publishing_components/components/layout_footer", {
       meta: {
         items: [


### PR DESCRIPTION
Fixes an issue where the escape link can obstruct interactive elements on the page. This is a major usability flaw and can cause a lot of frustration.

- simplifies component markup
- places the component in the main container
- floats component to avoid obstructions
- use a clear on the footer container (a clearfix on the component won't work, unfortunately)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="375" alt="Screenshot 2020-04-10 at 16 24 26" src="https://user-images.githubusercontent.com/788096/79002359-3416e980-7b48-11ea-8ef0-92e61923fcb6.png">


</td><td valign="top">

<img width="374" alt="Screenshot 2020-04-10 at 16 26 42" src="https://user-images.githubusercontent.com/788096/79002364-36794380-7b48-11ea-80c0-c0bb30ac7b1b.png">


</td></tr>
</table>
