### PR TITLE
Add rake task for extracting statistics

### DIFF
--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -1,0 +1,44 @@
+namespace :statistics do
+  desc "Get information on all form responses for a specified day, e.g. rake statistics:form_responses[2020-04-13]"
+  task :form_responses, [:date] => [:environment] do |_, args|
+    # Counts responses for each question (as defined in locales) on a given day
+    # and produces output in the following format (fictional data used as an
+    # example):
+    #
+    # What do you need to find help with because of coronavirus?
+    # - ["Feeling unsafe"]: 1
+    # - ["Feeling unsafe", "Paying bills"]: 3
+    # - ["Getting food"]: 2
+    # - ["Going in to work"]: 1
+    # - ["Having somewhere to live"]: 1
+    # - ["Paying bills"]: 3
+    # - ["Paying bills", "I’m not sure"]: 1
+    # - ["Paying bills", "Mental health and wellbeing"]: 1
+    #
+    # Do you need urgent medical help?
+    #  - No: 13
+    #
+    # Do you feel safe where you live?
+    #  - No: 2
+    #  - Yes: 1
+    #  - Yes, but I’m concerned about the safety of someone else: 1
+
+    args.with_defaults(date: Date.yesterday.to_s)
+
+    responses = FormResponse.where(created_at: Date.parse(args.date).all_day)
+
+    questions = I18n.t("coronavirus_form.groups").map { |_, v| v[:questions] }.reduce(:merge)
+
+    questions.each_key do |question|
+      question_text = questions.dig(question, :title)
+      response_count = responses.
+        group("form_response -> '#{question}'").
+        count.
+        reject { |k, _| k.nil? }.
+        sort.
+        map { |k, v| " - #{k}: #{v}" }.
+        join("\n")
+      puts "#{question_text}\n#{response_count}\n\n"
+    end
+  end
+end


### PR DESCRIPTION
Today we were asked by the SMT for statistics on how many selections of each option were made for each question.  This involved writing either database queries, or using the Rails console.

Here I have added a basic rake task to output these statistics for a specified day.

Rake task is invoked using (for yesterday's data):
`rake statistics:form_responses`

For a specified day's data:
`rake statistics:form_responses["2020-04-13"]`

The format of the data output is (this information is mocked example data, and not representative of real form submissions):
```
What do you need to find help with because of coronavirus?
 - ["Feeling unsafe"]: 1
 - ["Feeling unsafe", "Paying bills"]: 3
 - ["Getting food"]: 2
 - ["Going in to work"]: 1
 - ["Having somewhere to live"]: 1
 - ["Paying bills"]: 3
 - ["Paying bills", "I’m not sure"]: 1
 - ["Paying bills", "Mental health and wellbeing"]: 1

Do you need urgent medical help?
 - No: 13

Do you feel safe where you live?
 - No: 2
 - Yes: 1
 - Yes, but I’m concerned about the safety of someone else: 1
```

Trello card: https://trello.com/c/ucfW2mvB