### PR TITLE
Change self employment flow

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,7 +274,6 @@ en:
                 label: "Not sure"
             skip_next_question_options:
               - "Yes"
-              - "Not sure"
             custom_select_error: "Select yes if you’re self-employed or a sole trader"
           have_you_been_made_unemployed:
             title: "Have you been told to stop working?"


### PR DESCRIPTION
What
----

No longer skips the employment questions if a user is unsure about being self employed.

Previously they would have skipped the following two questions.

How to review
-------------

- Review the code.
- Run the app locally.  Select you need help with 'Unemployment'.  Check whether selecting the different options on 'Are you self employed' question skips the next two questions.

Links
-----

Trello card: https://trello.com/c/dbly3cUo