### PR TITLE
Simplify actions file further

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,42 +1,23 @@
 on: [push, pull_request]
-
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-
     services:
       postgres:
         image: postgres:11.5
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
+    env:
+      RAILS_ENV: test
+      TEST_DATABASE_URL: postgresql://postgres@localhost/coronavirus-find-support
     steps:
-    - uses: actions/checkout@v1
-    - uses: ruby/setup-ruby@v1
-
-    - uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: bundle-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: bundle
-
-    - run: sudo apt-get -yqq install libpq-dev
-    - run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
-        bundle exec rake db:create
-        bundle exec rake db:migrate
-      env:
-        PGHOST: localhost
-        PGUSER: postgres
-        RAILS_ENV: test
-        DB_USERNAME: postgres
-
-    - run: |
-        bundle exec rake
-        bundle exec rake spec:javascript
-      env:
-        PGHOST: localhost
-        PGUSER: postgres
-        RAILS_ENV: test
-        DB_USERNAME: postgres
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+      - uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: bundle-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: bundle
+      - run: bundle install --jobs 4 --retry 3 --deployment
+      - run: bundle exec rails db:setup
+      - run: bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-task default: %i[spec lint]
+task default: %i[spec spec:javascript lint]


### PR DESCRIPTION
What
----

This adds the JS tests to be part of the default rake task so that CI
steps can be replicated with a single command.

It then makes a number of simplifications to the actions file in line
with https://github.com/alphagov/govuk-developer-docs/pull/2533, mostly
evident in the simpler DB connection and single environment variable
definitions.

I did find myself quite motivated to try reduce the number of javascript environments, this projects seems to have 3 different things going on (chrome, phantomjs and miniracer) however this didn't work for me first time so I thought I'd leave my contribution at this.

How to review
-------------

Check you're happy.

Links
-----


