### PR TITLE
Add enhanced ecommerce to results page

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,3 +46,4 @@ jobs:
         DB_USERNAME: postgres
       run: |
         bundle exec rake
+        bundle exec rake spec:javascript

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ group :development, :test do
   gem "awesome_print", "~> 1.8"
   gem "byebug", "~> 11"
   gem "foreman", "~> 0.87.1"
+  gem "jasmine-core", [">= 2.99", "< 3"]
+  gem "jasmine-rails", "~> 0.15.0"
   gem "pry", "~> 0.13.1"
   gem "pry-rails", "~> 0.3.9"
   gem "rails-controller-testing", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,12 @@ GEM
       concurrent-ruby (~> 1.0)
     ipaddress (0.8.3)
     jaro_winkler (1.5.4)
+    jasmine-core (2.99.2)
+    jasmine-rails (0.15.0)
+      jasmine-core (>= 1.3, < 4.0)
+      phantomjs (>= 1.9)
+      railties (>= 3.2.0)
+      sprockets-rails
     kgio (2.11.3)
     kramdown (2.2.1)
       rexml
@@ -192,6 +198,7 @@ GEM
     parser (2.7.1.1)
       ast (~> 2.4.0)
     pg (1.2.3)
+    phantomjs (2.1.1.0)
     plek (3.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -374,6 +381,8 @@ DEPENDENCIES
   foreman (~> 0.87.1)
   govuk_app_config (~> 2.1.1)
   govuk_publishing_components (~> 21.43.0)
+  jasmine-core (>= 2.99, < 3)
+  jasmine-rails (~> 0.15.0)
   listen (~> 3)
   lograge
   mini_racer (~> 0.2)

--- a/app/assets/javascripts/analytics-enhancedEcommerce.js
+++ b/app/assets/javascripts/analytics-enhancedEcommerce.js
@@ -22,16 +22,19 @@ var enhancedEcommerceTracking = function (d) {
       return
     }
 
-    lists.forEach(function (list) {
+    for (var idx = 0; idx < lists.length; idx++) {
+      var list = lists[idx];
       var listName = list.getAttribute('data-track-ec-list')
       var positions = list.querySelectorAll('li')
 
-      positions.forEach(function (listItem, i) {
+      for (var i = 0; i < positions.length; i++) {
+        var listItem = positions[i]
         var links = listItem.querySelectorAll('a')
         var positionNumber = i + 1 // Position number needs to start from 1.
 
         if (links.length >= 1) {
-          links.forEach(function (link) {
+          for (var j = 0; j < links.length; j++) {
+            var link = links[j]
             var href = link.href
 
             // Save the position to the item in the DOM
@@ -61,10 +64,10 @@ var enhancedEcommerceTracking = function (d) {
                 list: list
               })
             })
-          })
+          }
         }
-      })
-    })
+      }
+    }
   }
 }
 

--- a/app/assets/javascripts/analytics-enhancedEcommerce.js
+++ b/app/assets/javascripts/analytics-enhancedEcommerce.js
@@ -1,0 +1,71 @@
+var enhancedEcommerceTracking = function (d) {
+  var consentCookie = window.GOVUK.getConsentCookie()
+
+  // Travels up the DOM from `el` to the first ancestor with `selector`. Returns
+  // that element.
+  var ancestor = function (el, selector) {
+    // travel two up the tree to search one up the tree
+    var present = el.parentElement.querySelectorAll(selector)
+
+    if (present.length < 1) {
+      return ancestor(el.parentElement, selector)
+    }
+
+    return present[0]
+  }
+
+  // Start analytics only if we have user consent
+  if (consentCookie && consentCookie["usage"] === true) {
+    var lists = d.querySelectorAll('[data-track-ec-list]')
+
+    if (lists.length === 0) {
+      return
+    }
+
+    lists.forEach(function (list) {
+      var listName = list.getAttribute('data-track-ec-list')
+      var positions = list.querySelectorAll('li')
+
+      positions.forEach(function (listItem, i) {
+        var links = listItem.querySelectorAll('a')
+        var positionNumber = i + 1 // Position number needs to start from 1.
+
+        if (links.length >= 1) {
+          links.forEach(function (link) {
+            var href = link.href
+
+            // Save the position to the item in the DOM
+            link.setAttribute('data-track-ec-position', positionNumber)
+
+            // Send the impression to GA
+            ga('ec:addImpression', {
+              name: href,
+              list: listName,
+              position: positionNumber
+            })
+
+            // Add a listener so that an event will be fired if the link(s) in
+            // the results are clicked.
+            link.addEventListener('click', function (event) {
+              var $a = event.target
+              var position = $a.getAttribute('data-track-ec-position')
+              var href = $a.href
+              var list = ancestor($a, '[data-track-ec-list]').getAttribute('data-track-ec-list')
+
+              ga('ec:addProduct', {
+                name: href,
+                position: position
+              })
+
+              ga('ec:setAction', 'click', {
+                list: list
+              })
+            })
+          })
+        }
+      })
+    })
+  }
+}
+
+window.GOVUK.enhancedEcommerceTracking = enhancedEcommerceTracking

--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -30,9 +30,12 @@ var analyticsInit = function () {
       m.parentNode.insertBefore(a, m)
     })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga')
 
+
     ga('create', trackingId, 'auto')
     ga('set', 'allowAdFeatures', false)
     ga('set', 'anonymizeIp', true)
+
+    ga('require', 'ec')
 
     window.GOVUK.enhancedEcommerceTracking(document)
 

--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -1,6 +1,12 @@
 // Start cookie banner (display settings controlled internally by cookies)
 var element = document.querySelector('[data-module="cookie-banner"]')
-new GOVUK.Modules.CookieBanner().start($(element))
+
+try {
+  if (element) new GOVUK.Modules.CookieBanner().start($(element))
+}
+catch(error) {
+  console.error(error)
+}
 
 var analyticsInit = function () {
   <% if Rails.application.config.analytics_tracking_id.present? %>
@@ -27,6 +33,9 @@ var analyticsInit = function () {
     ga('create', trackingId, 'auto')
     ga('set', 'allowAdFeatures', false)
     ga('set', 'anonymizeIp', true)
+
+    window.GOVUK.enhancedEcommerceTracking(document)
+
     ga('send', 'pageview')
   }
   <% end %>

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,6 +3,7 @@
 //= require govuk_publishing_components/components/cookie-banner
 //= require govuk_publishing_components/lib/cookie-functions
 //= require analytics
+//= require analytics-enhancedEcommerce
 //= require cookies
 window.CookieSettings.start()
 window.GOVUK.analyticsInit()

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -22,12 +22,14 @@
 <% if result_groups(session).empty? %>
   <%= sanitize(t("coronavirus_form.results.no_results")) %>
 <% else %>
-  <% result_groups(session).each do |group| %>
-    <%= render "components/actions-group", {
-      title: group[1][:heading],
-      subsections: group[1][:questions]
-    } %>
-  <% end %>
+  <div data-track-ec-list="Find coronavirus support">
+    <% result_groups(session).each do |group| %>
+      <%= render "components/actions-group", {
+        title: group[1][:heading],
+        subsections: group[1][:questions]
+      } %>
+    <% end %>
+  </div>
 <% end %>
 
 <%= render "components/callout", {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,4 +78,5 @@ Rails.application.routes.draw do
   end
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
+  mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
 end

--- a/spec/javascripts/analytics-enhancedEcommerce.spec.js
+++ b/spec/javascripts/analytics-enhancedEcommerce.spec.js
@@ -1,0 +1,168 @@
+/* global describe it expect beforeEach jasmine spyOn */
+
+describe('Enhanced ecommerce', function () {
+  'use strict'
+  var GOVUK = window.GOVUK
+
+  var snippet = function () {
+    var text = document.createTextNode('Example text')
+    var text2 = document.createTextNode('Example text too')
+
+    var a = document.createElement('a')
+    a.href = 'https://example.com'
+    a.className = 'govuk-link'
+
+    var a2 = document.createElement('a')
+    a2.href = 'https://example.com/?two'
+    a2.className = 'govuk-link'
+
+    var li = document.createElement('li')
+    var li2 = document.createElement('li')
+
+    var ul = document.createElement('ul')
+    ul.setAttribute('data-track-ec-list', 'ecommerce-list-name')
+
+    var wrapper = document.createElement('div')
+
+    a.appendChild(text)
+    a2.appendChild(text2)
+    li.appendChild(a)
+    li2.appendChild(a2)
+    ul.appendChild(li)
+    ul.appendChild(li2)
+    wrapper.appendChild(ul)
+
+    return wrapper
+  }
+
+  describe('with consent', function () {
+    beforeEach( function () {
+      GOVUK.setConsentCookie({
+        'essential': true,
+        'settings': false,
+        'usage': true,
+        'campaigns': false,
+      })
+
+      GOVUK.analyticsInit()
+
+      spyOn(window, 'ga')
+    })
+
+    it('has the cookies are set correctly', function () {
+      expect(GOVUK.getConsentCookie()).toEqual({
+        usage: true,
+        essential: true,
+        campaigns: false,
+        settings: false,
+      })
+    })
+
+    it('sets the correct data attributes on the list', function () {
+      var $clonedSnippet = snippet()
+      var beforeLink = $clonedSnippet.querySelectorAll('a')
+
+      expect(beforeLink[0].getAttribute('data-track-ec-position')).toBeNull()
+      expect(beforeLink[1].getAttribute('data-track-ec-position') ).toBeNull()
+
+      GOVUK.enhancedEcommerceTracking($clonedSnippet)
+
+      var afterLink = $clonedSnippet.querySelectorAll('a')
+
+      expect(afterLink[0].getAttribute('data-track-ec-position')).toEqual('1')
+      expect(afterLink[1].getAttribute('data-track-ec-position')).toEqual('2')
+    })
+
+    it('calls `ga()` to add an ecommerce impression', function () {
+      var $clonedSnippet = snippet()
+      GOVUK.enhancedEcommerceTracking($clonedSnippet)
+
+      expect(ga).toHaveBeenCalled()
+
+      expect(ga).toHaveBeenCalledWith(
+        'ec:addImpression',
+        { name: 'https://example.com/', list: 'ecommerce-list-name', position: 1 }
+      )
+    })
+
+    it('calls `ga()` when clicked', function () {
+      var $clonedSnippet = snippet()
+      GOVUK.enhancedEcommerceTracking($clonedSnippet)
+
+      $clonedSnippet.querySelector('a').addEventListener('click', function (event) {
+        event.preventDefault()
+      })
+
+      $clonedSnippet.querySelector('a').click()
+
+      expect(ga).toHaveBeenCalled()
+
+      expect(ga).toHaveBeenCalledWith(
+        'ec:addProduct',
+        { name: 'https://example.com/', position: '1' }
+      )
+
+      expect(ga).toHaveBeenCalledWith(
+        'ec:setAction',
+        'click',
+        {
+          list: 'ecommerce-list-name'
+        }
+      )
+    })
+  })
+
+  describe('without consent', function () {
+    beforeEach(function () {
+      GOVUK.setConsentCookie({
+        'essential': true,
+        'settings': false,
+        'usage': false,
+        'campaigns': false,
+      })
+
+      spyOn(window, 'ga')
+    })
+
+    it('has the cookies are set correctly', function () {
+      expect(GOVUK.getConsentCookie()).toEqual({
+        usage: false,
+        essential: true,
+        campaigns: false,
+        settings: false,
+      })
+    })
+
+    it("doesn't set the correct data attributes on the list", function () {
+      var $clonedSnippet = snippet()
+      var beforeLink = $clonedSnippet.querySelector('a')
+
+      expect(beforeLink.getAttribute('data-track-ec-position')).toBeNull()
+
+      GOVUK.enhancedEcommerceTracking($clonedSnippet)
+
+      var afterLink = $clonedSnippet.querySelector('a')
+
+      expect(beforeLink.getAttribute('data-track-ec-position')).toBeNull()
+    })
+
+    it("doesn't call `ga()` to add an ecommerce impression", function () {
+      var $clonedSnippet = snippet()
+      GOVUK.enhancedEcommerceTracking($clonedSnippet)
+
+      expect(ga).not.toHaveBeenCalled()
+    })
+
+    it("doesn't call `ga()` when clicked", function () {
+      var $clonedSnippet = snippet()
+      GOVUK.enhancedEcommerceTracking($clonedSnippet)
+
+      $clonedSnippet.querySelector('a').addEventListener('click', function (event) {
+        event.preventDefault()
+      })
+
+      $clonedSnippet.querySelector('a').click()
+      expect(ga).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,54 @@
+# path to parent directory of src_files
+# relative path from Rails.root
+# defaults to app/assets/javascripts
+src_dir: "app/assets/javascripts"
+
+# path to additional directory of source file that are not part of assets pipeline and need to be included
+# relative path from Rails.root
+# defaults to []
+# include_dir:
+#   - ../mobile_app/public/js
+
+# path to parent directory of css_files
+# relative path from Rails.root
+# defaults to app/assets/stylesheets
+# css_dir: "app/assets/stylesheets"
+
+# list of file expressions to include as source files
+# relative path from src_dir
+src_files:
+  - "application.js"
+
+# list of file expressions to include as css files
+# relative path from css_dir
+# css_files:
+
+# path to parent directory of spec_files
+# relative path from Rails.root
+#
+# Alternatively accept an array of directory to include external spec files
+# spec_dir:
+#   - spec/javascripts
+#   - ../engine/spec/javascripts
+#
+# defaults to spec/javascripts
+spec_dir: spec/javascripts
+
+# list of file expressions to include as helpers into spec runner
+# relative path from spec_dir
+helpers:
+  - "helpers/**/*.js"
+
+# list of file expressions to include as specs into spec runner
+# relative path from spec_dir
+spec_files:
+  - "**/*[Ss]pec.js"
+
+# path to directory of temporary files
+# (spec runner and asset cache)
+# defaults to tmp/jasmine
+tmp_dir: "tmp/jasmine"
+
+use_phantom_gem: false
+
+random: false


### PR DESCRIPTION
What
----

Add enhanced ecommerce to help the analytics reporting for this service. 

The results page for this service is different depending on what a user needs help with - because of this we can't tell what links are being seen the most, and what links are being clicked the most. The ecommerce plugin will help us do that by monitoring what positions the different links appear, and will help us to see what links are most useful for users. We can then analyse this information to improve the quality of the results.


How to review
-------------

Use a private mode in your browser.

Check that Google Analytics is not being blocked by your browser

1. Go to the service
1. Accept cookies
1. Go through service
1. On results page:
   1. Check that the page view is being fired with all the impressions of the results
   1. Check that when a link is clicked it is firing a GA event

Close the browser completely.

In another private browser window:

1. Go to the service
1. Don't accept cookies
1. Go through the service
1. On the results page:
   1. Check that the page view isn't fired at all
   1. Check that no events are fired when a link is clicked

Links
-----

Trello card 👉 https://trello.com/c/mRtFakg3

