### PR TITLE
Don't show users previous answers from session

### DIFF
--- a/app/controllers/coronavirus_form/need_help_with_controller.rb
+++ b/app/controllers/coronavirus_form/need_help_with_controller.rb
@@ -34,7 +34,7 @@ private
         value: title,
         label: title,
         id: "option_#{key}",
-        checked: @form_responses.fetch(controller_name.to_sym, []).include?(title),
+        checked: false,
       }
     end
 
@@ -43,7 +43,7 @@ private
         value: option,
         label: option,
         id: "option_#{option.parameterize.underscore}",
-        checked: @form_responses.fetch(controller_name.to_sym, []).include?(option),
+        checked: false,
       }
     end
 

--- a/app/views/application/_question_radio_buttons.html.erb
+++ b/app/views/application/_question_radio_buttons.html.erb
@@ -24,7 +24,7 @@
           value: option,
           text: option,
           id: "option_#{option.parameterize.underscore}",
-          checked: @form_responses[question.to_sym] == option,
+          checked: false,
         }
       end
   } %>

--- a/spec/requests/able_to_leave_spec.rb
+++ b/spec/requests/able_to_leave_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "able-to-leave" do
         page.set_rack_session(able_to_leave: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit able_to_leave_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
   end

--- a/spec/requests/afford_food_spec.rb
+++ b/spec/requests/afford_food_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "afford-food" do
         page.set_rack_session(afford_food: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit afford_food_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
+++ b/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "afford-rent-mortgage-bills" do
         page.set_rack_session(afford_rent_mortgage_bills: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit afford_rent_mortgage_bills_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/are_you_off_work_ill_spec.rb
+++ b/spec/requests/are_you_off_work_ill_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "still-working" do
         page.set_rack_session(are_you_off_work_ill: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit are_you_off_work_ill_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/feel_safe_spec.rb
+++ b/spec/requests/feel_safe_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "feel-safe" do
         page.set_rack_session(feel_safe: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit feel_safe_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/get_food_spec.rb
+++ b/spec/requests/get_food_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "get-food" do
         page.set_rack_session(get_food: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit get_food_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.get_food.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/have_somewhere_to_live_spec.rb
+++ b/spec/requests/have_somewhere_to_live_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "have-somewhere-to-live" do
         page.set_rack_session(have_somewhere_to_live: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit have_somewhere_to_live_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/have_you_been_evicted_spec.rb
+++ b/spec/requests/have_you_been_evicted_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "have-you-been-evicted" do
         page.set_rack_session(have_you_been_evicted: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit have_you_been_evicted_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/have_you_been_made_unemployed_spec.rb
+++ b/spec/requests/have_you_been_made_unemployed_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "have-you-been-made-unemployed" do
         page.set_rack_session(have_you_been_made_unemployed: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit have_you_been_made_unemployed_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/living_with_vulnerable_spec.rb
+++ b/spec/requests/living_with_vulnerable_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "living-with-vulnerable" do
         page.set_rack_session(living_with_vulnerable: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit living_with_vulnerable_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/mental_health_worries_spec.rb
+++ b/spec/requests/mental_health_worries_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "mental-health-worries" do
         page.set_rack_session(mental_health_worries: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit mental_health_worries_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/need_help_with_spec.rb
+++ b/spec/requests/need_help_with_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe "need-help-with" do
         page.set_rack_session(need_help_with: selected)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit need_help_with_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.title"))
-        expect(page.find("input#option_#{selected.first.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected.first.parameterize.underscore}")).not_to be_checked
       end
     end
   end

--- a/spec/requests/self_employed_spec.rb
+++ b/spec/requests/self_employed_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "self-employed" do
         page.set_rack_session(self_employed: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit self_employed_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/still_working_spec.rb
+++ b/spec/requests/still_working_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe "still-working" do
         page.set_rack_session(still_working: selected_option)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit still_working_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.still_working.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
       end
     end
 

--- a/spec/requests/urgent_medical_help_spec.rb
+++ b/spec/requests/urgent_medical_help_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe "urgent-medical-help" do
         page.set_rack_session(urgent_medical_help: selected_no)
       end
 
-      it "shows the form with prefilled response" do
+      it "shows the form without prefilled response" do
         visit urgent_medical_help_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.title"))
-        expect(page.find("input#option_#{selected_no.parameterize.underscore}")).to be_checked
+        expect(page.find("input#option_#{selected_no.parameterize.underscore}")).not_to be_checked
       end
     end
   end


### PR DESCRIPTION
For the find coronavirus support service, we don't have a
check-your-answers page, so having people be able to go back to the
start of their journey and see their previous answers has limited value.

There is a risk that another user of the same computer could start a new
journey before a session expires, and see answers from a previous user's
session. In some situations this could be harmful.

This commit updates the views so they don't show people's answers, but
leaves all other session handling in place (so the results page still
works in exactly the same way).

Note that the back button in browsers is "clever" with this, so
previous form responses may still be present when clicking back, but
should not be present when hard refreshing the page or navigating
directly to the URL.

To reproduce the old "bad" behaviour:

* Go through the journey as far as https://find-coronavirus-support.service.gov.uk/need-help-with
* Click Continue
* Close the tab
* Open https://find-coronavirus-support.service.gov.uk/need-help-with in a new tab
* Observe that your selections are still there

Trello: https://trello.com/c/QU0jShIH/239-dont-show-users-previous-answers-from-their-session