### PR TITLE
Use consistent quotes for translations in views

### DIFF
--- a/app/views/coronavirus_form/accessibility_statement.html.erb
+++ b/app/views/coronavirus_form/accessibility_statement.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %><%= t('accessibility_statement.title') %><% end %>
+<% content_for :title do %><%= t("accessibility_statement.title") %><% end %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", { href: @previous_page } %>
@@ -9,4 +9,4 @@
   margin_top: 0
 } %>
 
-<%= sanitize(t('accessibility_statement.body_text')) %>
+<%= sanitize(t("accessibility_statement.body_text")) %>

--- a/app/views/coronavirus_form/cookies.html.erb
+++ b/app/views/coronavirus_form/cookies.html.erb
@@ -25,7 +25,7 @@
     margin_top: 0,
   } %>
 
-  <%= tag.p t('cookies.settings_page.intro_html'), class: "govuk-body" %>
+  <%= tag.p t("cookies.settings_page.intro_html"), class: "govuk-body" %>
 
   <div class="cookie-settings__no-js">
     <%= sanitize(t("cookies.settings_page.no_javascript_explainer_html")) %>
@@ -33,12 +33,12 @@
 
   <div class="cookie-settings__form-wrapper">
     <p>
-      We use <%= t('cookies.settings_page.cookies').count %> types of cookie.
+      We use <%= t("cookies.settings_page.cookies").count %> types of cookie.
       You can choose which cookies you're happy for us to use.
     </p>
 
     <form data-module="cookie-settings">
-      <% t('cookies.settings_page.cookies').map do |cookie_item| %>
+      <% t("cookies.settings_page.cookies").map do |cookie_item| %>
         <% cookies_usage_hint = capture do %>
           <p class="govuk-body"><%= sanitize(cookie_item.dig(:text_html)) %></p>
           <%= render "govuk_publishing_components/components/table", {

--- a/app/views/coronavirus_form/privacy.html.erb
+++ b/app/views/coronavirus_form/privacy.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %><%= t('privacy_page.title') %><% end %>
+<% content_for :title do %><%= t("privacy_page.title") %><% end %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", { href: @previous_page } %>
@@ -9,4 +9,4 @@
   margin_top: 0
 } %>
 
-<%= sanitize(t('privacy_page.body_text')) %>
+<%= sanitize(t("privacy_page.body_text")) %>

--- a/app/views/coronavirus_form/session_expired.html.erb
+++ b/app/views/coronavirus_form/session_expired.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('session_expired.title') %><% end %>
+<% content_for :title do %><%= t("session_expired.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('session_expired.title') %>" />
+  <meta name="description" content="<%= t("session_expired.title") %>" />
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {
@@ -8,7 +8,7 @@
   margin_top: 0
 } %>
 
-<%= sanitize(t('session_expired.body_text')) %>
+<%= sanitize(t("session_expired.body_text")) %>
 
 <%= render "govuk_publishing_components/components/button", {
   text: "Start now",


### PR DESCRIPTION
In some places we are using double quotes, and in other places we are using single quotes when including translations in the views.

In the absence of view linting, updating to make this consistent in all views.