### PR TITLE
Clear session when using emergency exit button

### DIFF
--- a/app/controllers/coronavirus_form/session_controller.rb
+++ b/app/controllers/coronavirus_form/session_controller.rb
@@ -3,6 +3,10 @@
 class CoronavirusForm::SessionController < ApplicationController
   def delete
     reset_session
-    redirect_to "/"
+    if params[:ext_r] == "true"
+      redirect_to I18n.t("leave_this_website.link_redirect_to")
+    else
+      redirect_to "/"
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,7 +108,8 @@ en:
       <p class="govuk-body">We do this for your security. We've deleted all the details you entered to protect your data.</p>
   leave_this_website:
     link_text: "Leave this site"
-    link_href: "https://www.bbc.co.uk/"
+    link_href: "clear-session?ext_r=true"
+    link_redirect_to: "https://www.bbc.co.uk/"
   get_help_from_nhs:
     title: Get urgent help from the NHS now
     link_text: Go to NHS 111 online

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,7 +108,7 @@ en:
       <p class="govuk-body">We do this for your security. We've deleted all the details you entered to protect your data.</p>
   leave_this_website:
     link_text: "Leave this site"
-    link_href: "clear-session?ext_r=true"
+    link_href: "/clear-session?ext_r=true"
     link_redirect_to: "https://www.bbc.co.uk/"
   get_help_from_nhs:
     title: Get urgent help from the NHS now

--- a/spec/requests/clear_session_spec.rb
+++ b/spec/requests/clear_session_spec.rb
@@ -2,24 +2,47 @@ RSpec.describe "clear-session" do
   let(:selected_no) { I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.options").last }
 
   describe "GET /clear-session" do
-    context "with session data" do
+    context "without a redirect parameter" do
+      context "with session data" do
+        it "clears the session id" do
+          post urgent_medical_help_path, params: { urgent_medical_help: selected_no }
+          initial_session_id = session["session_id"]
+          get clear_session_path
+          expect(session["session_id"]).to_not eq(initial_session_id)
+        end
+
+        it "clears responses held in the session" do
+          post urgent_medical_help_path, params: { urgent_medical_help: selected_no }
+          expect(session[:urgent_medical_help]).to eq(selected_no)
+          get clear_session_path
+          expect(session[:have_you_been_made_unemployed]).to be_nil
+        end
+
+        it "redirects the user to root" do
+          get clear_session_path
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+
+    context "with an external redirect parameter" do
       it "clears the session id" do
         post urgent_medical_help_path, params: { urgent_medical_help: selected_no }
         initial_session_id = session["session_id"]
-        get clear_session_path
+        get clear_session_path, params: { ext_r: true }
         expect(session["session_id"]).to_not eq(initial_session_id)
       end
 
       it "clears responses held in the session" do
         post urgent_medical_help_path, params: { urgent_medical_help: selected_no }
         expect(session[:urgent_medical_help]).to eq(selected_no)
-        get clear_session_path
+        get clear_session_path, params: { ext_r: true }
         expect(session[:have_you_been_made_unemployed]).to be_nil
       end
 
       it "redirects the user to root" do
-        get clear_session_path
-        expect(response).to redirect_to("/")
+        get clear_session_path, params: { ext_r: true }
+        expect(response).to redirect_to(I18n.t("leave_this_website.link_redirect_to"))
       end
     end
   end

--- a/spec/requests/clear_session_spec.rb
+++ b/spec/requests/clear_session_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "clear-session" do
         expect(session[:have_you_been_made_unemployed]).to be_nil
       end
 
-      it "redirects the user to root" do
+      it "redirects the user to an external website" do
         get clear_session_path, params: { ext_r: true }
         expect(response).to redirect_to(I18n.t("leave_this_website.link_redirect_to"))
       end


### PR DESCRIPTION
Trello: https://trello.com/c/4JRtGN5p/240-clear-the-users-session-when-they-click-leave-this-site

**draft pending huw doing a manual test to be super sure**

## What
Instead of having the emergency button do directly to a target, route it through the clear session route, which can then redirect them onwards based on a param

## Why
There are fears that if a user clicks the emergency exit button, their session will remain. So if anyone revisists the site, their answers will still be present.

We've decided this presents a risk to some users and a click to the link should clear their session when they redirect.