### PR TITLE
Ensure GovUK analytics hasn't been blocked before trying to call it.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,5 +6,7 @@
 //= require analytics-enhancedEcommerce
 //= require cookies
 window.CookieSettings.start()
-window.GOVUK.analyticsInit()
 window.GOVUKFrontend.initAll()
+if (window.GOVUK.analyticsInit) {
+  window.GOVUK.analyticsInit()
+}


### PR DESCRIPTION
Previously the call was throwing exception when it had been blocked and it prevented initAll() being called.

What
----
Moved the call to GOVUK.analyticsInit to the end of the script and check loading the analytics has worked before trying to call it.

How to review
-------------
Step 1. Block analytics from loading using either a browser privacy plugin - or Brave browser.
Step 2. Load any page and ensure no javascript errors in the console log

Links
-----
https://trello.com/c/vduHcnvs/411-js-error-when-analytics-is-blocked
