### PR TITLE
Bugfix: Answering "I'm not sure" should redirect users to the first question

### DIFF
--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -30,7 +30,7 @@ module QuestionsHelper
   end
 
   def questions_to_ask
-    session_questions & all_questions.map(&:to_s)
+    session_questions & all_questions
   end
 
   def session_questions
@@ -54,6 +54,6 @@ module QuestionsHelper
   end
 
   def all_questions
-    I18n.t("coronavirus_form.groups").map { |_, group| group[:questions].keys if group[:title] }.compact.flatten
+    I18n.t("coronavirus_form.groups").map { |_, group| group[:questions].keys if group[:title] }.compact.flatten.map(&:to_s)
   end
 end

--- a/spec/helpers/questions_helper_spec.rb
+++ b/spec/helpers/questions_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe QuestionsHelper, type: :helper do
       groups = []
       all_questions = I18n.t("coronavirus_form.groups").map { |_, group| group[:questions].keys if group[:title] }.compact.flatten
 
-      expect(helper.determine_user_questions(groups)).to eq(all_questions)
+      expect(helper.determine_user_questions(groups)).to eq(all_questions.map(&:to_s))
     end
   end
 
@@ -62,6 +62,19 @@ RSpec.describe QuestionsHelper, type: :helper do
       allow(helper).to receive(:all_questions).and_return(%w(get_food afford_food question_3))
 
       expect(helper.questions_to_ask).to eq(%w(get_food afford_food))
+    end
+
+    context "when the session questions_to_ask is equal to all_questions" do
+      let(:all_questions) { %w(feel_safe afford_food) }
+
+      before do
+        allow(helper).to receive(:session_questions).and_return(all_questions)
+        allow(helper).to receive(:all_questions).and_return(all_questions)
+      end
+
+      it "returns all_questions" do
+        expect(helper.questions_to_ask).to eq(all_questions)
+      end
     end
   end
 end

--- a/spec/requests/need_help_with_spec.rb
+++ b/spec/requests/need_help_with_spec.rb
@@ -56,18 +56,26 @@ RSpec.describe "need-help-with" do
       expect(session[:need_help_with]).to eq(selected)
       expect(session[:selected_groups]).to eq(expected_groups)
       expect(session[:questions_to_ask]).to eq(expected_questions)
+      expect(response).to redirect_to(get_food_path)
     end
 
-    it "updates the session with all questions if the user selects I'm not sure" do
-      selected = ["I’m not sure"]
+    context "doesn't know what help they need" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w(feel_safe get_food))
+      end
+      let(:selected) { ["I’m not sure"] }
 
-      post need_help_with_path, params: { need_help_with: selected }
+      it "updates the session with all questions" do
+        post need_help_with_path, params: { need_help_with: selected }
 
-      all_questions = I18n.t("coronavirus_form.groups").map { |_, group| group[:questions].keys if group[:title] }.compact.flatten
+        all_questions = I18n.t("coronavirus_form.groups").map { |_, group| group[:questions].keys if group[:title] }.compact.flatten.map(&:to_s)
 
-      expect(session[:need_help_with]).to eq(selected)
-      expect(session[:selected_groups]).to be_empty
-      expect(session[:questions_to_ask]).to eq(all_questions)
+        expect(session[:need_help_with]).to eq(selected)
+        expect(session[:selected_groups]).to be_empty
+        expect(session[:questions_to_ask]).to eq(all_questions)
+
+        expect(response).to redirect_to(feel_safe_path)
+      end
     end
 
     it "redirects to the next question" do
@@ -81,6 +89,7 @@ RSpec.describe "need-help-with" do
 
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.title"))
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.custom_select_error"))
+      expect(response).to render_template("need_help_with")
     end
   end
 end


### PR DESCRIPTION
When a user has all questions to answer (eg when they answer
'I'm not sure' to the question what help do you need),
we should set their questions_to_answer to be all_questions.

Currently we set the questions_to_answer to be empty, which
means users are redirected to a nil path next_quest(nil).

Please let me know if there's a better way to fix this; I'm
not familiar with this bit.

Resolves https://sentry.io/organizations/govuk/issues/1621299615
https://trello.com/c/Pw8wJYuW/288