### PR TITLE
Fix Phantom JS failures 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :test do
   gem "apparition", "~> 0.5.0", require: false
   gem "capybara", "~> 3.32.1", require: false
   gem "mini_racer", "~> 0.2"
+  gem "phantomjs", "~> 2.1"
   gem "selenium-webdriver", "~> 3.142"
   gem "simplecov", "~> 0.16"
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,6 +375,7 @@ DEPENDENCIES
   lograge
   mini_racer (~> 0.2)
   pg (~> 1)
+  phantomjs (~> 2.1)
   pry (~> 0.13.1)
   pry-rails (~> 0.3.9)
   puma (~> 4.3)

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -49,6 +49,6 @@ spec_files:
 # defaults to tmp/jasmine
 tmp_dir: "tmp/jasmine"
 
-use_phantom_gem: false
+use_phantom_gem: true
 
 random: false


### PR DESCRIPTION
The master build is failing in Concourse because `spec:javascript` was [added to the default rake task](https://github.com/alphagov/govuk-coronavirus-find-support/commit/30e508acd2139bccd5fa548c4fa81e26715115b0?diff=split#diff-52c976fc38ed2b4e3b1192f8a8e24cffL11) but PhantomJS isn't installed in the container (but is available as a gem) so the tests are failing with "sh: 1: phantomjs: not found".

https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/govuk-corona-find-support-form/jobs/run-quality-checks/builds/172

This will (hopefully) fixes the issue by using the gem for PhantomJS commands.

Paired with @leenagupte on this.