### PR TITLE
Rename db in development and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then set up your local database
 
 Then set up your Docker database
 
-    DATABASE_URL="postgres://user:password@localhost:5432/coronavirus_form_development" rails db:setup
+    DATABASE_URL="postgres://user:password@localhost:5432/coronavirus_find_support_form_development" rails db:setup
 
 You'll then need to specify the `DATABASE_URL` environment variable before the below tasks.
 

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -77,7 +77,7 @@ jobs:
                 set -eu
                 service postgresql start
                 su - postgres -c "psql -c \"create role root with createdb login password 'password';\""
-                export DATABASE_URL="postgres://root:password@localhost:5432/coronavirus_form_development"
+                export DATABASE_URL="postgres://root:password@localhost:5432/coronavirus_find_support_form_development"
                 bundle install
                 bundle exec rails db:setup
                 bundle exec rails db:migrate

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,12 +6,12 @@ default: &default
 
 development:
   <<: *default
-  database: coronavirus_form_development
+  database: coronavirus_find_support_form_development
   url: <%= ENV["DATABASE_URL"]%>
 
 test:
   <<: *default
-  database: coronavirus_form_test
+  database: coronavirus_find_support_form_test
   url: <%= ENV["TEST_DATABASE_URL"] %>
 
 production:


### PR DESCRIPTION
The vulnerable people, business volunteer and find support forms all use the same
database names in development and testing. This is fine in production where they're
all hosted on different RDS instances, but can produce some interesting results locally.