### PR TITLE
Add a redirect from /where-live to /nation

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
     get "/urgent-medical-help", to: redirect("/nation")
     get "/get-help-from-nhs", to: redirect("/nation")
 
+    # Redirect for old route (301 is default)
+    get "/where-live", to: redirect("/nation")
+
     # Question: Where do you live
     get "/nation", to: "nation#show"
     post "/nation", to: "nation#submit"


### PR DESCRIPTION
A recent PR introduced both these routes and mistakenly left a redirect to `/where-live`. This adds a redirect from where-live to nation just in case there are users that are getting to `/where-live` from a cached 301.