### PR TITLE
Rename Concourse resource in filename

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -91,7 +91,7 @@ jobs:
         passed: [run-quality-checks]
       - task: deploy-to-paas
         config:
-        file: govuk-coronavirus-find-support/concourse/tasks/deploy-to-govuk-paas.yml
+        file: git-master/concourse/tasks/deploy-to-govuk-paas.yml
         params:
           CF_SPACE: staging
           INSTANCES: 5
@@ -113,7 +113,7 @@ jobs:
         passed:
           - build-tests-image
       - task: smoke-test
-        file: govuk-coronavirus-find-support/concourse/tasks/smoke-test.yml
+        file: git-master/concourse/tasks/smoke-test.yml
         params:
           URL: 'https://govuk-coronavirus-find-support-stg.cloudapps.digital/urgent-medical-help'
           MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
@@ -125,7 +125,7 @@ jobs:
         trigger: true
         passed: [smoke-test-staging]
       - task: deploy-to-paas
-        file: govuk-coronavirus-find-support/concourse/tasks/deploy-to-govuk-paas.yml
+        file: git-master/concourse/tasks/deploy-to-govuk-paas.yml
         params:
           CF_SPACE: production
           INSTANCES: 30
@@ -145,7 +145,7 @@ jobs:
         trigger: true
         passed: [deploy-to-prod]
       - task: smoke-test
-        file: govuk-coronavirus-find-support/concourse/tasks/smoke-test.yml
+        file: git-master/concourse/tasks/smoke-test.yml
         timeout: 5m
         params:
           # TODO: this should point at the production URL


### PR DESCRIPTION
The `govuk-coronavirus-find-support` resource was renamed to `git-master` in an earlier commit (82360cc2ccc997da6ac0a669bbfd23785375e097).  However the file path was not changed for tasks that reference this resource.