### PR TITLE
ci: Trim GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,7 @@ jobs:
         ruby-version: 2.6.5
 
     - name: Install PostgreSQL 11 client
-      run: |
-        sudo apt-get -yqq install libpq-dev
+      run: sudo apt-get -yqq install libpq-dev
 
     - uses: actions/cache@v1
       with:
@@ -38,11 +37,11 @@ jobs:
         RAILS_ENV: test
         DB_USERNAME: postgres
       run: |
-        gem install bundler
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rake db:create
         bundle exec rake db:migrate
+
     - name: Run Tests
       env:
         PGHOST: localhost


### PR DESCRIPTION
What
----

This shortens the GitHub Actions runtime slightly, because Ruby 2.6 already ships with Bundler.

How to review
-------------

See the CI build go green.

Links
-----

n/a

