### PR TITLE
Update custom dimension to number two 

### DIFF
--- a/app/assets/javascripts/analytics-enhancedEcommerce.js
+++ b/app/assets/javascripts/analytics-enhancedEcommerce.js
@@ -56,7 +56,7 @@ var enhancedEcommerceTracking = function (d) {
               var list = ancestor($a, '[data-track-ec-list]').getAttribute('data-track-ec-list')
               var subsection = ancestor($a, '[data-ec-list-subsection]').getAttribute('data-ec-list-subsection')
 
-              ga('set', 'dimension1', subsection)
+              ga('set', 'dimension2', subsection)
 
               ga('ec:addProduct', {
                 name: href,


### PR DESCRIPTION
What
----

Update the custom dimension on the results page from `dimension1` to `dimension2`.

How to review
-------------

1. Open site in private mode
1. Accept cookies
1. Navigate through the form
1. On the results page check that the links in the results fire an event with a `dimension2` and the title of the subsection that they're in.

Links
-----

Continuation of https://trello.com/c/mRtFakg3
