### PR TITLE
Add devolved links to results page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ private
   end
 
   def first_question_path
-    need_help_with_path
+    nation_path
   end
 
   def group; end
@@ -56,8 +56,14 @@ private
   end
 
   def check_first_question_answered
+    unless first_question_seen?
+      redirect_to nation_url
+    end
+  end
+
+  def check_filter_question_answered
     if questions_to_ask.blank?
-      redirect_to need_help_with_url
+      redirect_to nation_url
     end
   end
 

--- a/app/controllers/coronavirus_form/able_to_leave_controller.rb
+++ b/app/controllers/coronavirus_form/able_to_leave_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::AbleToLeaveController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
 
   def submit
     @form_responses = {

--- a/app/controllers/coronavirus_form/afford_food_controller.rb
+++ b/app/controllers/coronavirus_form/afford_food_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::AffordFoodController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
   before_action :check_current_question_selected
 
   def submit

--- a/app/controllers/coronavirus_form/afford_rent_mortgage_bills_controller.rb
+++ b/app/controllers/coronavirus_form/afford_rent_mortgage_bills_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::AffordRentMortgageBillsController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
   before_action :check_current_question_selected
 
   def submit

--- a/app/controllers/coronavirus_form/are_you_off_work_ill_controller.rb
+++ b/app/controllers/coronavirus_form/are_you_off_work_ill_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::AreYouOffWorkIllController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
   before_action :check_current_question_selected
 
   def submit

--- a/app/controllers/coronavirus_form/feel_safe_controller.rb
+++ b/app/controllers/coronavirus_form/feel_safe_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::FeelSafeController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
   before_action :check_current_question_selected
 
   def submit

--- a/app/controllers/coronavirus_form/get_food_controller.rb
+++ b/app/controllers/coronavirus_form/get_food_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::GetFoodController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
   before_action :check_current_question_selected
 
   def submit

--- a/app/controllers/coronavirus_form/have_somewhere_to_live_controller.rb
+++ b/app/controllers/coronavirus_form/have_somewhere_to_live_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::HaveSomewhereToLiveController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
   before_action :check_current_question_selected
 
   def submit

--- a/app/controllers/coronavirus_form/have_you_been_evicted_controller.rb
+++ b/app/controllers/coronavirus_form/have_you_been_evicted_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::HaveYouBeenEvictedController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
   before_action :check_current_question_selected
 
   def submit

--- a/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
+++ b/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::HaveYouBeenMadeUnemployedController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
   before_action :check_current_question_selected
 
   def submit

--- a/app/controllers/coronavirus_form/living_with_vulnerable_controller.rb
+++ b/app/controllers/coronavirus_form/living_with_vulnerable_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::LivingWithVulnerableController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
   before_action :check_current_question_selected
 
   def submit

--- a/app/controllers/coronavirus_form/mental_health_worries_controller.rb
+++ b/app/controllers/coronavirus_form/mental_health_worries_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::MentalHealthWorriesController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
   before_action :check_current_question_selected
 
   def submit

--- a/app/controllers/coronavirus_form/nation_controller.rb
+++ b/app/controllers/coronavirus_form/nation_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::NationController < ApplicationController
+  def submit
+    @form_responses = {
+      nation: strip_tags(params[:nation]).presence,
+    }
+
+    invalid_fields = validate_radio_field(
+      controller_name,
+      group,
+      radio: @form_responses[:nation],
+    )
+
+    if invalid_fields.any?
+      flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
+      render controller_path
+    else
+      update_session_store
+      redirect_to need_help_with_url
+    end
+  end
+
+private
+
+  def update_session_store
+    session[:nation] = @form_responses[:nation]
+  end
+
+  def group
+    "location"
+  end
+
+  def previous_path
+    "/"
+  end
+end

--- a/app/controllers/coronavirus_form/need_help_with_controller.rb
+++ b/app/controllers/coronavirus_form/need_help_with_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::NeedHelpWithController < ApplicationController
+  before_action :check_first_question_answered
+
   def submit
     @form_responses = {
       need_help_with: Array(params[:need_help_with]).map { |item| strip_tags(item).presence }.compact,
@@ -76,7 +78,7 @@ private
   end
 
   def previous_path
-    "/"
+    nation_path
   end
 
   def group

--- a/app/controllers/coronavirus_form/self_employed_controller.rb
+++ b/app/controllers/coronavirus_form/self_employed_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::SelfEmployedController < ApplicationController
-  before_action :check_first_question_answered
+  before_action :check_filter_question_answered
   before_action :check_current_question_selected
 
   def submit

--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -41,6 +41,10 @@ module QuestionsHelper
     questions_to_ask.first
   end
 
+  def first_question_seen?
+    session[:nation].present?
+  end
+
   def last_question
     questions_to_ask.last
   end

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -23,7 +23,7 @@ module ResultsHelper
 
   def filter_results_by_nation(question_results)
     question_results[:items] = question_results[:items].select do |item|
-      item[:show_to_nations].nil? || item[:show_to_nations].include?(session[:where_live])
+      item[:show_to_nations].nil? || item[:show_to_nations].include?(session[:nation])
     end
     question_results
   end

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -13,11 +13,19 @@ module ResultsHelper
   end
 
   def filter_questions_by_session(group_key, session)
-    I18n.t("results_link.#{group_key}").each_with_object([]) do |question, array|
+    group = I18n.t("results_link.#{group_key}").dup
+    group.each_with_object([]) do |question, array|
       if question[1][:show_options].include?(session[question[0]])
-        array << I18n.t("results_link.#{group_key}.#{question[0]}")
+        array << filter_results_by_nation(I18n.t("results_link.#{group_key}.#{question[0]}").dup)
       end
     end
+  end
+
+  def filter_results_by_nation(question_results)
+    question_results[:items] = question_results[:items].select do |item|
+      item[:show_to_nations].nil? || item[:show_to_nations].include?(session[:where_live])
+    end
+    question_results
   end
 
   def relevant_group_keys
@@ -27,7 +35,7 @@ module ResultsHelper
     # :help and :filter_questions which are not really groups
     # empty.
     if selected_groups.blank?
-      return I18n.t("coronavirus_form.groups").keys - %i[filter_questions help leave_home]
+      return I18n.t("coronavirus_form.groups").keys - %i[filter_questions help leave_home location]
     end
 
     selected_groups # Otherwise we can use selected groups

--- a/app/views/coronavirus_form/nation.html.erb
+++ b/app/views/coronavirus_form/nation.html.erb
@@ -1,0 +1,4 @@
+<%= render partial: "question_radio_buttons", locals: {
+  question: controller_name,
+  group: group,
+} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,9 +103,9 @@ en:
   session_expired:
     title: Your session has ended due to inactivity
     body_text: |
-      <p class="govuk-body">Your session has ended because you have not done anything for 4 hours. You'll have to start again.</p>
+      <p class="govuk-body">Your session has ended because you have not done anything for 4 hours. You’ll have to start again.</p>
 
-      <p class="govuk-body">We do this for your security. We've deleted all the details you entered to protect your data.</p>
+      <p class="govuk-body">We do this for your security. We’ve deleted all the details you entered to protect your data.</p>
 
       <h2 class="govuk-heading-m">If you didn’t expect to see this page</h2>
       <p class="govuk-body">You may be seeing this page because you’ve turned off cookies in your browser. You’ll need to <a class="govuk-link" href="https://ico.org.uk/your-data-matters/online/cookies/" rel="external" target="_blank">turn cookies on</a> before you can use this service.</p>
@@ -145,7 +145,7 @@ en:
           text_html: These cookies are required for this service to operate. We do not need to ask permission to use them.
           cookies:
             - - text: cookie_preferences_set
-              - text: Lets us know whether you've already set your cookies preferences.
+              - text: Lets us know whether you’ve already set your cookies preferences.
               - text: 1 year
             - - text: cookie_preferences
               - text: Let us know what your cookie preferences are.
@@ -202,7 +202,6 @@ en:
                 label: "Wales"
               optopn_northern_ireland:
                 label: "Northern Ireland"
-            custom_select_error: "Select where you live"
       filter_questions:
         questions:
           need_help_with:
@@ -404,22 +403,34 @@ en:
           - text: 'Find helplines <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse" class="govuk-link">if you’re a victim of domestic abuse or feel at risk of abuse</a>, or if you are a <a href="https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services" class="govuk-link">victim or witness of a crime</a> (these pages have no quick escape)'
           - text: "Get safety advice for survivors (Women’s Aid)"
             href: "https://www.womensaid.org.uk/covid-19-coronavirus-safety-advice-for-survivors/"
-          - text: "Get help if you’re in Northern Ireland (Nexus NI)"
+          - text: "Get help from Nexus NI"
             href: "https://nexusni.org/domestic-and-sexual-abuse-24-hour-helpline/"
-          - text: "Get help if you live in Wales (Live Fear Free)"
+            show_to_nations:
+              - Northern Ireland
+          - text: "Get help from Live Fear Free"
             href: "https://gov.wales/live-fear-free"
-          - text: "Get help if you live in Scotland (Women's Aid Scotland)"
+            show_to_nations:
+              - Wales
+          - text: "Get help from Women’s Aid Scotland"
             href: "https://womensaid.scot/"
+            show_to_nations:
+              - Scotland
           - text: "Get help for children (Childline)"
             href: "https://www.childline.org.uk/"
-          - text: "Get advice if you’re a child in Wales"
+          - text: "Get advice for children (Children’s Commissioner for Wales)"
             href: "https://www.childcomwales.org.uk/coronavirus/"
+            show_to_nations:
+              - Wales
           - text: "Contact NSPCC if you’re concerned about a child"
             href: "https://www.nspcc.org.uk/keeping-children-safe/our-services/nspcc-helpline/"
-          - text: "Find helplines if you’re an older person living in Wales"
+          - text: "Find helplines if you’re an older person (Older People’s Commissioner for Wales)"
             href: "https://www.olderpeoplewales.com/en/coronavirus.aspx"
-          - text: "Find victim support helplines if you live in Wales (in Welsh)"
+            show_to_nations:
+              - Wales
+          - text: "Find victim support helplines (this page is in Welsh)"
             href: "https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales"
+            show_to_nations:
+              - Wales
     paying_bills:
       afford_rent_mortgage_bills:
         title: "If you’re finding it hard to afford rent, your mortgage or bills"
@@ -427,26 +438,52 @@ en:
           - "Yes"
           - "Not sure"
         items:
-          - text: "What to do if you’re finding it hard to pay rent"
+          - text: "Your rights if you’re finding it hard to pay rent"
             href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
-          - text: "Help you can get if you’re finding it hard to pay energy bills"
-            href: "https://www.gov.uk/government/news/government-agrees-measures-with-energy-industry-to-support-vulnerable-people-through-covid-19"
           - text: "What to do if you cannot pay your rent or mortgage (Shelter)"
             href: "https://england.shelter.org.uk/housing_advice/coronavirus"
-          - text: "What to do if you cannot pay your rent, mortgage or bills (Citizens Advice)"
+            show_to_nations:
+              - England
+          - text: "What to do if you cannot pay your rent or mortgage (Shelter Scotland)"
+            href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
+            show_to_nations:
+              - Scotland
+          - text: "What to do if you cannot pay your rent or mortgage (Shelter Cymru)"
+            href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
+            show_to_nations:
+              - Wales
+          - text: "What to do if you cannot pay your bills or mortgage (Citizens Advice)"
             href: "https://www.citizensadvice.org.uk/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/"
+            show_to_nations:
+              - England
+          - text: "What to do if you cannot pay your bills or mortgage (Citizens Advice Scotland)"
+            href: "https://www.citizensadvice.org.uk/scotland/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/"
+            show_to_nations:
+              - Scotland
+          - text: "What to do if you cannot pay your bills or mortgage (Citizens Advice)"
+            href: "https://www.citizensadvice.org.uk/wales/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/"
+            show_to_nations:
+              - Wales
+          - text: Get help from Citizens Advice
+            href: "https://www.citizensadvice.org.uk/about-us/northern-ireland/"
+            show_to_nations:
+              - Northern Ireland
           - text: "Get help from the housing and debt helpline for Northern Ireland (Housing Rights)"
             href: "https://www.housingrights.org.uk/"
-          - text: "What to do if you’re finding it hard to pay rent and you live in Wales"
+            show_to_nations:
+              Northern Ireland
+          - text: "What to do if you’re finding it hard to pay rent (Welsh Government)"
             href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
-          - text: "Get coronavirus housing advice for Wales (Shelter)"
-            href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-          - text: "Find out about your rights if you have a private landlord in Scotland"
+            show_to_nations:
+              - Wales
+          - text: "Find out about your rights if you have a private landlord (mygov.scot)"
             href: "https://www.mygov.scot/private-rental-rights/"
-          - text: "Find out about your rights if you have a social landlord in Scotland"
+            show_to_nations:
+              - Scotland
+          - text: "Find out about your rights if you have a social landlord (mygov.scot)"
             href: "https://www.mygov.scot/social-rental-rights/"
-          - text: "Get coronavirus housing advice for Scotland (Shelter)"
-            href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
+            show_to_nations:
+              - Scotland
     getting_food:
       afford_food:
         title: "If you’re finding it hard to afford food"
@@ -460,13 +497,21 @@ en:
             href: "https://www.gov.uk/apply-free-school-meals"
           - text: "Apply for Healthy Start vouchers if you’re 10 or more weeks pregnant or have a child under 4"
             href: "https://www.healthystart.nhs.uk/healthy-start-vouchers/do-i-qualify/"
-          - text: "Find out if you’re eligible for the Scottish Welfare Fund if you live in Scotland"
+          - text: "Find out if you’re eligible for the Scottish Welfare Fund (mygov.scot)"
             href: "https://www.mygov.scot/scottish-welfare-fund/"
-          - text: "Find out if you can get a grant if you’re a parent or looking after a child in Scotland"
+            show_to_nations:
+              - Scotland
+          - text: "Find out if you can get a grant if you’re a parent or looking after a child (mygov.scot)"
             href: "https://www.mygov.scot/best-start-grant-best-start-foods/"
-          - text: "Check if you’re eligible for the Discretionary Assistance Fund if you live in Wales"
+            show_to_nations:
+              - Scotland
+          - text: "Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)"
             href: "https://gov.wales/discretionary-assistance-fund-daf"
-          - text: "If you’re in Northern Ireland call the coronavirus Community Helpline on <a href=\"tel:+448088020020\" class=\"govuk-link\">0808 802 0020</a>, email <a href=\"mailto:covid19@adviceni.net\" class=\"govuk-link\">covid19@adviceni.net</a> or text ‘ACTION’ to 81025"
+            show_to_nations:
+              - Wales
+          - text: "Call the coronavirus Community Helpline for Northern Ireland on <a href=\"tel:+448088020020\" class=\"govuk-link\">0808 802 0020</a>, email <a href=\"mailto:covid19@adviceni.net\" class=\"govuk-link\">covid19@adviceni.net</a> or text ‘ACTION’ to 81025"
+            show_to_nations:
+              - Northern Ireland
       get_food:
         title: "If you’re unable to get food"
         show_options:
@@ -497,22 +542,58 @@ en:
             href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work"
           - text: "What to do if your employer has told you not to work (Citizens Advice)"
             href: "https://www.citizensadvice.org.uk/work/coronavirus-if-your-employer-has-told-you-not-to-work/"
+            show_to_nations:
+              - England
+          - text: "What to do if your employer has told you not to work (Citizens Advice Scotland)"
+            href: "https://www.citizensadvice.org.uk/scotland/work/coronavirus-if-your-employer-has-told-you-not-to-work/"
+            show_to_nations:
+              - Scotland
+          - text: "What to do if your employer has told you not to work (Citizens Advice)"
+            href: "https://www.citizensadvice.org.uk/wales/work/coronavirus-if-your-employer-has-told-you-not-to-work/"
+            show_to_nations:
+              - Wales
           - text: "Find out about the financial support you might be able to get (Acas)"
             href: "https://www.acas.org.uk/coronavirus/if-the-employer-needs-to-close-the-workplace"
           - text: "Get information on applying for Universal Credit (Citizens Advice)"
             href: "https://www.citizensadvice.org.uk/benefits/universal-credit/"
-          - text: "Get advice on benefits if you live in Northern Ireland (Advice NI)"
+            show_to_nations:
+              - England
+          - text: "Get information on applying for Universal Credit (Citizens Advice Scotland)"
+            href: "https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/"
+            show_to_nations:
+              - Scotland
+          - text: "Get information on applying for Universal Credit (Citizens Advice)"
+            href: "https://www.citizensadvice.org.uk/wales/benefits/universal-credit/"
+            show_to_nations:
+              - Wales
+          - text: Get help from Citizens Advice
+            href: "https://www.citizensadvice.org.uk/about-us/northern-ireland/"
+            show_to_nations:
+              - Northern Ireland
+          - text: "Get advice on benefits (Advice NI)"
             href: "https://www.adviceni.net/"
-          - text: "Contact Working Wales if you’ve been made redundant in Wales"
+            show_to_nations:
+              - Northern Ireland
+          - text: "Contact Working Wales if you’ve been made redundant"
             href: "https://workingwales.gov.wales/"
+            show_to_nations:
+              - Wales
           - text: "Contact Citizens Advice Wales"
             href: "https://www.citizensadvice.org.uk/wales/about-us/contact-us/contact-us/contact-us/"
-          - text: "Check if you’re eligible for the Discretionary Assistance Fund if you live in Wales"
+            show_to_nations:
+              - Wales
+          - text: "Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)"
             href: "https://gov.wales/discretionary-assistance-fund-daf"
-          - text: "Get help if you’ve been made redundant in Scotland"
+            show_to_nations:
+              - Wales
+          - text: "Get help if you’ve been made redundant (mygov.scot)"
             href: "https://www.mygov.scot/help-redundancy/"
-          - text: "Find help with benefits if you live in Scotland"
+            show_to_nations:
+              - Scotland
+          - text: "Find help with benefits (mygov.scot)"
             href: "https://www.mygov.scot/benefits-support/"
+            show_to_nations:
+              - Scotland
       are_you_off_work_ill:
         title: "If you’re off work because you’re ill or self isolating"
         show_options:
@@ -524,8 +605,10 @@ en:
             href: "https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay"
           - text: "Find out about the help you can get if you’re self-employed or work in the gig economy (Money Advice Service)"
             href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
-          - text: "Check if you’re eligible for the Discretionary Assistance Fund if you live in Wales"
+          - text: "Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)"
             href: "https://gov.wales/discretionary-assistance-fund-daf"
+            show_to_nations:
+              - Wales
       self_employed:
         title: "If you’re self employed or a sole trader"
         show_options:
@@ -538,12 +621,32 @@ en:
             href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-if-youre-self-employed"
           - text: "Get information on applying for Universal Credit (Citizens Advice)"
             href: "https://www.citizensadvice.org.uk/benefits/universal-credit/"
-          - text: "Get advice on benefits if you live in Northern Ireland (Advice NI)"
+            show_to_nations:
+              - England
+          - text: "Get information on applying for Universal Credit (Citizens Advice Scotland)"
+            href: "https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/"
+            show_to_nations:
+              - Scotland
+          - text: "Get information on applying for Universal Credit (Citizens Advice)"
+            href: "https://www.citizensadvice.org.uk/wales/benefits/universal-credit/"
+            show_to_nations:
+              - Wales
+          - text: Get help from Citizens Advice
+            href: "https://www.citizensadvice.org.uk/about-us/northern-ireland/"
+            show_to_nations:
+              - Northern Ireland
+          - text: "Get advice on benefits (Advice NI)"
             href: "https://www.adviceni.net/"
-          - text: "Check if you’re eligible for the Discretionary Assistance Fund if you live in Wales"
+            show_to_nations:
+              - Northern Ireland
+          - text: "Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)"
             href: "https://gov.wales/discretionary-assistance-fund-daf"
-          - text: "Find help with benefits if you live in Scotland"
+            show_to_nations:
+              - Wales
+          - text: "Find help with benefits (mygov.scot)"
             href: "https://www.mygov.scot/benefits-support/"
+            show_to_nations:
+              - Scotland
     going_in_to_work:
       living_with_vulnerable:
         title: "If you’re worried about going in to work"
@@ -555,6 +658,20 @@ en:
             href: "https://www.gov.uk/government/publications/full-guidance-on-staying-at-home-and-away-from-others/full-guidance-on-staying-at-home-and-away-from-others"
           - text: "What to do if you’re worried about going to work because of coronavirus (Citizens Advice)"
             href: "https://www.citizensadvice.org.uk/work/coronavirus-if-youre-worried-about-working/"
+            show_to_nations:
+              - England
+          - text: "What to do if you’re worried about going to work because of coronavirus (Citizens Advice Scotland)"
+            href: "https://www.citizensadvice.org.uk/scotland/work/coronavirus-if-youre-worried-about-working/"
+            show_to_nations:
+              - Scotland
+          - text: "What to do if you’re worried about going to work because of coronavirus (Citizens Advice)"
+            href: "https://www.citizensadvice.org.uk/wales/work/coronavirus-if-youre-worried-about-working/"
+            show_to_nations:
+              - Wales
+          - text: Get help from Citizens Advice
+            href: "https://www.citizensadvice.org.uk/about-us/northern-ireland/"
+            show_to_nations:
+              - Northern Ireland
     somewhere_to_live:
       have_somewhere_to_live:
         title: "If you do not have somewhere to live or might become homeless"
@@ -565,15 +682,31 @@ en:
         items:
           - text: "Get help if you’re legally homeless (Shelter)"
             href: "https://england.shelter.org.uk/housing_advice/homelessness/rules/legally_homeless"
-          - text: 'If you’re in Northern Ireland call the Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
-          - text: "Get help from the housing and debt helpline for Northern Ireland (Housing Rights)"
+            show_to_nations:
+              - England
+          - text: "Get help if you’re homeless (Shelter Cymru)"
+            href: "https://sheltercymru.org.uk/get-advice/homelessness/"
+            show_to_nations:
+              - Wales
+          - text: 'Call the Northern Ireland Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
+            show_to_nations:
+              - Northern Ireland
+          - text: "Get help from Housing Rights housing and debt helpline"
             href: "https://www.housingadviceni.org/homeless/coronavirus"
-          - text: "Get coronavirus housing information for Wales (Shelter)"
+            show_to_nations:
+              - Northern Ireland
+          - text: "Get coronavirus housing information (Shelter Cymru)"
             href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-          - text: "Get help if you’re homeless in Scotland"
+            show_to_nations:
+              - Wales
+          - text: "Get help if you’re homeless (mygov.scot)"
             href: "https://www.mygov.scot/homelessness/"
+            show_to_nations:
+              - Scotland
           - text: "Get help if you’re homeless from Shelter Scotland"
             href: "https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness"
+            show_to_nations:
+              - Scotland
       have_you_been_evicted:
         title: "If you’ve been evicted or might be soon"
         show_options:
@@ -585,19 +718,35 @@ en:
             href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
           - text: "Get coronavirus housing advice (Shelter)"
             href: "https://england.shelter.org.uk/housing_advice/coronavirus"
-          - text: 'If you’re in Northern Ireland call the Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
-          - text: "Find advice from the Housing Executive if you live in Northern Ireland"
-            href: "https://www.nihe.gov.uk/My-Housing-Executive/Advice-for-Housing-Executive-Tenants/Covid-19-(Coronavirus)"
-          - text: "Get advice if you live in Northern Ireland (Housing Rights)"
-            href: "https://www.housingadviceni.org/coronavirus"
-          - text: "Get information on evictions if you live in Wales"
-            href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
-          - text: "Get coronavirus housing advice for Wales (Shelter)"
-            href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-          - text: "Find out how to get help if you’re being evicted in Scotland"
-            href: "https://www.mygov.scot/private-tenant-eviction/getting-help/"
-          - text: "Get coronavirus advice for Scotland (Shelter)"
+            show_to_nations:
+              - England
+          - text: "Get coronavirus housing advice (Shelter Scotland)"
             href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
+            show_to_nations:
+              - Scotland
+          - text: 'Call the Northern Ireland Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
+            show_to_nations:
+              - Northern Ireland
+          - text: "Find advice from the Housing Executive"
+            href: "https://www.nihe.gov.uk/My-Housing-Executive/Advice-for-Housing-Executive-Tenants/Covid-19-(Coronavirus)"
+            show_to_nations:
+              - Northern Ireland
+          - text: "Get advice from Housing Rights"
+            href: "https://www.housingadviceni.org/coronavirus"
+            show_to_nations:
+              - Northern Ireland
+          - text: "Get coronavirus housing advice for Wales (Shelter Cymru)"
+            href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
+            show_to_nations:
+              - Wales
+          - text: "Get information on evictions (Welsh Government)"
+            href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
+            show_to_nations:
+              - Wales
+          - text: "Find out how to get help if you’re being evicted (mygov.scot)"
+            href: "https://www.mygov.scot/private-tenant-eviction/getting-help/"
+            show_to_nations:
+              - Scotland
     mental_health:
       mental_health_worries:
         title: "If you’re worried about your mental health or someone else’s mental health"
@@ -615,9 +764,15 @@ en:
             href: "https://www.nhs.uk/oneyou/every-mind-matters"
           - text: "Supporting the mental health and wellbeing of children and young people"
             href: "https://www.gov.uk/government/publications/covid-19-guidance-on-supporting-children-and-young-peoples-mental-health-and-wellbeing/guidance-for-parents-and-carers-on-supporting-children-and-young-peoples-mental-health-and-wellbeing-during-the-coronavirus-covid-19-outbreak"
-          - text: "Additional information about taking care of your mental health if you live in Northern Ireland"
+          - text: "Additional information about taking care of your mental health (NI direct)"
             href: "https://www.nidirect.gov.uk/articles/coronavirus-covid-19-taking-care-your-mental-health-and-wellbeing"
-          - text: "Additional information about taking care of your mental health if you live in Wales"
+            show_to_nations:
+              - Northern Ireland
+          - text: "Additional information about taking care of your mental health (Public Health Wales)"
             href: "https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/"
+            show_to_nations:
+              - Wales
           - text: "Additional information about coronavirus and your mental wellbeing from the Scottish Association for Mental Health"
             href: "https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing"
+            show_to_nations:
+              - Scotland

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,6 +188,21 @@ en:
       radio_field: "Select %{field}"
       checkbox_field: "Select at least one %{field}"
     groups:
+      location:
+        questions:
+          nation:
+            title: "Where do you live?"
+            title_caption: "We will show you information which is relevant to where you live."
+            options:
+              option_england:
+                label: "England"
+              option_scotland:
+                label: "Scotland"
+              option_wales:
+                label: "Wales"
+              optopn_northern_ireland:
+                label: "Northern Ireland"
+            custom_select_error: "Select where you live"
       filter_questions:
         questions:
           need_help_with:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,12 @@ Rails.application.routes.draw do
     get "/accessibility-statement", to: "accessibility_statement#show"
 
     # Redirect for deleted question and page (301 is default)
-    get "/urgent-medical-help", to: redirect("/need-help-with")
-    get "/get-help-from-nhs", to: redirect("/need-help-with")
+    get "/urgent-medical-help", to: redirect("/where-live")
+    get "/get-help-from-nhs", to: redirect("/where-live")
+
+    # Question: Where do you live
+    get "/nation", to: "nation#show"
+    post "/nation", to: "nation#submit"
 
     # Question: What do you need to find help with?
     get "/need-help-with", to: "need_help_with#show"

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Fill in the find support form" do
   shared_examples "filling in the form" do
     scenario "Complete the form when not self employed" do
       given_a_user_is_struggling_because_of_coronavirus
+      and_they_live_in_england
       and_needs_help_with_all_options
       and_feels_unsafe_where_they_live
       and_is_finding_it_hard_to_afford_rent_mortgage_bills
@@ -44,6 +45,7 @@ RSpec.feature "Fill in the find support form" do
 
   scenario "Complete the form when not self employed but furloughed" do
     given_a_user_is_struggling_because_of_coronavirus
+    and_they_live_in_england
     and_needs_help_with_being_unemployed
     and_is_not_self_employed_or_a_sole_trader
     and_has_been_told_to_stop_working
@@ -55,6 +57,7 @@ RSpec.feature "Fill in the find support form" do
 
   scenario "Complete the form when self employed" do
     given_a_user_is_struggling_because_of_coronavirus
+    and_they_live_in_england
     and_needs_help_with_being_unemployed
     and_is_self_employed_or_a_sole_trader
     and_is_not_able_to_leave_home_if_absolutely_necessary

--- a/spec/helpers/result_helper_spec.rb
+++ b/spec/helpers/result_helper_spec.rb
@@ -63,4 +63,19 @@ RSpec.describe ResultsHelper, type: :helper do
       expect(result_groups(session)[:being_unemployed][:questions].map { |q| q[:title] }).not_to include(I18n.t("results_link.being_unemployed.are_you_off_work_ill.title"))
     end
   end
+
+  describe "#filter_results_by_nation" do
+    it "should return filtered results if the session nation matches that attached to the questions" do
+      session.merge!({
+        "nation": "nation 1",
+      })
+      test_hash = {
+        items: [
+          { show_to_nations: "nation 1" },
+          { show_to_nations: "nation 2" },
+        ],
+      }
+      expect(filter_results_by_nation(test_hash.dup)[:items]).to eq([{ show_to_nations: "nation 1" }])
+    end
+  end
 end

--- a/spec/helpers/result_helper_spec.rb
+++ b/spec/helpers/result_helper_spec.rb
@@ -28,17 +28,14 @@ RSpec.describe ResultsHelper, type: :helper do
         "have_you_been_made_unemployed": I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_might_be.label"),
         "are_you_off_work_ill": I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_yes.label"),
         "self_employed": I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
+        "nation": I18n.t("coronavirus_form.groups.location.questions.nation.options.option_england.label"),
       })
-      expect(result_groups(session)).to eq(
-        being_unemployed: {
-          heading: I18n.t("coronavirus_form.groups.being_unemployed.title"),
-          questions: [
-            I18n.t("results_link.being_unemployed.have_you_been_made_unemployed"),
-            I18n.t("results_link.being_unemployed.are_you_off_work_ill"),
-            I18n.t("results_link.being_unemployed.self_employed"),
-          ],
-        },
-      )
+      result_array = [
+        I18n.t("results_link.being_unemployed.have_you_been_made_unemployed.title"),
+        I18n.t("results_link.being_unemployed.are_you_off_work_ill.title"),
+        I18n.t("results_link.being_unemployed.self_employed.title"),
+      ]
+      expect(result_groups(session)[:being_unemployed][:questions].map { |q| q[:title] }).to eq(result_array)
     end
 
     it "should filter out empty groups" do
@@ -48,46 +45,22 @@ RSpec.describe ResultsHelper, type: :helper do
         "are_you_off_work_ill": I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_yes.label"),
         "self_employed": I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
         "afford_food": I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options.option_no.label"),
+        "nation": I18n.t("coronavirus_form.groups.location.questions.nation.options.option_england.label"),
       })
-      expect(result_groups(session)).to eq(
-        being_unemployed: {
-          heading: I18n.t("coronavirus_form.groups.being_unemployed.title"),
-          questions: [
-            I18n.t("results_link.being_unemployed.have_you_been_made_unemployed"),
-            I18n.t("results_link.being_unemployed.are_you_off_work_ill"),
-            I18n.t("results_link.being_unemployed.self_employed"),
-          ],
-        },
-      )
+      expect(result_groups(session).keys).not_to include(:getting_food)
     end
   end
 
   describe "#filter_questions_by_session" do
-    it "should return all group questions if all the session responses meet criteria" do
-      session.merge!({
-        "selected_groups": %i[being_unemployed],
-        "have_you_been_made_unemployed": I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_might_be.label"),
-        "are_you_off_work_ill": I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_yes.label"),
-        "self_employed": I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
-      })
-      expect(filter_questions_by_session(:being_unemployed, session)).to eq([
-        I18n.t("results_link.being_unemployed.have_you_been_made_unemployed"),
-        I18n.t("results_link.being_unemployed.are_you_off_work_ill"),
-        I18n.t("results_link.being_unemployed.self_employed"),
-      ])
-    end
-
     it "should return filtered group questions if the session responses do not meet criteria" do
       session.merge!({
         "selected_groups": %i[being_unemployed],
         "have_you_been_made_unemployed": I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_might_be.label"),
         "are_you_off_work_ill": I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_no.label"),
         "self_employed": I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
+        "nation": I18n.t("coronavirus_form.groups.location.questions.nation.options.option_england.label"),
       })
-      expect(filter_questions_by_session(:being_unemployed, session)).to eq([
-        I18n.t("results_link.being_unemployed.have_you_been_made_unemployed"),
-        I18n.t("results_link.being_unemployed.self_employed"),
-      ])
+      expect(result_groups(session)[:being_unemployed][:questions].map { |q| q[:title] }).not_to include(I18n.t("results_link.being_unemployed.are_you_off_work_ill.title"))
     end
   end
 end

--- a/spec/requests/able_to_leave_spec.rb
+++ b/spec/requests/able_to_leave_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "able-to-leave" do
       it "redirects to filter question" do
         get able_to_leave_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/afford_food_spec.rb
+++ b/spec/requests/afford_food_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "afford-food" do
       it "redirects to filter question" do
         get afford_food_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
+++ b/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "afford-rent-mortgage-bills" do
       it "redirects to filter question" do
         get afford_rent_mortgage_bills_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/are_you_off_work_ill_spec.rb
+++ b/spec/requests/are_you_off_work_ill_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "still-working" do
       it "redirects to filter question" do
         get are_you_off_work_ill_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/clear_session_spec.rb
+++ b/spec/requests/clear_session_spec.rb
@@ -1,19 +1,19 @@
 RSpec.describe "clear-session" do
-  let(:selected_feeling_unsafe) { [I18n.t("coronavirus_form.groups.feeling_unsafe.title")] }
+  let(:selected_england) { I18n.t("coronavirus_form.groups.help.questions.nation.options.option_england.label") }
 
   describe "GET /clear-session" do
     context "without a redirect parameter" do
       context "with session data" do
         it "clears the session id" do
-          post need_help_with_path, params: { need_help_with: selected_feeling_unsafe }
+          post nation_path, params: { nation: selected_england }
           initial_session_id = session["session_id"]
           get clear_session_path
           expect(session["session_id"]).to_not eq(initial_session_id)
         end
 
         it "clears responses held in the session" do
-          post need_help_with_path, params: { need_help_with: selected_feeling_unsafe }
-          expect(session[:need_help_with]).to eq(selected_feeling_unsafe)
+          post nation_path, params: { nation: selected_england }
+          expect(session[:nation]).to eq(selected_england)
           get clear_session_path
           expect(session[:have_you_been_made_unemployed]).to be_nil
         end
@@ -27,17 +27,17 @@ RSpec.describe "clear-session" do
 
     context "with an external redirect parameter" do
       it "clears the session id" do
-        post need_help_with_path, params: { need_help_with: selected_feeling_unsafe }
+        post nation_path, params: { nation: selected_england }
         initial_session_id = session["session_id"]
         get clear_session_path, params: { ext_r: true }
         expect(session["session_id"]).to_not eq(initial_session_id)
       end
 
       it "clears responses held in the session" do
-        post need_help_with_path, params: { need_help_with: selected_feeling_unsafe }
-        expect(session[:need_help_with]).to eq(selected_feeling_unsafe)
+        post nation_path, params: { nation: selected_england }
+        expect(session[:nation]).to eq(selected_england)
         get clear_session_path, params: { ext_r: true }
-        expect(session[:have_you_been_made_unemployed]).to be_nil
+        expect(session[:nation]).to be_nil
       end
 
       it "redirects the user to an external website" do

--- a/spec/requests/feel_safe_spec.rb
+++ b/spec/requests/feel_safe_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "feel-safe" do
       it "redirects to filter question" do
         get feel_safe_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/get_food_spec.rb
+++ b/spec/requests/get_food_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "get-food" do
       it "redirects to filter question" do
         get get_food_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/have_somewhere_to_live_spec.rb
+++ b/spec/requests/have_somewhere_to_live_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "have-somewhere-to-live" do
       it "redirects to filter question" do
         get have_somewhere_to_live_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/have_you_been_evicted_spec.rb
+++ b/spec/requests/have_you_been_evicted_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "have-you-been-evicted" do
       it "redirects to filter question" do
         get have_you_been_evicted_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/have_you_been_made_unemployed_spec.rb
+++ b/spec/requests/have_you_been_made_unemployed_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "have-you-been-made-unemployed" do
       it "redirects to filter question" do
         get have_you_been_made_unemployed_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/living_with_vulnerable_spec.rb
+++ b/spec/requests/living_with_vulnerable_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "living-with-vulnerable" do
       it "redirects to filter question" do
         get living_with_vulnerable_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/mental_health_worries_spec.rb
+++ b/spec/requests/mental_health_worries_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe "mental-health-worries" do
   end
 
   describe "GET /mental-health-worries" do
+    let(:selected) { ["Feeling unsafe"] }
+
+    context "without user having answered the where do you live question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:first_question_seen?).and_return(false)
+      end
+
+      it "redirects to where do you live question" do
+        get need_help_with_path
+
+        expect(response).to redirect_to(nation_path)
+      end
+    end
+
     context "without any questions to ask in the session data" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(nil)
@@ -16,7 +30,7 @@ RSpec.describe "mental-health-worries" do
       it "redirects to filter question" do
         get mental_health_worries_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/need_help_with_spec.rb
+++ b/spec/requests/need_help_with_spec.rb
@@ -1,19 +1,21 @@
 RSpec.describe "need-help-with" do
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[get_food feel_safe])
+    allow_any_instance_of(QuestionsHelper).to receive(:first_question_seen?).and_return(true)
   end
 
   describe "GET /need-help-with" do
     let(:selected) { [I18n.t("coronavirus_form.groups.feeling_unsafe.title")] }
 
     context "without session data" do
-      it "shows the form" do
-        visit need_help_with_path
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:first_question_seen?).and_return(false)
+      end
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.title"))
-        I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.options").each do |option|
-          expect(page.body).to have_content(option)
-        end
+      it "redirects to filter question" do
+        get need_help_with_path
+
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/requests/self_employed_spec.rb
+++ b/spec/requests/self_employed_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "self-employed" do
       it "redirects to filter question" do
         get self_employed_path
 
-        expect(response).to redirect_to(need_help_with_path)
+        expect(response).to redirect_to(nation_path)
       end
     end
 

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -2,7 +2,14 @@
 
 module FillInTheFormSteps
   def given_a_user_is_struggling_because_of_coronavirus
-    visit need_help_with_path
+    visit nation_path
+  end
+
+  def and_they_live_in_england
+    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.location.questions.nation.title"))
+
+    choose I18n.t("coronavirus_form.groups.location.questions.nation.options.option_england.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_needs_help_with_all_options


### PR DESCRIPTION
What
----

This adds in the functionality to filter our results based on what country the user has said that they are in. In order to make this work we've had to do some funny things with some of the tests and I think ideally we'd make further changes to decouple our testing of code from the copy we have.

## New question
<img width="1440" alt="Screenshot 2020-05-07 at 08 56 41" src="https://user-images.githubusercontent.com/24547207/81269056-b0fe8b80-9040-11ea-9292-107f88955b24.png">

Trello - https://trello.com/c/sW6sLedW/329-add-devolved-links-to-the-results-page
