### PR TITLE
Updates to 'if you do not feel safe' answers

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,9 +383,9 @@ en:
           - "Not sure"
         items:
           - text: "If you’re in immediate danger call 999 and ask for the Police."
-          - text: "If you’re in danger and unable to talk on the phone, call 999, and then press 55."
+          - text: "If you’re in danger and unable to talk on the phone, call 999, then press 55 when prompted."
           - text: 'Call the National Domestic Abuse Helpline on <a href="tel:0808 2000 247" class="govuk-link">0808 2000 247</a>'
-          - text: 'If you’re a child call Childline on <a href="tel:0800 1111" class="govuk-link">0800 1111</a>'
+          - text: 'If you’re a child or young person call Childline on <a href="tel:0800 1111" class="govuk-link">0800 1111</a>'
           - text: 'Find helplines <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse" class="govuk-link">if you’re a victim of domestic abuse or feel at risk of abuse</a>, or if you are a <a href="https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services" class="govuk-link">victim or witness of a crime</a> (these pages have no quick escape)'
           - text: "Get safety advice for survivors (Women’s Aid)"
             href: "https://www.womensaid.org.uk/covid-19-coronavirus-safety-advice-for-survivors/"


### PR DESCRIPTION
https://trello.com/c/Z3M5YAU3/339-small-content-changes-to-results-page

What
----

Change: 
If you’re in danger and unable to talk on the phone, call 999, and then press 55.
TO: 
If you’re in danger and unable to talk on the phone, call 999, and then press 55 when prompted.

Change: 
If you’re a child call Childline on 0800 1111
TO:
If you’re a child or young person call Childline on 0800 1111

Why:
To be more factually accurate 

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Describe the steps required to review and test the changes.

Links
-----

Add links to any relevant [Trello cards](https://trello.com/b/9Pvq5z2n/govuk-coronavirus-services-team-doing-board),
Zendesk tickets or Sentry issues.

