### PR TITLE
Tracking no results page

### DIFF
--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -36,4 +36,12 @@ module ResultsHelper
   def selected_groups
     session["selected_groups"]
   end
+
+  def results_title(result_groups_session)
+    if result_groups_session.empty?
+      t("coronavirus_form.results.header.title_no_results")
+    else
+      t("coronavirus_form.results.header.title")
+    end
+  end
 end

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -15,7 +15,7 @@
     margin_top: 0,
     margin_bottom: 6,
   } %>
-  <%= link_to t("coronavirus_form.results.header.start_again_text"), clear_session_path, class: "govuk-link" %>
+  <%= link_to t("coronavirus_form.results.header.start_again_text"), clear_session_path, class: "govuk-link", onclick: "ga('send', 'event', 'StartAgain', 'StartAgainClicked', '/results');" %>
 <% end %>
 
 <% if result_groups(session).empty? %>

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -1,10 +1,11 @@
-<% if result_groups(session).empty? %>
-  <% content_for :title do %><%= t('coronavirus_form.results.header.title_no_results') %><% end %>
-<% else %>
-  <% content_for :title do %><%= t('coronavirus_form.results.header.title') %><% end %>
+<% title = results_title(result_groups(session)) %>
+
+<% content_for :title do %>
+  <%= title %>
 <% end %>
+
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.results.header.title') %>" />
+  <meta name="description" content="<%= title %>" />
 <% end %>
 
 <% content_for :page_header do %>

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -1,4 +1,8 @@
-<% content_for :title do %><%= t('coronavirus_form.results.header.title') %><% end %>
+<% if result_groups(session).empty? %>
+  <% content_for :title do %><%= t('coronavirus_form.results.header.title_no_results') %><% end %>
+<% else %>
+  <% content_for :title do %><%= t('coronavirus_form.results.header.title') %><% end %>
+<% end %>
 <% content_for :meta_tags do %>
   <meta name="description" content="<%= t('coronavirus_form.results.header.title') %>" />
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -371,6 +371,7 @@ en:
       header:
         context: Coronavirus (COVID-19)
         title: Information based on your answers
+        title_no_results: Information based on your answers - no specific information
         start_again_text: Start again
       feedback:
         text: Help us improve


### PR DESCRIPTION
What
----

- Changes results page title depending on wether there are any specific results displayed to the user
- This will allow analysts to determine how many users were not presented with specific results
- Adds event tracking to the ‘Start again’ link

FYI

This solution is a quick way to implement adding event tracking. Ian is going to look into a more GOV.UK like solution which will be easier to maintain than keeping track of changes inline to elements, but we think this is ok for our current need.

How to review
-------------
Harriet (analyst) has already confirmed the naming for the `Event category`, `Action` and `Label`.
@injms and @huwd and I have tested it manually using Google Analytics Debugger. To test we:

- Accepted cookies
- Navigated to the results page
- Used the Google Analytics Debugger extension to see the event fired when the 'Start Again' link is clicked
- Denied cookies
- Checked that the event did not fire 

Links
-----

[Trello](https://trello.com/c/GTMlUZ8H/195-add-google-analytics-events-tracking-to-the-validation-errors-and-no-results-page)

