### PR TITLE
Prometheus instrumentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,7 @@ Metrics/BlockLength:
 Style/WordArray:
   Exclude:
     - config/**/*.rb
+
+Rails/HttpPositionalArguments:
+  Exclude:
+      - spec/requests/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,5 @@ group :development, :test do
   gem "rspec-rails", "~> 4.0.0"
   gem "rubocop-govuk"
 end
+
+gem "prometheus-client", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ GEM
     pg (1.2.3)
     phantomjs (2.1.1.0)
     plek (3.0.0)
+    prometheus-client (2.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -387,6 +388,7 @@ DEPENDENCIES
   lograge
   mini_racer (~> 0.2)
   pg (~> 1)
+  prometheus-client (~> 2.0)
   pry (~> 0.13.1)
   pry-rails (~> 0.3.9)
   puma (~> 4.3)

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -57,3 +57,8 @@ run:
 
       cf v3-zdt-push govuk-coronavirus-find-support --wait-for-deploy-complete --no-route
       cf map-route govuk-coronavirus-find-support cloudapps.digital --hostname "$HOSTNAME"
+
+      cf map-route govuk-coronavirus-find-support find-coronavirus-support.service.gov.uk --path metrics
+      cf map-route govuk-coronavirus-find-support cloudapps.digital --hostname govuk-coronavirus-find-support-prod --path metrics
+      cf bind-route-service find-coronavirus-support.service.gov.uk re-ip-whitelist-service --path metrics
+      cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname govuk-coronavirus-find-support-prod --path metrics

--- a/config.ru
+++ b/config.ru
@@ -2,6 +2,9 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
+require_relative "helpers/application_config"
 
-run Rails.application
+rackapp = ApplicationConfig.call
+
+run rackapp

--- a/helpers/application_config.rb
+++ b/helpers/application_config.rb
@@ -1,0 +1,18 @@
+require "prometheus/middleware/collector"
+require "prometheus/middleware/exporter"
+
+class ApplicationConfig
+  def self.call
+    Rack::Builder.app do
+      use Prometheus::Middleware::Collector
+
+      map "/metrics" do
+        use Rack::Deflater
+        use Prometheus::Middleware::Exporter, path: ""
+        run ->(_) { [500, { "Content-Type" => "text/html" }, ["Metrics endpoint is unreachable!"]] }
+      end
+
+      run Rails.application
+    end
+  end
+end

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,6 +7,7 @@ applications:
   - govuk-coronavirus-find-support-db
   - logit-ssl-drain
   - splunk-ssl-drain
+  - prometheus-service-broker
   env:
     GOVUK_APP_DOMAIN: cloudapps.digital
     GOVUK_WEBSITE_ROOT: www.gov.uk

--- a/spec/requests/view_metrics_spec.rb
+++ b/spec/requests/view_metrics_spec.rb
@@ -1,0 +1,21 @@
+require_relative "../../helpers/application_config"
+require "rack/test"
+require "spec_helper"
+
+RSpec.describe "prometheus metrics", type: :request do
+  include Rack::Test::Methods
+
+  rack_app = ApplicationConfig.call
+
+  let(:app) do
+    rack_app
+  end
+
+  context "when requesting app endpoints" do
+    it "returns ok response" do
+      get "/metrics"
+
+      expect(last_response).to be_ok
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Replicated the instrumentation changes from the `govuk-coronavirus-vulnerable-people-form` repo here, such that request level metrics are served on the `metrics` URL. 

## How to review

A test has been added to check that the `metrics` endpoint returns a 200, this test can be run (along with the other tests in the repo) using the usual command.

```bash
bundle exec rake
```

In addition to performing a manual test one can run the server via:

```bash
foreman start
```

And go to [http://localhost/metrics](http://localhost/metrics) and see that metrics are being returned. 

**Note**: Metrics are gathered as requests are made, so on the first visit it might look somewhat empty. If you refresh the page you'll see the metrics for the first load displayed... if you visit other URLs on the app, on subsequent visits to the metrics page you'll see data for those URLs displayed too.

## Links

https://trello.com/c/yOf6sEIk/381-instrument-the-find-support-app

