### PR TITLE
Change label for "Feeling unsafe" on filter question

### DIFF
--- a/app/controllers/coronavirus_form/need_help_with_controller.rb
+++ b/app/controllers/coronavirus_form/need_help_with_controller.rb
@@ -30,7 +30,7 @@ private
     groups_items = groups_hash.map do |key, title|
       {
         value: title,
-        label: title,
+        label: group_labels[key] || title,
         id: "option_#{key}",
         checked: false,
       }
@@ -62,6 +62,10 @@ private
 
   def groups_hash
     all_groups.map { |key, group| { key => group[:title] } if group[:title] }.compact.reduce(:merge)
+  end
+
+  def group_labels
+    @group_labels ||= all_groups.map { |key, group| { key => group[:need_help_with_label] } if group[:need_help_with_label] }.compact.reduce(:merge)
   end
 
   def update_session_store

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,7 @@ en:
             custom_select_error: "Select what you need to find help with, or ‘I’m not sure’"
       feeling_unsafe:
         title: "Feeling unsafe"
+        need_help_with_label: "Feeling unsafe where you live, or being worried about someone else"
         questions:
           feel_safe:
             title: "Do you feel safe where you live?"

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -8,7 +8,7 @@ module FillInTheFormSteps
   def and_needs_help_with_all_options
     expect(page.body).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.title"))
 
-    check I18n.t("coronavirus_form.groups.feeling_unsafe.title")
+    check I18n.t("coronavirus_form.groups.feeling_unsafe.need_help_with_label")
     check I18n.t("coronavirus_form.groups.paying_bills.title")
     check I18n.t("coronavirus_form.groups.getting_food.title")
     check I18n.t("coronavirus_form.groups.being_unemployed.title")


### PR DESCRIPTION
What
----

We currently use the group labels as checkbox options in the "What do you need help" filter question.  For "Feeling unsafe" we want to have a different label for the checkbox in this question, but retain the existing group title.

Therefore adding a `need_help_with_label` value to the group.  This will also us to override the label that is displayed in the "What do you need help with" question for a specific group.

![Screenshot 2020-05-07 at 10 29 09](https://user-images.githubusercontent.com/6329861/81278461-9bdc2980-904d-11ea-96bd-596c9c733559.png)

How to review
-------------

- Review code
- Run application locally and navigate to `/need-help-with`

Links
-----

Trello card: https://trello.com/c/NyFF0UUN