### PR TITLE
Fix chromedriver issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ group :test do
   gem "selenium-webdriver", "~> 3.142"
   gem "simplecov", "~> 0.16"
   gem "timecop"
-  gem "webdrivers", "~> 4.3"
 end
 
 group :development, :test do
@@ -46,4 +45,5 @@ group :development, :test do
   gem "rspec-rails", "~> 4.0.1"
   gem "rubocop-govuk"
   gem "scss_lint-govuk"
+  gem "webdrivers", "~> 4.3"
 end

--- a/concourse/Dockerfile
+++ b/concourse/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update --fix-missing && apt-get -y upgrade \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-      google-chrome-unstable \
+      google-chrome-stable \
       postgresql-11 \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -11,6 +11,7 @@
 # Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
 
 require "jasmine/runners/selenium"
+require "webdrivers/chromedriver"
 
 Jasmine.configure do |config|
   config.prevent_phantom_js_auto_install = true
@@ -18,6 +19,7 @@ Jasmine.configure do |config|
   config.runner = lambda { |formatter, jasmine_server_url|
     options = Selenium::WebDriver::Chrome::Options.new
     options.headless!
+    options.add_argument("--no-sandbox")
 
     webdriver = Selenium::WebDriver.for(:chrome, options: options)
     Jasmine::Runners::Selenium.new(formatter, jasmine_server_url, webdriver, 50)


### PR DESCRIPTION
What
----

`google-chrome-unstable`  -> `google-chrome-stable` because the webdriver gem can't get hold of the chromedriver that'll run on the unstable version.

Setting 'no sandbox' is required to run google-chrome as root... we're doing the same thing in the Dockerfile already, but the envvar we set isn't used by the webdrivers gem.

```
options.add_argument("--no-sandbox")
```

https://trello.com/c/7diNcGGx/458-replace-phantomjs