### PR TITLE
Fix jasmine tests for enhanced ecommerce

### DIFF
--- a/spec/javascripts/analytics-enhancedEcommerce.spec.js
+++ b/spec/javascripts/analytics-enhancedEcommerce.spec.js
@@ -129,6 +129,12 @@ describe('Enhanced ecommerce', function () {
   })
 
   describe('without consent', function () {
+    beforeAll(function () {
+      if (typeof window.ga === 'undefined') {
+        window.ga = function () { }
+      }
+    })
+
     beforeEach(function () {
       GOVUK.setConsentCookie({
         'essential': true,


### PR DESCRIPTION
## What and why

The tests for the result page tracking checked that the `ga()` function **wasn't** called when a user hadn't opted in to tracking. This was done by spying on `ga` and seeing if this had been called.

If the tests ran in order, that `ga()` function would exist. If they didn't run in order, the function wouldn't exist - and errors would be thrown...

Because we can't test that the `ga()` function works correctly in sending data to Google Analytics, we can happily just create an empty function to mock`ga()` so we can test that the function is called with the correct attributes.



How to review
-------------

Run the tests several times to check that the order that the tests are run in doesn't matter.


