### PR TITLE
Switch the master build of all forms to use Concourse, not Travis

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -76,12 +76,12 @@ jobs:
     serial: true
     build_logs_to_retain: 100
     plan:
-      - get: git-tests-image-deps
+      - get: git-test-image-deps
         trigger: true
       - put: tests-image
         params:
           build: build-tests-image-deps
-          dockerfile: git-tests-image-deps/features/Dockerfile
+          dockerfile: git-test-image-deps/features/Dockerfile
 
   - name: run-quality-checks
     plan:

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -20,10 +20,10 @@ resources:
     source:
       uri:  https://github.com/alphagov/govuk-coronavirus-business-volunteer-form
       branch: master
-    paths:
-      - features/Dockerfile
-      - Gemfile
-      - Gemfile.lock
+      paths:
+        - features/Dockerfile
+        - Gemfile
+        - Gemfile.lock
 
   - name: govuk-coronavirus-find-support-feature-tests
     type: git

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -73,15 +73,15 @@ jobs:
         file: govuk-coronavirus-find-support/concourse/pipeline.yml
 
   - name: build-tests-image
-      serial: true
-      build_logs_to_retain: 100
-      plan:
-        - get: git-tests-image-deps
-          trigger: true
-        - put: tests-image
-          params:
-            build: build-tests-image-deps
-            dockerfile: git-tests-image-deps/features/Dockerfile
+    serial: true
+    build_logs_to_retain: 100
+    plan:
+      - get: git-tests-image-deps
+        trigger: true
+      - put: tests-image
+        params:
+          build: build-tests-image-deps
+          dockerfile: git-tests-image-deps/features/Dockerfile
 
   - name: run-quality-checks
     plan:

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -14,6 +14,17 @@ resources:
       uri: https://github.com/alphagov/govuk-coronavirus-find-support
       branch: master
 
+  - name: git-test-image-deps
+    icon: github-circle
+    type: git
+    source:
+    uri:  https://github.com/alphagov/govuk-coronavirus-business-volunteer-form
+    branch: master
+    paths:
+      - features/Dockerfile
+      - Gemfile
+      - Gemfile.lock
+
   - name: govuk-coronavirus-find-support-feature-tests
     type: git
     icon: github-circle
@@ -46,6 +57,13 @@ resources:
       repository: ((readonly_private_ecr_repo_url))
       tag: govuk-coronavirus-find-support-feature-tests
 
+  - name: tests-image
+    type: docker-image
+    icon: docker
+    source:
+      repository: ((readonly_private_ecr_repo_url))
+      tag: govuk-coronavirus-find-support-tests
+
 jobs:
   - name: update-pipeline
     plan:
@@ -53,6 +71,45 @@ jobs:
         trigger: true
       - set_pipeline: govuk-corona-find-support-form
         file: govuk-coronavirus-find-support/concourse/pipeline.yml
+
+  - name: build-tests-image
+      serial: true
+      build_logs_to_retain: 100
+      plan:
+        - get: git-tests-image-deps
+          trigger: true
+        - put: tests-image
+          params:
+            build: build-tests-image-deps
+            dockerfile: git-tests-image-deps/features/Dockerfile
+
+  - name: run-quality-checks
+    plan:
+      - in_parallel:
+        - get: tests-image
+          passed:
+            - build-tests-image
+        - get: govuk-coronavirus-find-support
+          trigger: true
+        - task: run-tests-task
+          image: tests-image
+          config:
+            inputs:
+              - name: govuk-coronavirus-find-support
+            outputs:
+              - name: committer-details
+            platform: linux
+            run:
+              dir: govuk-coronavirus-find-support
+              path: bash
+              args:
+                - -c
+                - |
+                  set -ue
+                  cat .git/committer > ../committer-details/last-committer
+                  # Start the Postgres DB
+                  /etc/init.d/postgresql start
+                  bundle exec rake
 
   - name: build-feature-tests-image
     serial: true
@@ -135,4 +192,3 @@ jobs:
           # TODO: this should point at the production URL
           URL: 'https://govuk-coronavirus-find-support-prod.cloudapps.digital/urgent-medical-help'
           MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes. If this fails, you should investigate immediately."
-

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -18,7 +18,7 @@ resources:
     icon: github-circle
     type: git
     source:
-      uri:  https://github.com/alphagov/govuk-coronavirus-business-volunteer-form
+      uri:  https://github.com/alphagov/govuk-coronavirus-find-support
       branch: master
       paths:
         - features/Dockerfile
@@ -80,7 +80,7 @@ jobs:
         trigger: true
       - put: tests-image
         params:
-          build: build-tests-image-deps
+          build: git-test-image-deps
           dockerfile: git-test-image-deps/features/Dockerfile
 
   - name: run-quality-checks

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -18,8 +18,8 @@ resources:
     icon: github-circle
     type: git
     source:
-    uri:  https://github.com/alphagov/govuk-coronavirus-business-volunteer-form
-    branch: master
+      uri:  https://github.com/alphagov/govuk-coronavirus-business-volunteer-form
+      branch: master
     paths:
       - features/Dockerfile
       - Gemfile


### PR DESCRIPTION
- Using Travis meant that we needed to maintain a separate Concourse resource and it's often slow towards the end of the day as that's when the US wakes up and starts using it for all their builds. This leads to queues of builds, and slower deployments for us.

- We can cut out Travis by using Concourse for running tests within the pipeline.

- This commit does not remove Travis, but adds the jobs and resources that we will need. If this is successful then we will remove Travis in a future commit.

Co-authored-by: Huw Diprose <huw.diprose@digital.cabinet-office.gov.uk>