### PR TITLE
ci: Oops, pulling the Ruby version from `.ruby-version` is the default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-
     - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: .ruby-version
 
     - name: Install PostgreSQL 11 client
       run: sudo apt-get -yqq install libpq-dev


### PR DESCRIPTION
What
----

Simplicity. We can use the [defaults](https://github.com/ruby/setup-ruby#supported-version-syntax) of the `ruby/setup-ruby` Action, and slim down our tests.yml file - again...

How to review
-------------

Observe that CI still runs under 2.6.5.

Links
-----

n/a

