### PR TITLE
ci: Optimise Actions runs by caching `bundle install`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,14 @@ jobs:
     - name: Install PostgreSQL 11 client
       run: |
         sudo apt-get -yqq install libpq-dev
+
+    - uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
     - name: Build App
       env:
         PGHOST: localhost
@@ -31,6 +39,7 @@ jobs:
         DB_USERNAME: postgres
       run: |
         gem install bundler
+        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rake db:create
         bundle exec rake db:migrate


### PR DESCRIPTION
- The "build app" portion of our builds take four minutes every time.
  This is a lot slower than Travis. So we can cache `bundle install` and
  see if that improves things.