### PR TITLE
Add the ability to filter results, depending on an earlier question

### DIFF
--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -16,14 +16,14 @@ module ResultsHelper
     group = I18n.t("results_link.#{group_key}").dup
     group.each_with_object([]) do |question, array|
       if question[1][:show_options].include?(session[question[0]])
-        array << filter_results_by_nation(I18n.t("results_link.#{group_key}.#{question[0]}").dup)
+        array << filter_results_by_multiple_questions(I18n.t("results_link.#{group_key}.#{question[0]}").dup)
       end
     end
   end
 
-  def filter_results_by_nation(question_results)
+  def filter_results_by_multiple_questions(question_results)
     question_results[:items] = question_results[:items].select do |item|
-      item[:show_to_nations].nil? || item[:show_to_nations].include?(session[:nation])
+      show_to_nations_check(item) && show_to_vulnerable_check(item)
     end
     question_results
   end
@@ -51,5 +51,16 @@ module ResultsHelper
     else
       t("coronavirus_form.results.header.title")
     end
+  end
+
+private
+
+  def show_to_nations_check(item)
+    item[:show_to_nations].nil? || item[:show_to_nations].include?(session[:nation])
+  end
+
+  def show_to_vulnerable_check(item)
+    item[:show_to_vulnerable_person].nil? ||
+      I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_high_risk.label") == session[:able_to_leave]
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -545,6 +545,11 @@ en:
           - "No"
           - "Not sure"
         items:
+          - text: "Find out if you can get support as a clinically extremely vulnerable person."
+            href: "https://www.gov.uk/coronavirus-extremely-vulnerable/"
+            show_to_nations:
+              - England
+            show_to_vulnerable_person: true
           - text: "Find out if you can get help if you’re clinically at high risk from coronavirus (Gov.scot)."
             href: "https://www.gov.scot/publications/covid-shielding/pages/overview/"
             show_to_nations:

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -66,6 +66,30 @@ RSpec.feature "Fill in the find support form" do
     they_are_given_a_link_for_providing_feedback
   end
 
+  scenario "Complete the form when in England, cannot get food and is high risk vulnerable" do
+    given_a_user_is_struggling_because_of_coronavirus
+    and_they_live_in_england
+    and_needs_help_with_getting_food
+    and_is_not_finding_it_hard_to_afford_food
+    and_is_unable_to_get_food
+    and_is_not_able_to_leave_home_as_they_are_vulnerable
+    they_view_the_results_page
+    they_are_provided_with_information_about_getting_support_when_vulnerable
+    they_are_given_a_link_for_providing_feedback
+  end
+
+  scenario "Complete the form when in England, cannot get food and is not high risk vulnerable" do
+    given_a_user_is_struggling_because_of_coronavirus
+    and_they_live_in_england
+    and_needs_help_with_getting_food
+    and_is_not_finding_it_hard_to_afford_food
+    and_is_unable_to_get_food
+    and_is_not_able_to_leave_home_if_absolutely_necessary
+    they_view_the_results_page
+    they_are_not_provided_with_information_about_getting_support_when_vulnerable
+    they_are_given_a_link_for_providing_feedback
+  end
+
   scenario "Ensure we can perform a healthcheck" do
     visit healthcheck_path
 

--- a/spec/helpers/result_helper_spec.rb
+++ b/spec/helpers/result_helper_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ResultsHelper, type: :helper do
     end
   end
 
-  describe "#filter_results_by_nation" do
+  describe "#filter_results_by_multiple_questions" do
     it "should return filtered results if the session nation matches that attached to the questions" do
       session.merge!({
         "nation": "nation 1",
@@ -75,7 +75,50 @@ RSpec.describe ResultsHelper, type: :helper do
           { show_to_nations: "nation 2" },
         ],
       }
-      expect(filter_results_by_nation(test_hash.dup)[:items]).to eq([{ show_to_nations: "nation 1" }])
+      expect(filter_results_by_multiple_questions(test_hash.dup)[:items]).to eq([{ show_to_nations: "nation 1" }])
+    end
+
+    let(:vulnerable_person_label) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_high_risk.label") }
+    let(:not_vulnerable_label) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_other.label") }
+
+    it "should return show_to_vulnerable_person items if the session able_to_leave is high_risk" do
+      session.merge!({
+        "able_to_leave": vulnerable_person_label,
+      })
+      test_hash = {
+        items: [
+          { show_to_vulnerable_person: true },
+          { _: nil },
+        ],
+      }
+      expect(filter_results_by_multiple_questions(test_hash.dup)[:items]).to eq([{ show_to_vulnerable_person: true }, { _: nil }])
+    end
+
+    it "should not return show_to_vulnerable_person items when the session able_to_leave is not high_risk" do
+      session.merge!({
+        "able_to_leave": not_vulnerable_label,
+      })
+      test_hash = {
+        items: [
+          { show_to_vulnerable_person: true },
+          { _: nil },
+        ],
+      }
+      expect(filter_results_by_multiple_questions(test_hash.dup)[:items]).to eq([{ _: nil }])
+    end
+
+    it "should filter multiple questions with AND condition" do
+      session.merge!({
+        "able_to_leave": not_vulnerable_label,
+        "nation": "nation 1",
+      })
+      test_hash = {
+        items: [
+          { "nation": "nation 1", show_to_vulnerable_person: true },
+          { "nation": "nation 1" },
+        ],
+      }
+      expect(filter_results_by_multiple_questions(test_hash.dup)[:items]).to eq([{ "nation": "nation 1" }])
     end
   end
 end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -35,6 +35,14 @@ module FillInTheFormSteps
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
+  def and_needs_help_with_getting_food
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.title"))
+
+    check I18n.t("coronavirus_form.groups.getting_food.title")
+
+    click_on I18n.t("coronavirus_form.submit_and_next")
+  end
+
   def and_feels_unsafe_where_they_live
     expect(page.body).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
 
@@ -55,6 +63,14 @@ module FillInTheFormSteps
     expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
 
     choose I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options.option_yes.label")
+
+    click_on I18n.t("coronavirus_form.submit_and_next")
+  end
+
+  def and_is_not_finding_it_hard_to_afford_food
+    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
+
+    choose I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options.option_no.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
@@ -147,6 +163,14 @@ module FillInTheFormSteps
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
+  def and_is_not_able_to_leave_home_as_they_are_vulnerable
+    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
+
+    choose I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_high_risk.label")
+
+    click_on I18n.t("coronavirus_form.submit_and_next")
+  end
+
   def they_view_the_results_page
     expect(page.body).to have_content(I18n.t("coronavirus_form.results.header.title"))
     expect(current_path).to eq "/results"
@@ -163,6 +187,14 @@ module FillInTheFormSteps
   def they_are_provided_with_information_about_getting_food
     expect(page.body).to have_content(I18n.t("results_link.getting_food.afford_food.title"))
     expect(page.body).to have_content(I18n.t("results_link.getting_food.get_food.title"))
+  end
+
+  def they_are_provided_with_information_about_getting_support_when_vulnerable
+    expect(page.body).to have_content(I18n.t("results_link.getting_food.get_food.items")[0][:text])
+  end
+
+  def they_are_not_provided_with_information_about_getting_support_when_vulnerable
+    expect(page.body).not_to have_content(I18n.t("results_link.getting_food.get_food.items")[0][:text])
   end
 
   def they_are_provided_with_information_about_being_self_employed


### PR DESCRIPTION
What
----
Display a link to extremely vulnerable service if the user can't get food and they are vulnerable to coronavirus (and lives in England).

Specifically, check if they answered that they cannot go outside as they are are high risk.
https://trello.com/c/fQU3REzl/406-give-user-link-to-extremely-vulnerable-service-if-they-cant-get-food-and-they-are-vulnerable-to-coronavirus

How to review
-------------
Answer the questions:
Where do you live? -> England
Are you able to get food? -> No or Not sure
Are you able to leave your home for food, medicine, or health reasons?
-> I should not leave home because I think I’m at high risk of severe illness from coronavirus

The following link should appear at the top of the "Getting food" results section

Answer the questions about where you live or leaving home with different response and the link should not appear.

Links
-----

https://trello.com/c/fQU3REzl/406-give-user-link-to-extremely-vulnerable-service-if-they-cant-get-food-and-they-are-vulnerable-to-coronavirus
