### PR TITLE
Make the tests use internationalization text rather than hardcoding questions and answers

### DIFF
--- a/app/controllers/coronavirus_form/data_export_controller.rb
+++ b/app/controllers/coronavirus_form/data_export_controller.rb
@@ -43,7 +43,7 @@ class CoronavirusForm::DataExportController < ApplicationController
 private
 
   def produce_csv(results)
-    csv_data = CSV.generate do |csv|
+    csv_data = CSV.generate(col_sep: "|") do |csv|
       csv << %w(question answer date count)
       results.each do |question, value|
         value.each do |k|

--- a/app/controllers/coronavirus_form/urgent_medical_help_controller.rb
+++ b/app/controllers/coronavirus_form/urgent_medical_help_controller.rb
@@ -16,7 +16,7 @@ class CoronavirusForm::UrgentMedicalHelpController < ApplicationController
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
-    elsif @form_responses[:urgent_medical_help] == I18n.t("coronavirus_form.groups.#{group}.questions.#{controller_name}.options").first
+    elsif @form_responses[:urgent_medical_help] == I18n.t("coronavirus_form.groups.#{group}.questions.#{controller_name}.options.option_yes.label")
       update_session_store
       redirect_to get_help_from_nhs_path
     else

--- a/app/views/application/_question_radio_buttons.html.erb
+++ b/app/views/application/_question_radio_buttons.html.erb
@@ -19,11 +19,11 @@
     is_page_heading: true,
     name: question,
     error_message: error_items(question),
-    items: t("coronavirus_form.groups.#{group}.questions.#{question}.options").map do |option|
+    items: t("coronavirus_form.groups.#{group}.questions.#{question}.options").map do |option_key, item|
         {
-          value: option,
-          text: option,
-          id: "option_#{option.parameterize.underscore}",
+          value: item[:label],
+          text: item[:label],
+          id: option_key,
           checked: false,
         }
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,6 +178,7 @@ en:
               - text: This helps us count how many people visit the service by tracking if you’ve visited before
               - text: 3 years
   coronavirus_form:
+    submit_and_next: "Continue"
     errors:
       page_title_prefix: 'Error: '
       title: "There is a problem:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -199,8 +199,10 @@ en:
             title: "Do you need urgent medical help?"
             description: "You can check if you have coronavirus (COVID-19) symptoms and get medical advice"
             options:
-              - "Yes"
-              - "No"
+              option_yes:
+                label: "Yes"
+              option_no:
+                label: "No"
             custom_select_error: "Select yes if you need urgent medical help"
       feeling_unsafe:
         title: "Feeling unsafe"
@@ -208,10 +210,14 @@ en:
           feel_safe:
             title: "Do you feel safe where you live?"
             options:
-              - "Yes"
-              - "Yes, but I’m concerned about the safety of someone else"
-              - "No"
-              - "Not sure"
+              option_yes:
+                label: "Yes"
+              option_yes_someone_else:
+                label: "Yes, but I’m concerned about the safety of someone else"
+              option_no:
+                label: "No"
+              not_sure:
+                label: "Not sure"
             custom_select_error: "Select if you feel safe where you live or if you‘re worried about someone else"
       paying_bills:
         title: "Paying bills"
@@ -219,9 +225,12 @@ en:
           afford_rent_mortgage_bills:
             title: "Are you finding it hard to afford rent, your mortgage or bills?"
             options:
-              - "Yes"
-              - "No"
-              - "Not sure"
+              option_yes:
+                label: "Yes"
+              option_no:
+                label: "No"
+              not_sure:
+                label: "Not sure"
             custom_select_error: "Select yes if you’re finding it hard to afford your rent, your mortgage or bills"
       getting_food:
         title: "Getting food"
@@ -229,16 +238,22 @@ en:
           afford_food:
             title: "Are you finding it hard to afford food?"
             options:
-              - "Yes"
-              - "No"
-              - "Not sure"
+              option_yes:
+                label: "Yes"
+              option_no:
+                label: "No"
+              not_sure:
+                label: "Not sure"
             custom_select_error: "Select yes if you’re finding it hard to afford food"
           get_food:
             title: "Are you able to get food?"
             options:
-              - "Yes"
-              - "No"
-              - "Not sure"
+              option_yes:
+                label: "Yes"
+              option_no:
+                label: "No"
+              not_sure:
+                label: "Not sure"
             custom_select_error: "Select yes if you‘re able to get food"
       being_unemployed:
         title: "Being unemployed or not having any work"
@@ -247,25 +262,34 @@ en:
             title: "Have you been told to stop working?"
             title_caption: "Being unemployed or not having any work"
             options:
-              - "Yes, I’ve been made unemployed, or might be soon"
-              - "Yes, I’ve been put on temporary leave (on furlough), or might be soon"
-              - "No"
-              - "Not sure"
+              option_yes:
+                label: "Yes, I’ve been made unemployed, or might be soon"
+              option_might_be:
+                label: "Yes, I’ve been put on temporary leave (on furlough), or might be soon"
+              option_no:
+                label: "No"
+              not_sure:
+                label: "Not sure"
             custom_select_error: "Select if you’ve been made unemployed, or put on temporary leave (furloughed)"
           are_you_off_work_ill:
             title: "Are you off work because you’re ill or self-isolating?"
             title_caption: "Going in to work"
             options:
-              - "Yes"
-              - "No"
+              option_yes:
+                label: "Yes"
+              option_no:
+                label: "No"
             custom_select_error: "Select yes if you’re off work because you’re ill or self-isolating"
           self_employed:
             title: "Are you self-employed or a sole trader?"
             title_caption: "Being unemployed or not having any work"
             options:
-              - "Yes"
-              - "No"
-              - "Not sure"
+              option_yes:
+                label: "Yes"
+              option_no:
+                label: "No"
+              not_sure:
+                label: "Not sure"
             custom_select_error: "Select yes if you’re self-employed or a sole trader"
       going_in_to_work:
         title: "Going in to work"
@@ -273,9 +297,12 @@ en:
           living_with_vulnerable:
             title: "Are you worried about going in to work?"
             options:
-              - "Yes"
-              - "No"
-              - "Not sure"
+              option_yes:
+                label: "Yes"
+              option_no:
+                label: "No"
+              not_sure:
+                label: "Not sure"
             custom_select_error: "Select yes if you’re worried about going in to work"
       somewhere_to_live:
         title: "Having somewhere to live"
@@ -283,18 +310,26 @@ en:
           have_somewhere_to_live:
             title: "Do you have somewhere to live?"
             options:
-              - "Yes"
-              - "I do now but I might lose it"
-              - "No"
-              - "Not sure"
+              option_yes:
+                label: "Yes"
+              option_may_lose:
+                label: "I do now but I might lose it"
+              option_no:
+                label: "No"
+              not_sure:
+                label: "Not sure"
             custom_select_error: "Select if you have somewhere to live"
           have_you_been_evicted:
             title: "Have you been evicted?"
             options:
-              - "Yes"
-              - "I might be evicted soon"
-              - "No"
-              - "Not sure"
+              option_yes:
+                label: "Yes"
+              option_soon:
+                label: "I might be evicted soon"
+              option_no:
+                label: "No"
+              not_sure:
+                label: "Not sure"
             custom_select_error: "Select if you have been evicted or might be soon"
       mental_health:
         title: "Mental health and wellbeing"
@@ -302,20 +337,28 @@ en:
           mental_health_worries:
             title: "Are you worried about either your mental health or someone else’s mental health?"
             options:
-              - "Yes, I am"
-              - "No, I’m not"
-              - "Not sure"
+              option_yes:
+                label: "Yes, I am"
+              option_no:
+                label: "No, I’m not"
+              not_sure:
+                label: "Not sure"
             custom_select_error: "Select yes if you‘re worried about your mental health or someone else’s mental health"
       leave_home: # Q: Are you able to leave your home if absolutely neccessary?
         questions:
           able_to_leave:
             title: "Are you able to leave your home for food, medicine, or health reasons?"
             options:
-              - "Yes"
-              - "I should not leave home because I have coronavirus symptoms, or someone in my household does"
-              - "I should not leave home because I think I’m at high risk of severe illness from coronavirus"
-              - "I cannot go out because I have a disability"
-              - "I’m unable to leave my home for another reason"
+              option_yes:
+                label: "Yes"
+              option_has_symptoms:
+                label: "I should not leave home because I have coronavirus symptoms, or someone in my household does"
+              option_high_risk:
+                label: "I should not leave home because I think I’m at high risk of severe illness from coronavirus"
+              option_disability:
+                label: "I cannot go out because I have a disability"
+              option_other:
+                label: "I’m unable to leave my home for another reason"
             custom_select_error: "Select if you‘re able to leave your home or not"
     results:
       header:
@@ -486,7 +529,7 @@ en:
           - text: "Check if you’re eligible for the Discretionary Assistance Fund if you live in Wales"
             href: "https://gov.wales/discretionary-assistance-fund-daf"
           - text: "Find help with benefits if you live in Scotland"
-            href: "https://www.mygov.scot/benefits-support/" 
+            href: "https://www.mygov.scot/benefits-support/"
     going_in_to_work:
       living_with_vulnerable:
         title: "If you’re worried about going in to work"

--- a/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe CoronavirusForm::AbleToLeaveController, type: :controller do
     it "saves the form response to the database" do
       session[:questions_to_ask] = %w(get_food)
 
-      post :submit, params: { able_to_leave: "Yes" }
+      post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label") }
 
       expect(FormResponse.first.form_response).to eq(
         "questions_to_ask" => %w(get_food),
-        "able_to_leave" => "Yes",
+        "able_to_leave" => I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
       )
       expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
     end
@@ -23,7 +23,7 @@ RSpec.describe CoronavirusForm::AbleToLeaveController, type: :controller do
     it "does not save the session id or csrf token to the database" do
       session[:questions_to_ask] = %w(get_food)
 
-      post :submit, params: { able_to_leave: "Yes" }
+      post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label") }
 
       expect(FormResponse.first.form_response["session_id"]).to be_nil
       expect(FormResponse.first.form_response["_csrf_token"]).to be_nil

--- a/spec/controllers/coronavirus_form/data_export_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/data_export_controller_spec.rb
@@ -10,49 +10,73 @@ RSpec.describe CoronavirusForm::DataExportController, type: :controller do
     let(:end_date) { "2020-04-15" }
 
     before do
-      FormResponse.create(form_response: { able_to_leave: "Yes", get_food: "Yes" }, created_at: "2020-04-10 10:00:00")
-      FormResponse.create(form_response: { able_to_leave: "Yes", get_food: "No" }, created_at: "2020-04-10 10:00:00")
-      FormResponse.create(form_response: { able_to_leave: "Yes", get_food: "Yes" }, created_at: "2020-04-11 10:00:00")
-      FormResponse.create(form_response: { able_to_leave: "No", get_food: "No" }, created_at: "2020-04-11 10:00:00")
+      FormResponse.create(
+        form_response: {
+         able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
+         get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_yes.label"),
+        },
+        created_at: "2020-04-10 10:00:00",
+       )
+      FormResponse.create(
+        form_response: {
+          able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
+          get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label"),
+        },
+        created_at: "2020-04-10 10:00:00",
+      )
+      FormResponse.create(
+        form_response: {
+          able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
+          get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_yes.label"),
+        },
+        created_at: "2020-04-11 10:00:00",
+      )
+      FormResponse.create(
+        form_response: {
+          able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_other.label"),
+          get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label"),
+        },
+        created_at: "2020-04-11 10:00:00",
+      )
     end
 
     it "returns a hash containing aggregated form responses" do
       expected_response = {
         "Are you able to leave your home for food, medicine, or health reasons?" => [
           {
-            response: "Yes",
+            response: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
             date: "2020-04-10",
             count: 2,
           },
           {
-            response: "No",
+            response: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_other.label"),
             date: "2020-04-11",
             count: 1,
           },
           {
-            response: "Yes",
+            response: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
             date: "2020-04-11",
             count: 1,
           },
         ],
         "Are you able to get food?" => [
           {
-            response: "No",
+            response: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label"),
             date: "2020-04-10",
             count: 1,
           },
           {
-            response: "Yes",
+            response: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_yes.label"),
             date: "2020-04-10",
             count: 1,
           },
           {
-            response: "No",
+            response: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label"),
             date: "2020-04-11",
             count: 1,
           },
           {
-            response: "Yes",
+            response: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_yes.label"),
             date: "2020-04-11",
             count: 1,
           },

--- a/spec/helpers/result_helper_spec.rb
+++ b/spec/helpers/result_helper_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe ResultsHelper, type: :helper do
     it "should return a group data structure with a heading and filtered questions" do
       session.merge!({
         "selected_groups": %i[being_unemployed],
-        "have_you_been_made_unemployed": "Yes, I’ve been made unemployed, or might be soon",
-        "are_you_off_work_ill": "Yes",
-        "self_employed": "Yes",
+        "have_you_been_made_unemployed": I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_might_be.label"),
+        "are_you_off_work_ill": I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_yes.label"),
+        "self_employed": I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
       })
       expect(result_groups(session)).to eq(
         being_unemployed: {
@@ -44,10 +44,10 @@ RSpec.describe ResultsHelper, type: :helper do
     it "should filter out empty groups" do
       session.merge!({
         "selected_groups": %i[being_unemployed getting_food],
-        "have_you_been_made_unemployed": "Yes, I’ve been made unemployed, or might be soon",
-        "are_you_off_work_ill": "Yes",
-        "self_employed": "Yes",
-        "afford_food": "No",
+        "have_you_been_made_unemployed": I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_might_be.label"),
+        "are_you_off_work_ill": I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_yes.label"),
+        "self_employed": I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
+        "afford_food": I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options.option_no.label"),
       })
       expect(result_groups(session)).to eq(
         being_unemployed: {
@@ -66,9 +66,9 @@ RSpec.describe ResultsHelper, type: :helper do
     it "should return all group questions if all the session responses meet criteria" do
       session.merge!({
         "selected_groups": %i[being_unemployed],
-        "have_you_been_made_unemployed": "Yes, I’ve been made unemployed, or might be soon",
-        "are_you_off_work_ill": "Yes",
-        "self_employed": "Yes",
+        "have_you_been_made_unemployed": I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_might_be.label"),
+        "are_you_off_work_ill": I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_yes.label"),
+        "self_employed": I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
       })
       expect(filter_questions_by_session(:being_unemployed, session)).to eq([
         I18n.t("results_link.being_unemployed.have_you_been_made_unemployed"),
@@ -80,9 +80,9 @@ RSpec.describe ResultsHelper, type: :helper do
     it "should return filtered group questions if the session responses do not meet criteria" do
       session.merge!({
         "selected_groups": %i[being_unemployed],
-        "have_you_been_made_unemployed": "Yes, I’ve been made unemployed, or might be soon",
-        "are_you_off_work_ill": "No",
-        "self_employed": "Yes",
+        "have_you_been_made_unemployed": I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_might_be.label"),
+        "are_you_off_work_ill": I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_no.label"),
+        "self_employed": I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
       })
       expect(filter_questions_by_session(:being_unemployed, session)).to eq([
         I18n.t("results_link.being_unemployed.have_you_been_made_unemployed"),

--- a/spec/requests/able_to_leave_spec.rb
+++ b/spec/requests/able_to_leave_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "able-to-leave" do
+  let(:options) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(able_to_leave feel_safe))
   end
 
   describe "GET /able-to-leave" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,37 +25,35 @@ RSpec.describe "able-to-leave" do
         visit able_to_leave_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
-        I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(able_to_leave: selected_option)
+        page.set_rack_session(able_to_leave: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit able_to_leave_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
   end
 
   describe "POST /able-to-leave" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options").sample }
-
     it "updates the session store" do
-      post able_to_leave_path, params: { able_to_leave: selected_option }
+      post able_to_leave_path, params: { able_to_leave: selected_option_text }
 
-      expect(session[:able_to_leave]).to eq(selected_option)
+      expect(session[:able_to_leave]).to eq(selected_option_text)
     end
 
     it "redirects to the results page" do
-      post able_to_leave_path, params: { able_to_leave: selected_option }
+      post able_to_leave_path, params: { able_to_leave: selected_option_text }
 
       expect(response).to redirect_to(results_path)
     end

--- a/spec/requests/afford_food_spec.rb
+++ b/spec/requests/afford_food_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "afford-food" do
+  let(:options) { I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(afford_food feel_safe))
   end
 
   describe "GET /afford-food" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,22 +25,22 @@ RSpec.describe "afford-food" do
         visit afford_food_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
-        I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(afford_food: selected_option)
+        page.set_rack_session(afford_food: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit afford_food_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
 
@@ -56,16 +58,14 @@ RSpec.describe "afford-food" do
   end
 
   describe "POST /afford-food" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options").sample }
-
     it "updates the session store" do
-      post afford_food_path, params: { afford_food: selected_option }
+      post afford_food_path, params: { afford_food: selected_option_text }
 
-      expect(session[:afford_food]).to eq(selected_option)
+      expect(session[:afford_food]).to eq(selected_option_text)
     end
 
     it "redirects to the next question" do
-      post afford_food_path, params: { afford_food: selected_option }
+      post afford_food_path, params: { afford_food: selected_option_text }
 
       expect(response).to redirect_to(controller: "feel_safe", action: "show")
     end

--- a/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
+++ b/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "afford-rent-mortgage-bills" do
+  let(:options) { I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(afford_rent_mortgage_bills feel_safe))
   end
 
   describe "GET /afford-rent-mortgage-bills" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,22 +25,22 @@ RSpec.describe "afford-rent-mortgage-bills" do
         visit afford_rent_mortgage_bills_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.title"))
-        I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(afford_rent_mortgage_bills: selected_option)
+        page.set_rack_session(afford_rent_mortgage_bills: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit afford_rent_mortgage_bills_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
 
@@ -56,16 +58,14 @@ RSpec.describe "afford-rent-mortgage-bills" do
   end
 
   describe "POST /afford-rent-mortgage-bills" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options").sample }
-
     it "updates the session store" do
-      post afford_rent_mortgage_bills_path, params: { afford_rent_mortgage_bills: selected_option }
+      post afford_rent_mortgage_bills_path, params: { afford_rent_mortgage_bills: selected_option_text }
 
-      expect(session[:afford_rent_mortgage_bills]).to eq(selected_option)
+      expect(session[:afford_rent_mortgage_bills]).to eq(selected_option_text)
     end
 
     it "redirects to the next question" do
-      post afford_rent_mortgage_bills_path, params: { afford_rent_mortgage_bills: selected_option }
+      post afford_rent_mortgage_bills_path, params: { afford_rent_mortgage_bills: selected_option_text }
 
       expect(response).to redirect_to(controller: "feel_safe", action: "show")
     end

--- a/spec/requests/are_you_off_work_ill_spec.rb
+++ b/spec/requests/are_you_off_work_ill_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "still-working" do
+  let(:options) { I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(are_you_off_work_ill feel_safe))
   end
 
   describe "GET /still-working" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,22 +25,22 @@ RSpec.describe "still-working" do
         visit are_you_off_work_ill_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
-        I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(are_you_off_work_ill: selected_option)
+        page.set_rack_session(are_you_off_work_ill: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit are_you_off_work_ill_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
 
@@ -56,16 +58,14 @@ RSpec.describe "still-working" do
   end
 
   describe "POST /still-working" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options").sample }
-
     it "updates the session store" do
-      post are_you_off_work_ill_path, params: { are_you_off_work_ill: selected_option }
+      post are_you_off_work_ill_path, params: { are_you_off_work_ill: selected_option_text }
 
-      expect(session[:are_you_off_work_ill]).to eq(selected_option)
+      expect(session[:are_you_off_work_ill]).to eq(selected_option_text)
     end
 
     it "redirects to the next question" do
-      post are_you_off_work_ill_path, params: { are_you_off_work_ill: selected_option }
+      post are_you_off_work_ill_path, params: { are_you_off_work_ill: selected_option_text }
 
       expect(response).to redirect_to(controller: "feel_safe", action: "show")
     end

--- a/spec/requests/clear_session_spec.rb
+++ b/spec/requests/clear_session_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "clear-session" do
-  let(:selected_no) { I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.options").last }
+  let(:selected_no) { I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.options.option_no.label") }
 
   describe "GET /clear-session" do
     context "without a redirect parameter" do

--- a/spec/requests/data_export_spec.rb
+++ b/spec/requests/data_export_spec.rb
@@ -3,23 +3,68 @@ RSpec.describe "data-export" do
   let(:end_date) { "2020-04-15" }
 
   before do
-    FormResponse.create(form_response: { able_to_leave: "Yes", get_food: "Yes" }, created_at: "2020-04-10 10:00:00")
-    FormResponse.create(form_response: { able_to_leave: "Yes", get_food: "No" }, created_at: "2020-04-10 10:00:00")
-    FormResponse.create(form_response: { able_to_leave: "Yes", get_food: "Yes" }, created_at: "2020-04-11 10:00:00")
-    FormResponse.create(form_response: { able_to_leave: "No", get_food: "No" }, created_at: "2020-04-11 10:00:00")
+    FormResponse.create(
+      form_response: {
+       able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
+       get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_yes.label"),
+      },
+      created_at: "2020-04-10 10:00:00",
+     )
+    FormResponse.create(
+      form_response: {
+        able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
+        get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label"),
+      },
+      created_at: "2020-04-10 10:00:00",
+    )
+    FormResponse.create(
+      form_response: {
+        able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
+        get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_yes.label"),
+      },
+      created_at: "2020-04-11 10:00:00",
+    )
+    FormResponse.create(
+      form_response: {
+        able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_other.label"),
+        get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label"),
+      },
+      created_at: "2020-04-11 10:00:00",
+    )
   end
 
   describe "GET /able-to-leave" do
     let(:expected_lines) do
       [
-        %{question,answer,date,count},
-        %{"Are you able to leave your home for food, medicine, or health reasons?",Yes,2020-04-10,2},
-        %{"Are you able to leave your home for food, medicine, or health reasons?",Yes,2020-04-11,1},
-        %{"Are you able to leave your home for food, medicine, or health reasons?",No,2020-04-11,1},
-        %{Are you able to get food?,Yes,2020-04-10,1},
-        %{Are you able to get food?,No,2020-04-10,1},
-        %{Are you able to get food?,Yes,2020-04-11,1},
-        %{Are you able to get food?,No,2020-04-11,1},
+        "question|answer|date|count",
+        "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label')}|" \
+          "2020-04-10|" \
+          "2",
+        "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label')}|" \
+          "2020-04-11|" \
+          "1",
+        "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_other.label')}|" \
+          "2020-04-11|" \
+          "1",
+        "#{I18n.t('coronavirus_form.groups.getting_food.questions.get_food.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.getting_food.questions.get_food.options.option_yes.label')}|" \
+          "2020-04-10|" \
+          "1",
+        "#{I18n.t('coronavirus_form.groups.getting_food.questions.get_food.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label')}|" \
+          "2020-04-10|" \
+          "1",
+        "#{I18n.t('coronavirus_form.groups.getting_food.questions.get_food.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.getting_food.questions.get_food.options.option_yes.label')}|" \
+          "2020-04-11|" \
+          "1",
+        "#{I18n.t('coronavirus_form.groups.getting_food.questions.get_food.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label')}|" \
+          "2020-04-11|" \
+          "1",
       ]
     end
 

--- a/spec/requests/feel_safe_spec.rb
+++ b/spec/requests/feel_safe_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "feel-safe" do
+  let(:options) { I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(feel_safe get_food))
   end
 
   describe "GET /feel-safe" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,22 +25,22 @@ RSpec.describe "feel-safe" do
         visit feel_safe_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
-        I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(feel_safe: selected_option)
+        page.set_rack_session(feel_safe: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit feel_safe_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
 
@@ -56,16 +58,14 @@ RSpec.describe "feel-safe" do
   end
 
   describe "POST /feel-safe" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options").sample }
-
     it "updates the session store" do
-      post feel_safe_path, params: { feel_safe: selected_option }
+      post feel_safe_path, params: { feel_safe: selected_option_text }
 
-      expect(session[:feel_safe]).to eq(selected_option)
+      expect(session[:feel_safe]).to eq(selected_option_text)
     end
 
     it "redirects to the next question" do
-      post feel_safe_path, params: { feel_safe: selected_option }
+      post feel_safe_path, params: { feel_safe: selected_option_text }
 
       expect(response).to redirect_to(controller: "get_food", action: "show")
     end

--- a/spec/requests/get_food_spec.rb
+++ b/spec/requests/get_food_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "get-food" do
+  let(:options) { I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(get_food feel_safe))
   end
 
   describe "GET /get-food" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,22 +25,22 @@ RSpec.describe "get-food" do
         visit get_food_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.get_food.title"))
-        I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(get_food: selected_option)
+        page.set_rack_session(get_food: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit get_food_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.get_food.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
 
@@ -56,16 +58,14 @@ RSpec.describe "get-food" do
   end
 
   describe "POST /get-food" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options").sample }
-
     it "updates the session store" do
-      post get_food_path, params: { get_food: selected_option }
+      post get_food_path, params: { get_food: selected_option_text }
 
-      expect(session[:get_food]).to eq(selected_option)
+      expect(session[:get_food]).to eq(selected_option_text)
     end
 
     it "redirects to the next question" do
-      post get_food_path, params: { get_food: selected_option }
+      post get_food_path, params: { get_food: selected_option_text }
 
       expect(response).to redirect_to(controller: "feel_safe", action: "show")
     end

--- a/spec/requests/have_somewhere_to_live_spec.rb
+++ b/spec/requests/have_somewhere_to_live_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "have-somewhere-to-live" do
+  let(:options) { I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(have_somewhere_to_live feel_safe))
   end
 
   describe "GET /have-somewhere-to-live" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,22 +25,22 @@ RSpec.describe "have-somewhere-to-live" do
         visit have_somewhere_to_live_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.title"))
-        I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(have_somewhere_to_live: selected_option)
+        page.set_rack_session(have_somewhere_to_live: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit have_somewhere_to_live_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
 
@@ -56,16 +58,14 @@ RSpec.describe "have-somewhere-to-live" do
   end
 
   describe "POST /have-somewhere-to-live" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.options").sample }
-
     it "updates the session store" do
-      post have_somewhere_to_live_path, params: { have_somewhere_to_live: selected_option }
+      post have_somewhere_to_live_path, params: { have_somewhere_to_live: selected_option_text }
 
-      expect(session[:have_somewhere_to_live]).to eq(selected_option)
+      expect(session[:have_somewhere_to_live]).to eq(selected_option_text)
     end
 
     it "redirects to the next question" do
-      post have_somewhere_to_live_path, params: { have_somewhere_to_live: selected_option }
+      post have_somewhere_to_live_path, params: { have_somewhere_to_live: selected_option_text }
 
       expect(response).to redirect_to(controller: "feel_safe", action: "show")
     end

--- a/spec/requests/have_you_been_evicted_spec.rb
+++ b/spec/requests/have_you_been_evicted_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "have-you-been-evicted" do
+  let(:options) { I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(have_you_been_evicted feel_safe))
   end
 
   describe "GET /have-you-been-evicted" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,22 +25,22 @@ RSpec.describe "have-you-been-evicted" do
         visit have_you_been_evicted_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.title"))
-        I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(have_you_been_evicted: selected_option)
+        page.set_rack_session(have_you_been_evicted: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit have_you_been_evicted_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
 
@@ -56,16 +58,14 @@ RSpec.describe "have-you-been-evicted" do
   end
 
   describe "POST /have-you-been-evicted" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options").sample }
-
     it "updates the session store" do
-      post have_you_been_evicted_path, params: { have_you_been_evicted: selected_option }
+      post have_you_been_evicted_path, params: { have_you_been_evicted: selected_option_text }
 
-      expect(session[:have_you_been_evicted]).to eq(selected_option)
+      expect(session[:have_you_been_evicted]).to eq(selected_option_text)
     end
 
     it "redirects to the next question" do
-      post have_you_been_evicted_path, params: { have_you_been_evicted: selected_option }
+      post have_you_been_evicted_path, params: { have_you_been_evicted: selected_option_text }
 
       expect(response).to redirect_to(controller: "feel_safe", action: "show")
     end

--- a/spec/requests/have_you_been_made_unemployed_spec.rb
+++ b/spec/requests/have_you_been_made_unemployed_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "have-you-been-made-unemployed" do
+  let(:options) { I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(have_you_been_made_unemployed feel_safe))
   end
 
   describe "GET /have-you-been-made-unemployed" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,22 +25,22 @@ RSpec.describe "have-you-been-made-unemployed" do
         visit have_you_been_made_unemployed_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
-        I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(have_you_been_made_unemployed: selected_option)
+        page.set_rack_session(have_you_been_made_unemployed: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit have_you_been_made_unemployed_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
 
@@ -56,16 +58,14 @@ RSpec.describe "have-you-been-made-unemployed" do
   end
 
   describe "POST /still-working" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options").sample }
-
     it "updates the session store" do
-      post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: selected_option }
+      post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: selected_option_text }
 
-      expect(session[:have_you_been_made_unemployed]).to eq(selected_option)
+      expect(session[:have_you_been_made_unemployed]).to eq(selected_option_text)
     end
 
     it "redirects to the next question" do
-      post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: selected_option }
+      post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: selected_option_text }
 
       expect(response).to redirect_to(controller: "feel_safe", action: "show")
     end

--- a/spec/requests/living_with_vulnerable_spec.rb
+++ b/spec/requests/living_with_vulnerable_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "living-with-vulnerable" do
+  let(:options) { I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(living_with_vulnerable feel_safe))
   end
 
   describe "GET /living-with-vulnerable" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,22 +25,22 @@ RSpec.describe "living-with-vulnerable" do
         visit living_with_vulnerable_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.title"))
-        I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(living_with_vulnerable: selected_option)
+        page.set_rack_session(living_with_vulnerable: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit living_with_vulnerable_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
 
@@ -56,16 +58,14 @@ RSpec.describe "living-with-vulnerable" do
   end
 
   describe "POST /living-with-vulnerable" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.options").sample }
-
     it "updates the session store" do
-      post living_with_vulnerable_path, params: { living_with_vulnerable: selected_option }
+      post living_with_vulnerable_path, params: { living_with_vulnerable: selected_option_text }
 
-      expect(session[:living_with_vulnerable]).to eq(selected_option)
+      expect(session[:living_with_vulnerable]).to eq(selected_option_text)
     end
 
     it "redirects to the next question" do
-      post living_with_vulnerable_path, params: { living_with_vulnerable: selected_option }
+      post living_with_vulnerable_path, params: { living_with_vulnerable: selected_option_text }
 
       expect(response).to redirect_to(controller: "feel_safe", action: "show")
     end

--- a/spec/requests/mental_health_worries_spec.rb
+++ b/spec/requests/mental_health_worries_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "mental-health-worries" do
+  let(:options) { I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(mental_health_worries feel_safe))
   end
 
   describe "GET /mental-health-worries" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,22 +25,22 @@ RSpec.describe "mental-health-worries" do
         visit mental_health_worries_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.title"))
-        I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(mental_health_worries: selected_option)
+        page.set_rack_session(mental_health_worries: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit mental_health_worries_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
 
@@ -56,16 +58,14 @@ RSpec.describe "mental-health-worries" do
   end
 
   describe "POST /mental-health-worries" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options").sample }
-
     it "updates the session store" do
-      post mental_health_worries_path, params: { mental_health_worries: selected_option }
+      post mental_health_worries_path, params: { mental_health_worries: selected_option_text }
 
-      expect(session[:mental_health_worries]).to eq(selected_option)
+      expect(session[:mental_health_worries]).to eq(selected_option_text)
     end
 
     it "redirects to the next question" do
-      post mental_health_worries_path, params: { mental_health_worries: selected_option }
+      post mental_health_worries_path, params: { mental_health_worries: selected_option_text }
 
       expect(response).to redirect_to(controller: "feel_safe", action: "show")
     end

--- a/spec/requests/self_employed_spec.rb
+++ b/spec/requests/self_employed_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe "self-employed" do
+  let(:options) { I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options") }
+  let(:selected_option) { options.keys.sample }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.#{selected_option}.label") }
+
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(self_employed feel_safe))
   end
 
   describe "GET /self-employed" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options").sample }
-
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -23,22 +25,22 @@ RSpec.describe "self-employed" do
         visit self_employed_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
-        I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(self_employed: selected_option)
+        page.set_rack_session(self_employed: selected_option_text)
       end
 
       it "shows the form without prefilled response" do
         visit self_employed_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
-        expect(page.find("input#option_#{selected_option.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
 
@@ -56,16 +58,14 @@ RSpec.describe "self-employed" do
   end
 
   describe "POST /self-employed" do
-    let(:selected_option) { I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options").sample }
-
     it "updates the session store" do
-      post self_employed_path, params: { self_employed: selected_option }
+      post self_employed_path, params: { self_employed: selected_option_text }
 
-      expect(session[:self_employed]).to eq(selected_option)
+      expect(session[:self_employed]).to eq(selected_option_text)
     end
 
     it "redirects to the next question" do
-      post self_employed_path, params: { self_employed: selected_option }
+      post self_employed_path, params: { self_employed: selected_option_text }
 
       expect(response).to redirect_to(controller: "feel_safe", action: "show")
     end

--- a/spec/requests/urgent_medical_help_spec.rb
+++ b/spec/requests/urgent_medical_help_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "urgent-medical-help" do
-  let(:selected_yes) { I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.options").first }
-  let(:selected_no) { I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.options").last }
+  let(:selected_yes) { I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.options.option_yes") }
+  let(:selected_no) { I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.options.option_no") }
 
   describe "GET /urgent-medical-help" do
     context "without session data" do
@@ -8,41 +8,41 @@ RSpec.describe "urgent-medical-help" do
         visit urgent_medical_help_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.title"))
-        I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.options").each do |option|
-          expect(page.body).to have_content(option)
+        I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.options").each do |_, option|
+          expect(page.body).to have_content(option[:label])
         end
       end
     end
 
     context "with session data" do
       before do
-        page.set_rack_session(urgent_medical_help: selected_no)
+        page.set_rack_session(urgent_medical_help: selected_no[:label])
       end
 
       it "shows the form without prefilled response" do
         visit urgent_medical_help_path
 
         expect(page.body).to have_content(I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.title"))
-        expect(page.find("input#option_#{selected_no.parameterize.underscore}")).not_to be_checked
+        expect(page.find("input#option_no")).not_to be_checked
       end
     end
   end
 
   describe "POST /still-working" do
     it "updates the session store" do
-      post urgent_medical_help_path, params: { urgent_medical_help: selected_no }
+      post urgent_medical_help_path, params: { urgent_medical_help: selected_no[:label] }
 
-      expect(session[:urgent_medical_help]).to eq(selected_no)
+      expect(session[:urgent_medical_help]).to eq(selected_no[:label])
     end
 
     it "redirects to the next question for a no response" do
-      post urgent_medical_help_path, params: { urgent_medical_help: selected_no }
+      post urgent_medical_help_path, params: { urgent_medical_help: selected_no[:label] }
 
       expect(response).to redirect_to(need_help_with_path)
     end
 
     it "redirects to the next question for a yes response" do
-      post urgent_medical_help_path, params: { urgent_medical_help: selected_yes }
+      post urgent_medical_help_path, params: { urgent_medical_help: selected_yes[:label] }
 
       expect(response).to redirect_to(get_help_from_nhs_path)
     end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -10,7 +10,7 @@ module FillInTheFormSteps
 
     choose "No"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_needs_help_with_all_options
@@ -25,7 +25,7 @@ module FillInTheFormSteps
     check I18n.t("coronavirus_form.groups.mental_health.title")
     check I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.options").first
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_feels_unsafe_where_they_live
@@ -33,7 +33,7 @@ module FillInTheFormSteps
 
     choose "No"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_is_finding_it_hard_to_afford_rent_mortgage_bills
@@ -41,7 +41,7 @@ module FillInTheFormSteps
 
     choose "Yes"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_is_finding_it_hard_to_afford_food
@@ -49,7 +49,7 @@ module FillInTheFormSteps
 
     choose "Yes"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_is_unable_to_get_food
@@ -57,7 +57,7 @@ module FillInTheFormSteps
 
     choose "No"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_has_been_told_to_stop_working
@@ -65,7 +65,7 @@ module FillInTheFormSteps
 
     choose "Yes, I’ve been made unemployed, or might be soon"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_is_off_work_because_ill_or_self_isolating
@@ -73,7 +73,7 @@ module FillInTheFormSteps
 
     choose "Yes"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_is_self_employed_or_a_sole_trader
@@ -81,7 +81,7 @@ module FillInTheFormSteps
 
     choose "Yes"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_is_worried_about_going_to_work_because_of_living_with_someone_vulnerable
@@ -89,7 +89,7 @@ module FillInTheFormSteps
 
     choose "Yes"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_has_nowhere_to_live
@@ -97,7 +97,7 @@ module FillInTheFormSteps
 
     choose "No"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_has_been_evicted
@@ -105,7 +105,7 @@ module FillInTheFormSteps
 
     choose "Yes"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_is_worried_about_mental_health
@@ -113,7 +113,7 @@ module FillInTheFormSteps
 
     choose "Yes, I am"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_is_not_able_to_leave_home_if_absolutely_necessary
@@ -121,7 +121,7 @@ module FillInTheFormSteps
 
     choose "I should not leave home because I have coronavirus symptoms, or someone in my household does"
 
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def they_view_the_results_page

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -8,7 +8,7 @@ module FillInTheFormSteps
   def and_does_not_need_urgent_medical_help
     expect(page).to have_content(I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.title"))
 
-    choose "No"
+    choose I18n.t("coronavirus_form.groups.help.questions.urgent_medical_help.options.option_no.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -31,7 +31,7 @@ module FillInTheFormSteps
   def and_feels_unsafe_where_they_live
     expect(page).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
 
-    choose "No"
+    choose I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.option_no.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -39,7 +39,7 @@ module FillInTheFormSteps
   def and_is_finding_it_hard_to_afford_rent_mortgage_bills
     expect(page).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.title"))
 
-    choose "Yes"
+    choose I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.option_yes.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -47,7 +47,7 @@ module FillInTheFormSteps
   def and_is_finding_it_hard_to_afford_food
     expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
 
-    choose "Yes"
+    choose I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options.option_yes.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -55,7 +55,7 @@ module FillInTheFormSteps
   def and_is_unable_to_get_food
     expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.get_food.title"))
 
-    choose "No"
+    choose I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -63,7 +63,7 @@ module FillInTheFormSteps
   def and_has_been_told_to_stop_working
     expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
 
-    choose "Yes, I’ve been made unemployed, or might be soon"
+    choose I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_yes.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -71,7 +71,7 @@ module FillInTheFormSteps
   def and_is_off_work_because_ill_or_self_isolating
     expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
 
-    choose "Yes"
+    choose I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_yes.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -79,7 +79,7 @@ module FillInTheFormSteps
   def and_is_self_employed_or_a_sole_trader
     expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
 
-    choose "Yes"
+    choose I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -87,7 +87,7 @@ module FillInTheFormSteps
   def and_is_worried_about_going_to_work_because_of_living_with_someone_vulnerable
     expect(page).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.title"))
 
-    choose "Yes"
+    choose I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.options.option_yes.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -95,7 +95,7 @@ module FillInTheFormSteps
   def and_has_nowhere_to_live
     expect(page).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.title"))
 
-    choose "No"
+    choose I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.options.option_no.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -103,7 +103,7 @@ module FillInTheFormSteps
   def and_has_been_evicted
     expect(page).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.title"))
 
-    choose "Yes"
+    choose I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options.option_yes.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -111,7 +111,7 @@ module FillInTheFormSteps
   def and_is_worried_about_mental_health
     expect(page).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.title"))
 
-    choose "Yes, I am"
+    choose I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options.option_yes.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -119,7 +119,7 @@ module FillInTheFormSteps
   def and_is_not_able_to_leave_home_if_absolutely_necessary
     expect(page).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
 
-    choose "I should not leave home because I have coronavirus symptoms, or someone in my household does"
+    choose I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_has_symptoms.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end


### PR DESCRIPTION
Trello: https://trello.com/c/HgWQqjjb

When we [change a question](https://github.com/alphagov/govuk-coronavirus-find-support/pull/122/commits/a02d719719717d0606046416fc1e6bce99d7ee9f), the tests fail because they [hardcode a lot of the question and answer text](https://github.com/alphagov/govuk-coronavirus-find-support/pull/122/commits/2876ee7abcf1e57dc25002e1879329830e05c0d0).

We should make the tests use the values from the internationalizations so that we don't have to do this manual dev task.