### PR TITLE
Restructure employment questions

### DIFF
--- a/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
+++ b/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
@@ -19,8 +19,13 @@ class CoronavirusForm::HaveYouBeenMadeUnemployedController < ApplicationControll
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
+    elsif I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.skip_next_question_options").include? @form_responses[:have_you_been_made_unemployed]
+      update_session_store
+      session[:questions_to_ask] = remove_questions(%w(are_you_off_work_ill))
+      redirect_to polymorphic_url(next_question(controller_name))
     else
       update_session_store
+      session[:questions_to_ask] = add_questions(%w(are_you_off_work_ill), controller_name)
       redirect_to polymorphic_url(next_question(controller_name))
     end
   end

--- a/app/controllers/coronavirus_form/self_employed_controller.rb
+++ b/app/controllers/coronavirus_form/self_employed_controller.rb
@@ -19,8 +19,13 @@ class CoronavirusForm::SelfEmployedController < ApplicationController
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
+    elsif I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.skip_next_question_options").include? @form_responses[:self_employed]
+      update_session_store
+      session[:questions_to_ask] = remove_questions(%w(have_you_been_made_unemployed are_you_off_work_ill))
+      redirect_to polymorphic_url(next_question(controller_name))
     else
       update_session_store
+      session[:questions_to_ask] = add_questions(%w(have_you_been_made_unemployed are_you_off_work_ill), controller_name)
       redirect_to polymorphic_url(next_question(controller_name))
     end
   end

--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -56,4 +56,8 @@ module QuestionsHelper
   def all_questions
     I18n.t("coronavirus_form.groups").map { |_, group| group[:questions].keys if group[:title] }.compact.flatten.map(&:to_s)
   end
+
+  def remove_questions(questions)
+    questions_to_ask - questions
+  end
 end

--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -60,4 +60,13 @@ module QuestionsHelper
   def remove_questions(questions)
     questions_to_ask - questions
   end
+
+  def add_questions(questions, after_question)
+    index = questions_to_ask.index(after_question) + 1
+    questions_to_ask
+      .dup
+      .insert(index, questions)
+      .flatten
+      .uniq
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -259,6 +259,17 @@ en:
       being_unemployed:
         title: "Being unemployed or not having any work"
         questions:
+          self_employed:
+            title: "Are you self-employed or a sole trader?"
+            title_caption: "Being unemployed or not having any work"
+            options:
+              option_yes:
+                label: "Yes"
+              option_no:
+                label: "No"
+              not_sure:
+                label: "Not sure"
+            custom_select_error: "Select yes if you’re self-employed or a sole trader"
           have_you_been_made_unemployed:
             title: "Have you been told to stop working?"
             title_caption: "Being unemployed or not having any work"
@@ -281,17 +292,6 @@ en:
               option_no:
                 label: "No"
             custom_select_error: "Select yes if you’re off work because you’re ill or self-isolating"
-          self_employed:
-            title: "Are you self-employed or a sole trader?"
-            title_caption: "Being unemployed or not having any work"
-            options:
-              option_yes:
-                label: "Yes"
-              option_no:
-                label: "No"
-              not_sure:
-                label: "Not sure"
-            custom_select_error: "Select yes if you’re self-employed or a sole trader"
       going_in_to_work:
         title: "Going in to work"
         questions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -269,6 +269,9 @@ en:
                 label: "No"
               not_sure:
                 label: "Not sure"
+            skip_next_question_options:
+              - "Yes"
+              - "Not sure"
             custom_select_error: "Select yes if you’re self-employed or a sole trader"
           have_you_been_made_unemployed:
             title: "Have you been told to stop working?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,6 +285,9 @@ en:
                 label: "No"
               not_sure:
                 label: "Not sure"
+            skip_next_question_options:
+              - "Yes, I’ve been made unemployed, or might be soon"
+              - "Yes, I’ve been put on temporary leave (on furlough), or might be soon"
             custom_select_error: "Select if you’ve been made unemployed, or put on temporary leave (furloughed)"
           are_you_off_work_ill:
             title: "Are you off work because you’re ill or self-isolating?"

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Fill in the form" do
     and_is_finding_it_hard_to_afford_food
     and_is_unable_to_get_food
     and_is_not_self_employed_or_a_sole_trader
-    and_has_been_told_to_stop_working
+    and_has_not_been_told_to_stop_working
     and_is_off_work_because_ill_or_self_isolating
     and_is_worried_about_going_to_work_because_of_living_with_someone_vulnerable
     and_has_nowhere_to_live
@@ -25,10 +25,21 @@ RSpec.feature "Fill in the form" do
     they_are_provided_with_information_about_feeling_unsafe
     they_are_provided_with_information_about_paying_bills
     they_are_provided_with_information_about_getting_food
-    they_are_provided_with_information_about_being_unemployed
     they_are_provided_with_information_about_going_in_to_work
     they_are_provided_with_information_about_having_somewhere_to_live
     they_are_provided_with_information_about_mental_health
+    they_are_given_a_link_for_providing_feedback
+  end
+
+  scenario "Complete the form when not self employed but furloughed" do
+    given_a_user_is_struggling_because_of_coronavirus
+    and_does_not_need_urgent_medical_help
+    and_needs_help_with_being_unemployed
+    and_is_not_self_employed_or_a_sole_trader
+    and_has_been_told_to_stop_working
+    and_is_not_able_to_leave_home_if_absolutely_necessary
+    they_view_the_results_page
+    they_are_provided_with_information_about_being_unemployed
     they_are_given_a_link_for_providing_feedback
   end
 

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.feature "Fill in the form" do
   include FillInTheFormSteps
 
-  scenario "Complete the form" do
+  scenario "Complete the form when not self employed" do
     given_a_user_is_struggling_because_of_coronavirus
     and_does_not_need_urgent_medical_help
     and_needs_help_with_all_options
@@ -13,7 +13,7 @@ RSpec.feature "Fill in the form" do
     and_is_finding_it_hard_to_afford_rent_mortgage_bills
     and_is_finding_it_hard_to_afford_food
     and_is_unable_to_get_food
-    and_is_self_employed_or_a_sole_trader
+    and_is_not_self_employed_or_a_sole_trader
     and_has_been_told_to_stop_working
     and_is_off_work_because_ill_or_self_isolating
     and_is_worried_about_going_to_work_because_of_living_with_someone_vulnerable
@@ -29,6 +29,17 @@ RSpec.feature "Fill in the form" do
     they_are_provided_with_information_about_going_in_to_work
     they_are_provided_with_information_about_having_somewhere_to_live
     they_are_provided_with_information_about_mental_health
+    they_are_given_a_link_for_providing_feedback
+  end
+
+  scenario "Complete the form when self employed" do
+    given_a_user_is_struggling_because_of_coronavirus
+    and_does_not_need_urgent_medical_help
+    and_needs_help_with_being_unemployed
+    and_is_self_employed_or_a_sole_trader
+    and_is_not_able_to_leave_home_if_absolutely_necessary
+    they_view_the_results_page
+    they_are_provided_with_information_about_being_self_employed
     they_are_given_a_link_for_providing_feedback
   end
 

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -13,9 +13,9 @@ RSpec.feature "Fill in the form" do
     and_is_finding_it_hard_to_afford_rent_mortgage_bills
     and_is_finding_it_hard_to_afford_food
     and_is_unable_to_get_food
+    and_is_self_employed_or_a_sole_trader
     and_has_been_told_to_stop_working
     and_is_off_work_because_ill_or_self_isolating
-    and_is_self_employed_or_a_sole_trader
     and_is_worried_about_going_to_work_because_of_living_with_someone_vulnerable
     and_has_nowhere_to_live
     and_has_been_evicted

--- a/spec/helpers/questions_helper_spec.rb
+++ b/spec/helpers/questions_helper_spec.rb
@@ -83,4 +83,14 @@ RSpec.describe QuestionsHelper, type: :helper do
       expect(helper.remove_questions(%w(get_food))).to eq(%w(afford_food))
     end
   end
+
+  describe "#add_questions" do
+    it "adds all questions from array when question not already in array" do
+      expect(helper.add_questions(%w(question_3 question_4), "get_food")).to eq(%w(get_food question_3 question_4 afford_food))
+    end
+
+    it "does not add question when question already in array" do
+      expect(helper.add_questions(%w(afford_food), "get_food")).to eq(%w(get_food afford_food))
+    end
+  end
 end

--- a/spec/helpers/questions_helper_spec.rb
+++ b/spec/helpers/questions_helper_spec.rb
@@ -77,4 +77,10 @@ RSpec.describe QuestionsHelper, type: :helper do
       end
     end
   end
+
+  describe "#remove_questions" do
+    it "removes all questions from array" do
+      expect(helper.remove_questions(%w(get_food))).to eq(%w(afford_food))
+    end
+  end
 end

--- a/spec/requests/have_you_been_made_unemployed_spec.rb
+++ b/spec/requests/have_you_been_made_unemployed_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "have-you-been-made-unemployed" do
   let(:selected_option_text) { I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.#{selected_option}.label") }
 
   before do
-    allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(have_you_been_made_unemployed feel_safe))
+    allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(have_you_been_made_unemployed are_you_off_work_ill feel_safe))
   end
 
   describe "GET /have-you-been-made-unemployed" do
@@ -58,16 +58,28 @@ RSpec.describe "have-you-been-made-unemployed" do
   end
 
   describe "POST /still-working" do
+    let(:positive_response) { I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.skip_next_question_options").sample }
+    let(:negative_response) do
+      (I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options").map { |_, option| option[:label] } -
+        I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.skip_next_question_options")).sample
+    end
     it "updates the session store" do
-      post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: selected_option_text }
+      post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: positive_response }
 
-      expect(session[:have_you_been_made_unemployed]).to eq(selected_option_text)
+      expect(session[:have_you_been_made_unemployed]).to eq(positive_response)
     end
 
-    it "redirects to the next question" do
-      post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: selected_option_text }
+    it "redirects to the next question for no response" do
+      post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: negative_response }
 
-      expect(response).to redirect_to(feel_safe_path)
+      expect(session[:questions_to_ask]).to eq(%w(have_you_been_made_unemployed are_you_off_work_ill feel_safe))
+      expect(response).to redirect_to(are_you_off_work_ill_path)
+    end
+
+    it "removes irrelevant question for yes response" do
+      post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: positive_response }
+
+      expect(session[:questions_to_ask]).to eq(%w(have_you_been_made_unemployed feel_safe))
     end
 
     it "shows an error when no radio button selected" do

--- a/spec/requests/self_employed_spec.rb
+++ b/spec/requests/self_employed_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "self-employed" do
   let(:selected_option_text) { I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.#{selected_option}.label") }
 
   before do
-    allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(self_employed feel_safe))
+    allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(self_employed have_you_been_made_unemployed feel_safe))
   end
 
   describe "GET /self-employed" do
@@ -58,16 +58,29 @@ RSpec.describe "self-employed" do
   end
 
   describe "POST /self-employed" do
-    it "updates the session store" do
-      post self_employed_path, params: { self_employed: selected_option_text }
-
-      expect(session[:self_employed]).to eq(selected_option_text)
+    let(:positive_response) { I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.skip_next_question_options").sample }
+    let(:negative_response) do
+      (I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options").map { |_, option| option[:label] } -
+        I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.skip_next_question_options")).sample
     end
 
-    it "redirects to the next question" do
-      post self_employed_path, params: { self_employed: selected_option_text }
+    it "updates the session store" do
+      post self_employed_path, params: { self_employed: positive_response }
 
-      expect(response).to redirect_to(feel_safe_path)
+      expect(session[:self_employed]).to eq(positive_response)
+    end
+
+    it "redirects to the next question for no response" do
+      post self_employed_path, params: { self_employed: negative_response }
+
+      expect(session[:questions_to_ask]).to eq(%w(self_employed have_you_been_made_unemployed are_you_off_work_ill feel_safe))
+      expect(response).to redirect_to(have_you_been_made_unemployed_path)
+    end
+
+    it "removes irrelevant question for yes response" do
+      post self_employed_path, params: { self_employed: positive_response }
+
+      expect(session[:questions_to_ask]).to eq(%w(self_employed feel_safe))
     end
 
     it "shows an error when no radio button selected" do

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -28,6 +28,14 @@ module FillInTheFormSteps
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
+  def and_needs_help_with_being_unemployed
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.title"))
+
+    check I18n.t("coronavirus_form.groups.being_unemployed.title")
+
+    click_on I18n.t("coronavirus_form.submit_and_next")
+  end
+
   def and_feels_unsafe_where_they_live
     expect(page).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
 
@@ -80,6 +88,14 @@ module FillInTheFormSteps
     expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
 
     choose I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label")
+
+    click_on I18n.t("coronavirus_form.submit_and_next")
+  end
+
+  def and_is_not_self_employed_or_a_sole_trader
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
+
+    choose I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_no.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -142,10 +158,13 @@ module FillInTheFormSteps
     expect(page).to have_content(I18n.t("results_link.getting_food.get_food.title"))
   end
 
+  def they_are_provided_with_information_about_being_self_employed
+    expect(page).to have_content(I18n.t("results_link.being_unemployed.self_employed.title"))
+  end
+
   def they_are_provided_with_information_about_being_unemployed
     expect(page).to have_content(I18n.t("results_link.being_unemployed.have_you_been_made_unemployed.title"))
     expect(page).to have_content(I18n.t("results_link.being_unemployed.are_you_off_work_ill.title"))
-    expect(page).to have_content(I18n.t("results_link.being_unemployed.self_employed.title"))
   end
 
   def they_are_provided_with_information_about_going_in_to_work

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -76,6 +76,14 @@ module FillInTheFormSteps
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
+  def and_has_not_been_told_to_stop_working
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
+
+    choose I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_no.label")
+
+    click_on I18n.t("coronavirus_form.submit_and_next")
+  end
+
   def and_is_off_work_because_ill_or_self_isolating
     expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
 
@@ -164,6 +172,9 @@ module FillInTheFormSteps
 
   def they_are_provided_with_information_about_being_unemployed
     expect(page).to have_content(I18n.t("results_link.being_unemployed.have_you_been_made_unemployed.title"))
+  end
+
+  def they_are_provided_with_information_about_being_off_work_ill
     expect(page).to have_content(I18n.t("results_link.being_unemployed.are_you_off_work_ill.title"))
   end
 


### PR DESCRIPTION
Makes changes to the user flow through the employment questions:
- "Are you self employed" is now the first question in the group
- Later questions in the group ("Have you been told to stop working" and "Are you off work") are not asked if the user is self employed
- Final question ("Are you off work") is not asked if the user has been told to stop working

Trello card: https://trello.com/c/y3mCWrG1