### PR TITLE
Increase heading sizes on results page

### DIFF
--- a/app/views/components/_actions-group.html.erb
+++ b/app/views/components/_actions-group.html.erb
@@ -5,12 +5,12 @@
 <section class="app-c-actions-group">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
-      <h2 class="govuk-heading-m"><%= title %></h2>
+      <h2 class="govuk-heading-l"><%= title %></h2>
     </div>
     <div class="govuk-grid-column-two-thirds">
       <% subsections.each do |subsection| %>
         <div data-ec-list-subsection="<%= subsection[:title] %>">
-          <h3 class="govuk-heading-s"><%= subsection[:title] %></h3>
+          <h3 class="govuk-heading-m"><%= subsection[:title] %></h3>
           <% if subsection[:items].any? %>
             <ul class="govuk-list">
               <% subsection[:items].each do |item| %>


### PR DESCRIPTION
What
----

Increase the heading sizes on the results page so subsections are clearer.

## Visual differences

Before:

![image](https://user-images.githubusercontent.com/1732331/81915781-f126b680-95ca-11ea-9af2-d7ec87f58382.png)


After:

![image](https://user-images.githubusercontent.com/1732331/81915679-d2c0bb00-95ca-11ea-83fb-3abe1b9b578b.png)

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/1732331/81915952-2501dc00-95cb-11ea-8ead-644007a75994.png) | ![image](https://user-images.githubusercontent.com/1732331/81916025-3b0f9c80-95cb-11ea-9b6b-6a644f2d5dbe.png) |


How to review
-------------
1. Fill in form
1. Check results headings are now `govuk-heading-l` for the sections and `govuk-headin-m` for the subsections

Links
-----

Trello card 👉 https://trello.com/c/Am4icV9a
