### PR TITLE
Add enhanced ecommerce link click tracking

### DIFF
--- a/app/assets/javascripts/analytics-enhancedEcommerce.js
+++ b/app/assets/javascripts/analytics-enhancedEcommerce.js
@@ -54,6 +54,9 @@ var enhancedEcommerceTracking = function (d) {
               var position = $a.getAttribute('data-track-ec-position')
               var href = $a.href
               var list = ancestor($a, '[data-track-ec-list]').getAttribute('data-track-ec-list')
+              var subsection = ancestor($a, '[data-ec-list-subsection]').getAttribute('data-ec-list-subsection')
+
+              ga('set', 'dimension1', subsection)
 
               ga('ec:addProduct', {
                 name: href,
@@ -62,6 +65,13 @@ var enhancedEcommerceTracking = function (d) {
 
               ga('ec:setAction', 'click', {
                 list: list
+              })
+
+              ga('send', {
+                hitType: 'event',
+                eventCategory: 'UX',
+                eventAction: 'click',
+                eventLabel: 'Results'
               })
             })
           }

--- a/app/views/components/_actions-group.html.erb
+++ b/app/views/components/_actions-group.html.erb
@@ -9,20 +9,22 @@
     </div>
     <div class="govuk-grid-column-two-thirds">
       <% subsections.each do |subsection| %>
-        <h3 class="govuk-heading-s"><%= subsection[:title] %></h3>
-        <% if subsection[:items].any? %>
-          <ul class="govuk-list">
-            <% subsection[:items].each do |item| %>
-              <li>
-                <% if item[:href] %>
-                  <%= link_to item[:text], item[:href], class: "govuk-link" %>
-                <% else %>
-                  <%= sanitize(item[:text]) %>
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
+        <div data-ec-list-subsection="<%= subsection[:title] %>">
+          <h3 class="govuk-heading-s"><%= subsection[:title] %></h3>
+          <% if subsection[:items].any? %>
+            <ul class="govuk-list">
+              <% subsection[:items].each do |item| %>
+                <li>
+                  <% if item[:href] %>
+                    <%= link_to item[:text], item[:href], class: "govuk-link" %>
+                  <% else %>
+                    <%= sanitize(item[:text]) %>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/spec/javascripts/analytics-enhancedEcommerce.spec.js
+++ b/spec/javascripts/analytics-enhancedEcommerce.spec.js
@@ -20,7 +20,12 @@ describe('Enhanced ecommerce', function () {
     var li2 = document.createElement('li')
 
     var ul = document.createElement('ul')
-    ul.setAttribute('data-track-ec-list', 'ecommerce-list-name')
+
+    var subsection = document.createElement('div')
+    subsection.setAttribute('data-ec-list-subsection', 'ecommerce-subsection-name')
+
+    var section = document.createElement('section')
+    section.setAttribute('data-track-ec-list', 'ecommerce-list-name')
 
     var wrapper = document.createElement('div')
 
@@ -30,7 +35,9 @@ describe('Enhanced ecommerce', function () {
     li2.appendChild(a2)
     ul.appendChild(li)
     ul.appendChild(li2)
-    wrapper.appendChild(ul)
+    subsection.appendChild(ul)
+    section.appendChild(subsection)
+    wrapper.appendChild(section)
 
     return wrapper
   }
@@ -107,6 +114,15 @@ describe('Enhanced ecommerce', function () {
         'click',
         {
           list: 'ecommerce-list-name'
+        }
+      )
+
+      expect(ga).toHaveBeenCalledWith(
+        'send', {
+          hitType: 'event',
+          eventCategory: 'UX',
+          eventAction: 'click',
+          eventLabel: 'Results'
         }
       )
     })


### PR DESCRIPTION
## What

Clicks on link in the results page weren't being successfully tracked by the enhanced commerce Google Analytics plugin.

Turns out that any enhanced ecommerce events fired need to piggyback onto  a subsequent event - for example, clicks are added to the `ga()` function which bundles them into the next event being fired into GA.

A click event is now fired when a user clicks on a link. This event now includes the enhanced ecommerce information and a custom dimension that reports on which subsection the link is in.

A `data-ec-list-subsection` was added to each subsection to allow the subsection title to be read without brittly trawling though the DOM.

How to review
-------------

1. Visit site in the browser's private mode
1. Accept cookies
1. Fill in the form
1. On the results page, check that the ecommerce `ec:addProduct`, `ec:setAction`, and `send` events are fired
1. Check that these events have `dimension1` set to be the subsection title.


Links
-----

Hopefully the last part of Trello card 👉 https://trello.com/c/mRtFakg3

