### PR TITLE
Adds test image and "quality checks" to concourse

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -105,9 +105,12 @@ jobs:
             args:
               - -c
               - |
-                set -ue
-                cat .git/committer > ../committer-details/last-committer
-                postgres -p 5432 -D /usr/local/var/postgres >&1 &
+                set -eu
+                service postgresql start
+                su - postgres -c "psql -c \"create role root with createdb login password 'password';\""
+                export DATABASE_URL="postgres://root:password@localhost:5432/coronavirus_form_development"
+                bundle exec rails db:setup
+                bundle exec rails db:migrate
                 bundle exec rake
 
   - name: build-feature-tests-image

--- a/features/Dockerfile
+++ b/features/Dockerfile
@@ -1,27 +1,32 @@
 #========================================================================================
-# This Dockerfile creates a container image which contains ruby and google chrome,
-# as well as the application source and bundled dependencies.
+# This Dockerfile creates a container image which contains Ruby,
+# Google Chrome and Postgres, as well as the application source and bundled dependencies.
 #
-# This is needed for running the feature tests in a container environment like concourse.
+# This is needed for running the feature tests in a container environment like Concourse.
 #========================================================================================
 FROM ruby:2.6.5-buster
 
+# Updates all debian dependencies
+# Adds google chrome to software sources, install chrome, install postgres
+# clear up lists behind ourselves
 RUN apt-get update --fix-missing && apt-get -y upgrade \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-unstable --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
+      google-chrome-unstable \
+      postgresql-11 \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb
 
 ENV CHROME_NO_SANDBOX=true
 
-COPY Gemfile* .ruby-version /home/chrome/src/
+COPY Gemfile* .ruby-version /application/
 
-WORKDIR /home/chrome/src
+WORKDIR /application/
 
 RUN bundle install
 
-COPY . /home/chrome/src/
+COPY . /application/
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
## What
![image](https://user-images.githubusercontent.com/3694062/79376156-aa08bf80-7f51-11ea-89ff-d2ad0729a93b.png)

- Sets up a new test docker image, rebuilt  whenever we change the `.ruby_file`, `Gemfile` or `Gemfile.lock`
- uses that image to:
  - start the postgres service running as a daemon
  - create the appropriate roles
  - setup and migrate the database
  - run bundle exec rake

## Why
We want a way to run tests within concourse so we can do continuious delivery that ships conditional on passing tests.

Whilst we have that set up currently with Travis, there is a potential race condition where the deployed master and tested branch could diverge.

Adding tests to the pipeline helps prevent deploying code which does not meet quality checks.

## Next steps
Now we know this passes, we can knit this into the pipeline itself,
- removing travis as the trigger and replacing it with any update to the master branch
- running quality checks first in the pipeline and making all subsequent steps conditional on passes
