### PR TITLE
Replace PhantomJS with Chromedriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ group :test do
   gem "apparition", "~> 0.5.0", require: false
   gem "capybara", "~> 3.32.2", require: false
   gem "mini_racer", "~> 0.2"
-  gem "phantomjs", "~> 2.1"
   gem "selenium-webdriver", "~> 3.142"
   gem "simplecov", "~> 0.16"
   gem "timecop"
@@ -38,8 +37,9 @@ group :development, :test do
   gem "awesome_print", "~> 1.8"
   gem "byebug", "~> 11"
   gem "foreman", "~> 0.87.1"
-  gem "jasmine-core", ">= 2.99", "< 4"
-  gem "jasmine-rails", "~> 0.15.0"
+  gem "govuk_test", "~> 1.0"
+  gem "jasmine"
+  gem "jasmine_selenium_runner", require: false
   gem "pry", "~> 0.13.1"
   gem "pry-rails", "~> 0.3.9"
   gem "rails-controller-testing", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     awesome_print (1.8.0)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
+    brakeman (4.8.2)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.32.2)
@@ -135,18 +136,27 @@ GEM
       rake
       rouge
       sprockets (< 4)
+    govuk_test (1.0.3)
+      brakeman (~> 4.6)
+      capybara
+      puma
+      selenium-webdriver (>= 3.142)
+      webdrivers (>= 4)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     ipaddress (0.8.3)
+    jasmine (3.5.1)
+      jasmine-core (~> 3.5.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
     jasmine-core (3.5.0)
-    jasmine-rails (0.15.0)
-      jasmine-core (>= 1.3, < 4.0)
-      phantomjs (>= 1.9)
-      railties (>= 3.2.0)
-      sprockets-rails
+    jasmine_selenium_runner (3.0.0)
+      jasmine (~> 3.0)
+      selenium-webdriver (~> 3.8)
     kgio (2.11.3)
     kramdown (2.2.1)
       rexml
@@ -369,13 +379,13 @@ DEPENDENCIES
   foreman (~> 0.87.1)
   govuk_app_config (~> 2.2.0)
   govuk_publishing_components (~> 21.47.0)
-  jasmine-core (>= 2.99, < 4)
-  jasmine-rails (~> 0.15.0)
+  govuk_test (~> 1.0)
+  jasmine
+  jasmine_selenium_runner
   listen (~> 3)
   lograge
   mini_racer (~> 0.2)
   pg (~> 1)
-  phantomjs (~> 2.1)
   pry (~> 0.13.1)
   pry-rails (~> 0.3.9)
   puma (~> 4.3)

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -1,0 +1,6 @@
+namespace :spec do
+  desc "Run Javascript specs using Jasmine"
+  task javascript: :environment do
+    Rake::Task["jasmine:ci"].invoke
+  end
+end

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,54 +1,139 @@
-# path to parent directory of src_files
-# relative path from Rails.root
-# defaults to app/assets/javascripts
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - 'dist/**/*.js'
+#
+src_files:
+  - assets/application.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - 'stylesheets/*.css'
+#
+stylesheets:
+  - assets/application.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - 'helpers/**/*.js'
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - '**/*[sS]pec.js'
+#
+spec_files:
+  - '**/*[Ss]pec.js'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
 src_dir: "app/assets/javascripts"
 
-# path to additional directory of source file that are not part of assets pipeline and need to be included
-# relative path from Rails.root
-# defaults to []
-# include_dir:
-#   - ../mobile_app/public/js
-
-# path to parent directory of css_files
-# relative path from Rails.root
-# defaults to app/assets/stylesheets
-# css_dir: "app/assets/stylesheets"
-
-# list of file expressions to include as source files
-# relative path from src_dir
-src_files:
-  - "application.js"
-
-# list of file expressions to include as css files
-# relative path from css_dir
-# css_files:
-
-# path to parent directory of spec_files
-# relative path from Rails.root
+# spec_dir
 #
-# Alternatively accept an array of directory to include external spec files
-# spec_dir:
-#   - spec/javascripts
-#   - ../engine/spec/javascripts
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
 #
-# defaults to spec/javascripts
-spec_dir: spec/javascripts
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir:
 
-# list of file expressions to include as helpers into spec runner
-# relative path from spec_dir
-helpers:
-  - "helpers/**/*.js"
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
 
-# list of file expressions to include as specs into spec runner
-# relative path from spec_dir
-spec_files:
-  - "**/*[Ss]pec.js"
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
 
-# path to directory of temporary files
-# (spec runner and asset cache)
-# defaults to tmp/jasmine
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
 tmp_dir: "tmp/jasmine"
 
-use_phantom_gem: true
+use_phantom_gem: false
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+
+# phantom_cli_options
+#
+# Extra options to be passed to the phantomjs cli,
+# e.g. to enable localStorage in PhantomJs 2.5
+#
+# EXAMPLE
+#
+# phantom_cli_options:
+#   local-storage-quota: 5000
 
 random: false

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,25 @@
+# Use this file to set/override Jasmine configuration options
+# You can remove it if you don't need it.
+# This file is loaded *after* jasmine.yml is interpreted.
+#
+# Example: using a different boot file.
+# Jasmine.configure do |config|
+#    config.boot_dir = '/absolute/path/to/boot_dir'
+#    config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
+# end
+#
+# Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+
+require "jasmine/runners/selenium"
+
+Jasmine.configure do |config|
+  config.prevent_phantom_js_auto_install = true
+
+  config.runner = lambda { |formatter, jasmine_server_url|
+    options = Selenium::WebDriver::Chrome::Options.new
+    options.headless!
+
+    webdriver = Selenium::WebDriver.for(:chrome, options: options)
+    Jasmine::Runners::Selenium.new(formatter, jasmine_server_url, webdriver, 50)
+  }
+end


### PR DESCRIPTION
This copies the approach taken in other GOV.UK apps, like Content Publisher, to use Chromedriver rather than the deprecated PhantomJS.

https://trello.com/c/7diNcGGx/458-replace-phantomjs

The magic happens in govuk_test, which configures and runs Chromedriver.