### PR TITLE
Fix indentation and naming in the concourse pipeline

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -14,7 +14,7 @@ resources:
       uri: https://github.com/alphagov/govuk-coronavirus-find-support
       branch: master
 
-  - name: git-test-image-deps
+  - name: git-tests-image-deps
     icon: github-circle
     type: git
     source:
@@ -76,12 +76,12 @@ jobs:
     serial: true
     build_logs_to_retain: 100
     plan:
-      - get: git-test-image-deps
+      - get: git-tests-image-deps
         trigger: true
       - put: tests-image
         params:
-          build: git-test-image-deps
-          dockerfile: git-test-image-deps/features/Dockerfile
+          build: git-tests-image-deps
+          dockerfile: git-tests-image-deps/features/Dockerfile
 
   - name: run-quality-checks
     plan:
@@ -91,25 +91,24 @@ jobs:
             - build-tests-image
         - get: govuk-coronavirus-find-support
           trigger: true
-        - task: run-tests-task
-          image: tests-image
-          config:
-            inputs:
-              - name: govuk-coronavirus-find-support
-            outputs:
-              - name: committer-details
-            platform: linux
-            run:
-              dir: govuk-coronavirus-find-support
-              path: bash
-              args:
-                - -c
-                - |
-                  set -ue
-                  cat .git/committer > ../committer-details/last-committer
-                  # Start the Postgres DB
-                  /etc/init.d/postgresql start
-                  bundle exec rake
+      - task: run-tests-task
+        image: tests-image
+        config:
+          inputs:
+            - name: govuk-coronavirus-find-support
+          outputs:
+            - name: committer-details
+          platform: linux
+          run:
+            dir: govuk-coronavirus-find-support
+            path: bash
+            args:
+              - -c
+              - |
+                set -ue
+                cat .git/committer > ../committer-details/last-committer
+                postgres -p 5432 -D /usr/local/var/postgres >&1 &
+                bundle exec rake
 
   - name: build-feature-tests-image
     serial: true


### PR DESCRIPTION
An extension for this: https://github.com/alphagov/govuk-coronavirus-find-support/pulls?q=is%3Apr+is%3Aclosed+

That pipeline runs but the test task is failing.