### PR TITLE
Add information on how to enable cookies to the cookie page

### DIFF
--- a/app/views/coronavirus_form/cookies.html.erb
+++ b/app/views/coronavirus_form/cookies.html.erb
@@ -32,6 +32,21 @@
   </div>
 
   <div class="cookie-settings__form-wrapper">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Where to find information about controlling cookies"
+    } %>
+    <ul class="govuk-list">
+      <% t('cookies.settings_page.enable').each do |browser| %>
+        <li>
+          <% if browser[:href] %>
+            <%= link_to browser[:text], browser[:href], class: "govuk-link" %>
+          <% else %>
+            <%= sanitize(browser[:text]) %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+    
     <p>
       We use <%= t('cookies.settings_page.cookies').count %> types of cookie.
       You can choose which cookies you're happy for us to use.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,6 +177,19 @@ en:
             - - text: _gid
               - text: This helps us count how many people visit the service by tracking if you’ve visited before
               - text: 3 years
+      enable:
+        - text: "Chrome cookies information"
+          href: "https://support.google.com/chrome/answer/95647?hl=en-GB"
+        - text: "Firefox cookies information"
+          href: "https://support.mozilla.org/en-US/kb/delete-browsing-search-download-history-firefox"
+        - text: "Internet Explorer cookies information"
+          href: "https://support.microsoft.com/en-gb/help/17442/windows-internet-explorer-delete-manage-cookies"
+        - text: "Microsoft Edge cookies information"
+          href: "https://privacy.microsoft.com/en-us/windows-10-microsoft-edge-and-privacy"
+        - text: "Opera cookies information"
+          href: "https://www.opera.com/help/tutorials/security/cookies/"
+        - text: 'Safari cookies information – <a href="https://support.apple.com/en-gb/HT201265" class="govuk-link">mobile devices</a> and <a href="https://support.apple.com/kb/PH21411?locale=en_GB" class="govuk-link">desktops</a>'
+
   coronavirus_form:
     submit_and_next: "Continue"
     errors:


### PR DESCRIPTION
This adds links to information on how users can enable cookies for their browsers.

## Before
<img width="1426" alt="Screenshot 2020-04-23 at 15 13 59" src="https://user-images.githubusercontent.com/24547207/80109493-76432080-8575-11ea-99da-195aca1120e9.png">
## After
<img width="1440" alt="Screenshot 2020-04-23 at 15 14 21" src="https://user-images.githubusercontent.com/24547207/80109504-79d6a780-8575-11ea-9e29-cdfa6e20b484.png">



