### PR TITLE
Use `scss_lint-govuk` gem rather than `scss-lint`

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,1 @@
+plugin_gems: ["scss_lint-govuk"]

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ group :test do
   gem "apparition", "~> 0.5.0", require: false
   gem "capybara", "~> 3.32.1", require: false
   gem "mini_racer", "~> 0.2"
-  gem "scss-lint", "~> 0.7.0", require: false
   gem "selenium-webdriver", "~> 3.142"
   gem "simplecov", "~> 0.16"
   gem "timecop"
@@ -45,4 +44,5 @@ group :development, :test do
   gem "rails-controller-testing", "~> 1.0"
   gem "rspec-rails", "~> 4.0.0"
   gem "rubocop-govuk"
+  gem "scss_lint-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,6 @@ GEM
       xpath (~> 3.2)
     childprocess (3.0.0)
     coderay (1.1.2)
-    colorize (0.8.1)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     diff-lcs (1.3)
@@ -309,9 +308,10 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scss-lint (0.7.0)
-      colorize
-      sass
+    scss_lint (0.59.0)
+      sass (~> 3.5, >= 3.5.5)
+    scss_lint-govuk (0.2.0)
+      scss_lint
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -384,7 +384,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0)
   rubocop-govuk
   sass-rails (< 6)
-  scss-lint (~> 0.7.0)
+  scss_lint-govuk
   selenium-webdriver (~> 3.142)
   sentry-raven (~> 3.0)
   simplecov (~> 0.16)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -3,6 +3,5 @@
 desc "Lint files"
 task "lint" => :environment do
   sh "rubocop --format clang"
-  # TODO: Figure out what Sass linting is failing on CI
-  # sh "scss-lint app/assets/stylesheets"
+  sh "scss-lint app/assets/stylesheets"
 end


### PR DESCRIPTION
What
----

- We should use our wrappers, as that's got GOV.UK-preferred config.

How to review
-------------

Observe that CI hopefully passes?

Links
-----

https://trello.com/c/0WEIi10A/450-use-scsslint-govuk-gem-rather-than-scss-lint

