### PR TITLE
Redirect GET /start to first_question

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,13 +7,15 @@ Rails.application.routes.draw do
   get "/", to: redirect("https://www.gov.uk/find-coronavirus-support")
 
   scope module: "coronavirus_form" do
+    first_question = "/nation"
+
     get "/privacy", to: "privacy#show"
     get "/cookies", to: "cookies#show"
     get "/accessibility-statement", to: "accessibility_statement#show"
 
     # Redirect for deleted question and page (301 is default)
-    get "/urgent-medical-help", to: redirect("/nation")
-    get "/get-help-from-nhs", to: redirect("/nation")
+    get "/urgent-medical-help", to: redirect(first_question)
+    get "/get-help-from-nhs", to: redirect(first_question)
 
     # Redirect for old route (301 is default)
     get "/where-live", to: redirect("/nation")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   scope module: "coronavirus_form" do
     first_question = "/nation"
 
+    get "/start", to: redirect(first_question)
+
     get "/privacy", to: "privacy#show"
     get "/cookies", to: "cookies#show"
     get "/accessibility-statement", to: "accessibility_statement#show"

--- a/spec/requests/start_spec.rb
+++ b/spec/requests/start_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe "start" do
+  describe "GET /start" do
+    it "redirects to the first question" do
+      get start_path
+      expect(response).to redirect_to nation_path
+    end
+  end
+end


### PR DESCRIPTION
What
----

- Aliased "/nation" as a `first_question` variable so it can be changed once in future
- Add a redirect from `/start` to `first_question` with request test.

How to review
-------------

Once this is up we'll be able to point start pages at the `/start` route permenantly. Start routes are outside of the app and so easy to miss whenever we update a first question.

This has occured in the past and this ticket is a follow on action from a previous incidnet.

Links
-----

[Trello Create a `/start` path to redirect to first question](https://trello.com/c/HoPfPgbX/396-create-a-start-path-to-redirect-to-first-question),

