### PR TITLE
Get tests-image in smoke-test-prod job

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -149,6 +149,9 @@ jobs:
       - get: git-master
         trigger: true
         passed: [deploy-to-prod]
+      - get: tests-image
+        passed:
+          - build-tests-image
       - task: smoke-test
         file: git-master/concourse/tasks/smoke-test.yml
         timeout: 5m


### PR DESCRIPTION
Get tests-image in smoke-test-prod job

fixes failure:

```
missing image artifact source: tests-image

make sure there's a corresponding 'get' step, or a task that produces it as an output
```