### PR TITLE
Skip deleted questions

### DIFF
--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -4,7 +4,7 @@ module QuestionsHelper
 
   def determine_user_questions(groups)
     if groups.empty?
-      I18n.t("coronavirus_form.groups").map { |_, group| group[:questions].keys if group[:title] }.compact.flatten
+      all_questions
     else
       questions_to_ask = groups.map do |group|
         I18n.t("coronavirus_form.groups.#{group}.questions").stringify_keys.keys
@@ -30,6 +30,10 @@ module QuestionsHelper
   end
 
   def questions_to_ask
+    session_questions & all_questions.map(&:to_s)
+  end
+
+  def session_questions
     session[:questions_to_ask]
   end
 
@@ -47,5 +51,9 @@ module QuestionsHelper
 
   def last_question_seen?
     session[FINAL_QUESTION.to_sym].present?
+  end
+
+  def all_questions
+    I18n.t("coronavirus_form.groups").map { |_, group| group[:questions].keys if group[:title] }.compact.flatten
   end
 end

--- a/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
@@ -9,19 +9,19 @@ RSpec.describe CoronavirusForm::AbleToLeaveController, type: :controller do
     end
 
     it "saves the form response to the database" do
-      session[:questions_to_ask] = %w(foo)
+      session[:questions_to_ask] = %w(get_food)
 
       post :submit, params: { able_to_leave: "Yes" }
 
       expect(FormResponse.first.form_response).to eq(
-        "questions_to_ask" => %w(foo),
+        "questions_to_ask" => %w(get_food),
         "able_to_leave" => "Yes",
       )
       expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
     end
 
     it "does not save the session id or csrf token to the database" do
-      session[:questions_to_ask] = %w(foo)
+      session[:questions_to_ask] = %w(get_food)
 
       post :submit, params: { able_to_leave: "Yes" }
 

--- a/spec/helpers/questions_helper_spec.rb
+++ b/spec/helpers/questions_helper_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe QuestionsHelper, type: :helper do
   before do
-    allow(helper).to receive(:questions_to_ask).and_return(%w(question_1 question_2))
+    allow(helper).to receive(:session_questions).and_return(%w(get_food afford_food))
   end
 
   describe "#determine_user_questions" do
@@ -21,29 +21,47 @@ RSpec.describe QuestionsHelper, type: :helper do
 
   describe "#next_question" do
     it "returns the next question key" do
-      expect(helper.next_question("question_1")).to eq("question_2")
+      expect(helper.next_question("get_food")).to eq("afford_food")
     end
 
     it "returns the final compulsory question for the final item" do
-      expect(helper.next_question("question_2")).to eq("able_to_leave")
+      expect(helper.next_question("afford_food")).to eq("able_to_leave")
     end
 
     it "returns the first question for the need help with question" do
-      expect(helper.next_question("need_help_with")).to eq("question_1")
+      expect(helper.next_question("need_help_with")).to eq("get_food")
     end
   end
 
   describe "#previous_question" do
     it "returns the previous question key" do
-      expect(helper.previous_question("question_2")).to eq("question_1")
+      expect(helper.previous_question("afford_food")).to eq("get_food")
     end
 
     it "returns the filter question page key for the first item" do
-      expect(helper.previous_question("question_1")).to eq("need_help_with")
+      expect(helper.previous_question("get_food")).to eq("need_help_with")
     end
 
     it "returns the last question for the able to leave question" do
-      expect(helper.previous_question("able_to_leave")).to eq("question_2")
+      expect(helper.previous_question("able_to_leave")).to eq("afford_food")
+    end
+  end
+
+  describe "#questions_to_ask" do
+    it "returns questions to ask the user" do
+      expect(helper.questions_to_ask).to eq(%w(get_food afford_food))
+    end
+
+    it "does not include a question that has been removed since the user made their selection" do
+      allow(helper).to receive(:all_questions).and_return(%w(get_food))
+
+      expect(helper.questions_to_ask).to eq(%w(get_food))
+    end
+
+    it "does not include a question that has been added since the user made their selection" do
+      allow(helper).to receive(:all_questions).and_return(%w(get_food afford_food question_3))
+
+      expect(helper.questions_to_ask).to eq(%w(get_food afford_food))
     end
   end
 end


### PR DESCRIPTION
We recently removed a question.  Since some users had already begun their journey through the form, their `questions_to_ask` session array contained the removed question's key and they were redirected to that path, even though it no longer exists.

This performs an intersection of questions the user should be asked, and the questions available in the app each time the next or previous question is being determined.  That will prevent redirection to non-existent routes.