### PR TITLE
Add basic auth to data export endpoint

### DIFF
--- a/app/controllers/coronavirus_form/data_export_controller.rb
+++ b/app/controllers/coronavirus_form/data_export_controller.rb
@@ -3,6 +3,13 @@
 require "csv"
 
 class CoronavirusForm::DataExportController < ApplicationController
+  if ENV.key?("DATA_EXPORT_BASIC_AUTH_USERNAME") && ENV.key?("DATA_EXPORT_BASIC_AUTH_PASSWORD")
+    http_basic_authenticate_with(
+      name: ENV.fetch("DATA_EXPORT_BASIC_AUTH_USERNAME"),
+      password: ENV.fetch("DATA_EXPORT_BASIC_AUTH_PASSWORD"),
+    )
+  end
+
   def show
     respond_to do |format|
       format.html

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -102,6 +102,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((aws-secret-access-key))
           SECRET_KEY_BASE: ((secret-key-base-staging))
           AWS_ASSETS_BUCKET_NAME: govuk-coronavirus-find-support-assets-staging
+          DATA_EXPORT_BASIC_AUTH_USERNAME: ((data-export-basic-auth-username))
+          DATA_EXPORT_BASIC_AUTH_PASSWORD: ((data-export-basic-auth-password))
           HOSTNAME: govuk-coronavirus-find-support-stg
 
   - name: smoke-test-staging
@@ -141,6 +143,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((aws-secret-access-key-prod))
           SECRET_KEY_BASE: ((secret-key-base-prod))
           AWS_ASSETS_BUCKET_NAME: govuk-coronavirus-find-support-assets-prod
+          DATA_EXPORT_BASIC_AUTH_USERNAME: ((data-export-basic-auth-username))
+          DATA_EXPORT_BASIC_AUTH_PASSWORD: ((data-export-basic-auth-password))
           HOSTNAME: govuk-coronavirus-find-support-prod
 
   - name: smoke-test-prod

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -21,6 +21,8 @@ params:
   BASIC_AUTH_PASSWORD:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
+  DATA_EXPORT_BASIC_AUTH_USERNAME:
+  DATA_EXPORT_BASIC_AUTH_PASSWORD:
   GA_VIEW_ID: UA-43115970-1
 run:
   dir: src
@@ -44,6 +46,8 @@ run:
         cf set-env govuk-coronavirus-find-support REQUIRE_BASIC_AUTH "$REQUIRE_BASIC_AUTH"
       fi
       cf set-env govuk-coronavirus-find-support BASIC_AUTH_PASSWORD "$BASIC_AUTH_PASSWORD"
+      cf set-env govuk-coronavirus-find-support DATA_EXPORT_BASIC_AUTH_USERNAME "$DATA_EXPORT_BASIC_AUTH_USERNAME"
+      cf set-env govuk-coronavirus-find-support DATA_EXPORT_BASIC_AUTH_PASSWORD "$DATA_EXPORT_BASIC_AUTH_PASSWORD"
       cf set-env govuk-coronavirus-find-support SENTRY_DSN "$SENTRY_DSN"
       cf set-env govuk-coronavirus-find-support SENTRY_CURRENT_ENV "$CF_SPACE"
       cf set-env govuk-coronavirus-find-support GA_VIEW_ID "$GA_VIEW_ID"

--- a/spec/controllers/coronavirus_form/data_export_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/data_export_controller_spec.rb
@@ -5,6 +5,28 @@ require "spec_helper"
 RSpec.describe CoronavirusForm::DataExportController, type: :controller do
   subject(:instance) { described_class.new }
 
+  describe "#show" do
+    let(:start_date) { "2020-04-10" }
+    let(:end_date) { "2020-04-15" }
+
+    context "with basic auth enabled" do
+      it "rejects unauthenticated users" do
+        request.headers["HTTP_ACCEPT"] = "text/csv"
+        get :show, params: { start_date: start_date, end_date: end_date }
+        expect(response).to have_http_status(401)
+      end
+
+      it "permits authenticated users" do
+        request.headers["HTTP_ACCEPT"] = "text/csv"
+        username = ENV["DATA_EXPORT_BASIC_AUTH_USERNAME"]
+        password = ENV["DATA_EXPORT_BASIC_AUTH_PASSWORD"]
+        request.headers["HTTP_AUTHORIZATION"] = ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
+        get :show, params: { start_date: start_date, end_date: end_date }
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
   describe "#usage_statistics" do
     let(:start_date) { "2020-04-10" }
     let(:end_date) { "2020-04-15" }

--- a/spec/requests/data_export_spec.rb
+++ b/spec/requests/data_export_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "data-export" do
+RSpec.describe "data-export", type: :request do
   let(:start_date) { "2020-04-10" }
   let(:end_date) { "2020-04-15" }
 
@@ -69,7 +69,12 @@ RSpec.describe "data-export" do
     end
 
     it "shows all expected responses in CSV format" do
-      get data_export_path, params: { start_date: start_date, end_date: end_date }, headers: { "HTTP_ACCEPT" => "text/csv" }
+      username = ENV["DATA_EXPORT_BASIC_AUTH_USERNAME"]
+      password = ENV["DATA_EXPORT_BASIC_AUTH_PASSWORD"]
+      get data_export_path, params: { start_date: start_date, end_date: end_date }, headers: {
+        "HTTP_ACCEPT" => "text/csv",
+        "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password),
+      }
 
       expected_lines.each do |line|
         expect(response.body).to have_content(line)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,3 +24,6 @@ RSpec.configure do |config|
     page.driver.add_headers("SMOKE_TEST" => "true")
   end
 end
+
+ENV["DATA_EXPORT_BASIC_AUTH_USERNAME"] ||= "testuser"
+ENV["DATA_EXPORT_BASIC_AUTH_PASSWORD"] ||= SecureRandom.hex


### PR DESCRIPTION
What
----

This requires basic authentication when accessing the `/data-export.csv` path.

Though no personal information is provided via this endpoint, end users don't need access to this reporting tool.

The relevant secrets have already been added. I'll need to share the username/password with those who require access. Should the requirements of the reporting tool change or if we need to share these credentials more widely, we should look at using signon for authentication.

Links
-----

https://trello.com/c/KEUQdHPk/328-put-data-export-endpoint-behind-basic-auth
