### PR TITLE
Set the analytics transport mechanism to beacon

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -34,6 +34,7 @@ var analyticsInit = function () {
     ga('create', trackingId, 'auto')
     ga('set', 'allowAdFeatures', false)
     ga('set', 'anonymizeIp', true)
+    ga('set', 'transport', 'beacon')
 
     ga('require', 'ec')
 


### PR DESCRIPTION
What
----

Set the Google Analytics transport mechanism to `beacon`, which is a protocol made for sending small amounts of data asynchronously without blocking the browser. This should make tracking the clicks on links to another domain (such as on the results page) more reliable.

How to review
-------------

1. Open site in private mode.
2. Accept cookies
3. Check if the GA events are being fired using your debugging tool of choice.


Links
-----

Related to Trello card: https://trello.com/c/mRtFakg3

Further reading:
 - [sendBeacon on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon)

