### PR TITLE
Update enhanced ecommerce

### DIFF
--- a/app/assets/javascripts/analytics-enhancedEcommerce.js
+++ b/app/assets/javascripts/analytics-enhancedEcommerce.js
@@ -75,6 +75,12 @@ var enhancedEcommerceTracking = function (d) {
               })
             })
           }
+        } else {
+          ga('ec:addImpression', {
+            name: 'No link',
+            list: listName,
+            position: positionNumber
+          })
         }
       }
     }

--- a/app/assets/javascripts/analytics-enhancedEcommerce.js
+++ b/app/assets/javascripts/analytics-enhancedEcommerce.js
@@ -31,6 +31,7 @@ var enhancedEcommerceTracking = function (d) {
         var listItem = positions[i]
         var links = listItem.querySelectorAll('a')
         var positionNumber = i + 1 // Position number needs to start from 1.
+        var subsection = ancestor(listItem, '[data-ec-list-subsection]').getAttribute('data-ec-list-subsection')
 
         if (links.length >= 1) {
           for (var j = 0; j < links.length; j++) {
@@ -44,7 +45,8 @@ var enhancedEcommerceTracking = function (d) {
             ga('ec:addImpression', {
               name: href,
               list: listName,
-              position: positionNumber
+              position: positionNumber,
+              dimension2: subsection
             })
 
             // Add a listener so that an event will be fired if the link(s) in
@@ -79,7 +81,8 @@ var enhancedEcommerceTracking = function (d) {
           ga('ec:addImpression', {
             name: 'No link',
             list: listName,
-            position: positionNumber
+            position: positionNumber,
+            dimension2: subsection
           })
         }
       }

--- a/spec/javascripts/analytics-enhancedEcommerce.spec.js
+++ b/spec/javascripts/analytics-enhancedEcommerce.spec.js
@@ -92,17 +92,17 @@ describe('Enhanced ecommerce', function () {
 
       expect(ga).toHaveBeenCalledWith(
         'ec:addImpression',
-        { name: 'https://example.com/', list: 'ecommerce-list-name', position: 1 }
+        { name: 'https://example.com/', list: 'ecommerce-list-name', position: 1, dimension2: 'ecommerce-subsection-name' }
       )
 
       expect(ga).toHaveBeenCalledWith(
         'ec:addImpression',
-        { name: 'https://example.com/?two', list: 'ecommerce-list-name', position: 2 }
+        { name: 'https://example.com/?two', list: 'ecommerce-list-name', position: 2, dimension2: 'ecommerce-subsection-name' }
       )
 
       expect(ga).toHaveBeenCalledWith(
         'ec:addImpression',
-        { name: 'No link', list: 'ecommerce-list-name', position: 3 }
+        { name: 'No link', list: 'ecommerce-list-name', position: 3, dimension2: 'ecommerce-subsection-name' }
       )
     })
 
@@ -119,8 +119,15 @@ describe('Enhanced ecommerce', function () {
       expect(ga).toHaveBeenCalled()
 
       expect(ga).toHaveBeenCalledWith(
+        'set',
+        'dimension2',
+        'ecommerce-subsection-name'
+      )
+
+      expect(ga).toHaveBeenCalledWith(
         'ec:addProduct',
-        { name: 'https://example.com/', position: '1' }
+        {
+          name: 'https://example.com/', position: '1' }
       )
 
       expect(ga).toHaveBeenCalledWith(

--- a/spec/javascripts/analytics-enhancedEcommerce.spec.js
+++ b/spec/javascripts/analytics-enhancedEcommerce.spec.js
@@ -7,6 +7,7 @@ describe('Enhanced ecommerce', function () {
   var snippet = function () {
     var text = document.createTextNode('Example text')
     var text2 = document.createTextNode('Example text too')
+    var text3 = document.createTextNode('Example text without a link')
 
     var a = document.createElement('a')
     a.href = 'https://example.com'
@@ -18,6 +19,7 @@ describe('Enhanced ecommerce', function () {
 
     var li = document.createElement('li')
     var li2 = document.createElement('li')
+    var li3 = document.createElement('li')
 
     var ul = document.createElement('ul')
 
@@ -33,8 +35,10 @@ describe('Enhanced ecommerce', function () {
     a2.appendChild(text2)
     li.appendChild(a)
     li2.appendChild(a2)
+    li3.appendChild(text3)
     ul.appendChild(li)
     ul.appendChild(li2)
+    ul.appendChild(li3)
     subsection.appendChild(ul)
     section.appendChild(subsection)
     wrapper.appendChild(section)
@@ -89,6 +93,16 @@ describe('Enhanced ecommerce', function () {
       expect(ga).toHaveBeenCalledWith(
         'ec:addImpression',
         { name: 'https://example.com/', list: 'ecommerce-list-name', position: 1 }
+      )
+
+      expect(ga).toHaveBeenCalledWith(
+        'ec:addImpression',
+        { name: 'https://example.com/?two', list: 'ecommerce-list-name', position: 2 }
+      )
+
+      expect(ga).toHaveBeenCalledWith(
+        'ec:addImpression',
+        { name: 'No link', list: 'ecommerce-list-name', position: 3 }
       )
     })
 


### PR DESCRIPTION
## What

We currently only track impressions for positions on the results page that have links in them - this changes that to also track positions that don't have a link in them.

It also makes sure that the custom dimension is attached to all impressions that are being fired.

How to review
-------------

1. Open site in private mode
1. Accept cookies
1. Navigate through the form
1. On the results page check that the ecommerce impressions are being fired, and that include "No links" as appropriate, and that the impressions have the custom dimension attached to them.

Links
-----

Continuation of https://trello.com/c/mRtFakg3

