### PR TITLE
Add rake task to import CSV into locale file

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,4 @@
+---
 en:
   accessibility_statement:
     title: Accessibility statement
@@ -110,28 +111,28 @@ en:
       <h2 class="govuk-heading-m">If you didn’t expect to see this page</h2>
       <p class="govuk-body">You may be seeing this page because you’ve turned off cookies in your browser. You’ll need to <a class="govuk-link" href="https://ico.org.uk/your-data-matters/online/cookies/" rel="external" target="_blank">turn cookies on</a> before you can use this service.</p>
   leave_this_website:
-    link_text: "Leave this site"
+    link_text: Leave this site
     link_href: "/clear-session?ext_r=true"
-    link_redirect_to: "https://www.bbc.co.uk/"
+    link_redirect_to: https://www.bbc.co.uk/
   get_help_from_nhs:
     title: Get urgent help from the NHS now
     link_text: Go to NHS 111 online
-    link_href: "https://111.nhs.uk/"
+    link_href: https://111.nhs.uk/
   cookies:
     title: Cookies
     banner:
-      title: "Can we store analytics cookies on your device?"
-      text: "Analytics cookies help us understand how our website is being used."
-      confirmation_message: "You’ve accepted all cookies. You can <a class='govuk-link' href='/cookies'>change your cookie settings</a> at any time."
+      title: Can we store analytics cookies on your device?
+      text: Analytics cookies help us understand how our website is being used.
+      confirmation_message: You’ve accepted all cookies. You can <a class='govuk-link'
+        href='/cookies'>change your cookie settings</a> at any time.
     settings_page:
-      saved: "Your cookie settings were saved."
-      back: "Go back to the page you were looking at"
-      no_javascript_explainer_html:
-        <p class="govuk-body">We use Javascript to set most of our cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>reloading the page</li>
-          <li>turning on Javascript in your browser</li>
-        </ul>
+      saved: Your cookie settings were saved.
+      back: Go back to the page you were looking at
+      no_javascript_explainer_html: <p class="govuk-body">We use Javascript to set
+        most of our cookies. Unfortunately Javascript is not running on your browser,
+        so you cannot change your settings. You can try:</p> <ul class="govuk-list
+        govuk-list--bullet"> <li>reloading the page</li> <li>turning on Javascript
+        in your browser</li> </ul>
       intro_html: |
         <p class="govuk-body">This service puts small files (known as ‘cookies’) onto your computer.</p>
         <p class="govuk-body">Cookies are used to:</p>
@@ -141,238 +142,252 @@ en:
         </ul>
         <p class="govuk-body"><a class="govuk-link" href="https://ico.org.uk/your-data-matters/online/cookies/" rel="external">Find out how to manage cookies</a></p>
       cookies:
-        - header: Essential cookies
-          text_html: These cookies are required for this service to operate. We do not need to ask permission to use them.
-          cookies:
-            - - text: cookie_preferences_set
-              - text: Lets us know whether you’ve already set your cookies preferences.
-              - text: 1 year
-            - - text: cookie_preferences
-              - text: Let us know what your cookie preferences are.
-              - text: 1 year
-            - - text: _session_id
-              - text: Remembers which question you’re up to and how you answered previous questions.
-              - text: 4 hours
-        - header: Measuring website usage with Google Analytics (analytics cookies)
-          text_html: |
-            <p class="govuk-body">We use Google Analytics software to collect anonymised information about how you use the service. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
-            Google Analytics stores information about:</p>
-            <ul class="govuk-list govuk-list--bullet">
-              <li>the pages you visit</li>
-              <li>how long you spend on each page</li>
-              <li>how you arrived at the site</li>
-              <li>what you click on while you’re visiting the site</li>
-              <li>the device and browser you’re using</li>
-            </ul>
-            <p class="govuk-body">We don’t collect or store your personal information (for example your name or address) so this information can’t be used to identify who you are.</p>
-            <p class="govuk-body">We don’t allow Google to use or share our analytics data.</p>
-            <p class="govuk-body">Google Analytics sets the following cookies:</p>
-          cookie_options_name: "cookies-usage"
-          cookie_options:
-            - value: "on"
-              text: Use cookies that measure my website use
-            - value: "off"
-              text: Do not use cookies that measure my website use
-          cookies:
-            - - text: _ga
-              - text: This helps us count how many people visit the service by tracking if you’ve visited before
-              - text: 2 years
-            - - text: _gid
-              - text: This helps us count how many people visit the service by tracking if you’ve visited before
-              - text: 3 years
+      - header: Essential cookies
+        text_html: These cookies are required for this service to operate. We do not
+          need to ask permission to use them.
+        cookies:
+        - - text: cookie_preferences_set
+          - text: Lets us know whether you’ve already set your cookies preferences.
+          - text: 1 year
+        - - text: cookie_preferences
+          - text: Let us know what your cookie preferences are.
+          - text: 1 year
+        - - text: _session_id
+          - text: Remembers which question you’re up to and how you answered previous
+              questions.
+          - text: 4 hours
+      - header: Measuring website usage with Google Analytics (analytics cookies)
+        text_html: |
+          <p class="govuk-body">We use Google Analytics software to collect anonymised information about how you use the service. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
+          Google Analytics stores information about:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>the pages you visit</li>
+            <li>how long you spend on each page</li>
+            <li>how you arrived at the site</li>
+            <li>what you click on while you’re visiting the site</li>
+            <li>the device and browser you’re using</li>
+          </ul>
+          <p class="govuk-body">We don’t collect or store your personal information (for example your name or address) so this information can’t be used to identify who you are.</p>
+          <p class="govuk-body">We don’t allow Google to use or share our analytics data.</p>
+          <p class="govuk-body">Google Analytics sets the following cookies:</p>
+        cookie_options_name: cookies-usage
+        cookie_options:
+        - value: 'on'
+          text: Use cookies that measure my website use
+        - value: 'off'
+          text: Do not use cookies that measure my website use
+        cookies:
+        - - text: _ga
+          - text: This helps us count how many people visit the service by tracking
+              if you’ve visited before
+          - text: 2 years
+        - - text: _gid
+          - text: This helps us count how many people visit the service by tracking
+              if you’ve visited before
+          - text: 3 years
   coronavirus_form:
-    submit_and_next: "Continue"
+    submit_and_next: Continue
     errors:
       page_title_prefix: 'Error: '
-      title: "There is a problem:"
-      radio_field: "Select %{field}"
-      checkbox_field: "Select at least one %{field}"
+      title: 'There is a problem:'
+      radio_field: Select %{field}
+      checkbox_field: Select at least one %{field}
     groups:
       location:
         questions:
           nation:
-            title: "Where do you live?"
-            title_caption: "We will show you information which is relevant to where you live."
+            title: Where do you live?
+            title_caption: We will show you information which is relevant to where
+              you live.
             options:
               option_england:
-                label: "England"
+                label: England
               option_scotland:
-                label: "Scotland"
+                label: Scotland
               option_wales:
-                label: "Wales"
+                label: Wales
               optopn_northern_ireland:
-                label: "Northern Ireland"
+                label: Northern Ireland
       filter_questions:
         questions:
           need_help_with:
-            title: "What do you need help with because of coronavirus?"
-            hint_text: "Select all that apply"
+            title: What do you need help with because of coronavirus?
+            hint_text: Select all that apply
             options:
-              - "I’m not sure"
-            custom_select_error: "Select what you need to find help with, or ‘I’m not sure’"
+            - I’m not sure
+            custom_select_error: Select what you need to find help with, or ‘I’m not
+              sure’
       feeling_unsafe:
-        title: "Feeling unsafe"
-        need_help_with_label: "Feeling unsafe where you live, or what to do if you’re worried about the safety of another adult or child"
+        title: Feeling unsafe
+        need_help_with_label: Feeling unsafe where you live, or what to do if you’re worried about the safety of another adult or child
         questions:
           feel_safe:
-            title: "Do you feel safe where you live?"
+            title: Do you feel safe where you live?
             options:
               option_yes:
-                label: "Yes"
+                label: 'Yes'
               option_yes_someone_else:
-                label: "Yes, but I’m worried about the safety of another adult or a child"
+                label: Yes, but I’m worried about the safety of another adult or a child
               option_no:
-                label: "No"
+                label: 'No'
               not_sure:
-                label: "Not sure"
-            custom_select_error: "Select if you feel safe where you live or if you’re worried about someone else"
+                label: Not sure
+            custom_select_error: Select if you feel safe where you live or if you’re
+              worried about someone else
       paying_bills:
-        title: "Paying bills"
+        title: Paying bills
         questions:
           afford_rent_mortgage_bills:
-            title: "Are you finding it hard to afford rent, your mortgage or bills?"
+            title: Are you finding it hard to afford rent, your mortgage or bills?
             options:
               option_yes:
-                label: "Yes"
+                label: 'Yes'
               option_no:
-                label: "No"
+                label: 'No'
               not_sure:
-                label: "Not sure"
-            custom_select_error: "Select yes if you’re finding it hard to afford your rent, your mortgage or bills"
+                label: Not sure
+            custom_select_error: Select yes if you’re finding it hard to afford your
+              rent, your mortgage or bills
       getting_food:
-        title: "Getting food"
+        title: Getting food
         questions:
           afford_food:
-            title: "Are you finding it hard to afford food?"
+            title: Are you finding it hard to afford food?
             options:
               option_yes:
-                label: "Yes"
+                label: 'Yes'
               option_no:
-                label: "No"
+                label: 'No'
               not_sure:
-                label: "Not sure"
-            custom_select_error: "Select yes if you’re finding it hard to afford food"
+                label: Not sure
+            custom_select_error: Select yes if you’re finding it hard to afford food
           get_food:
-            title: "Are you able to get food?"
+            title: Are you able to get food?
             options:
               option_yes:
-                label: "Yes"
+                label: 'Yes'
               option_no:
-                label: "No"
+                label: 'No'
               not_sure:
-                label: "Not sure"
-            custom_select_error: "Select yes if you’re able to get food"
+                label: Not sure
+            custom_select_error: Select yes if you’re able to get food
       being_unemployed:
-        title: "Being unemployed or not having any work"
+        title: Being unemployed or not having any work
         questions:
           self_employed:
-            title: "Are you self-employed or a sole trader?"
-            title_caption: "Being unemployed or not having any work"
+            title: Are you self-employed or a sole trader?
+            title_caption: Being unemployed or not having any work
             options:
               option_yes:
-                label: "Yes"
+                label: 'Yes'
               option_no:
-                label: "No"
+                label: 'No'
               not_sure:
-                label: "Not sure"
+                label: Not sure
             skip_next_question_options:
-              - "Yes"
-            custom_select_error: "Select yes if you’re self-employed or a sole trader"
+            - 'Yes'
+            custom_select_error: Select yes if you’re self-employed or a sole trader
           have_you_been_made_unemployed:
-            title: "Have you been told to stop working?"
-            title_caption: "Being unemployed or not having any work"
+            title: Have you been told to stop working?
+            title_caption: Being unemployed or not having any work
             options:
               option_yes:
-                label: "Yes, I’ve been made unemployed, or might be soon"
+                label: Yes, I’ve been made unemployed, or might be soon
               option_might_be:
-                label: "Yes, I’ve been put on temporary leave (on furlough), or might be soon"
+                label: Yes, I’ve been put on temporary leave (on furlough), or might
+                  be soon
               option_no:
-                label: "No"
+                label: 'No'
               not_sure:
-                label: "Not sure"
+                label: Not sure
             skip_next_question_options:
-              - "Yes, I’ve been made unemployed, or might be soon"
-              - "Yes, I’ve been put on temporary leave (on furlough), or might be soon"
-            custom_select_error: "Select if you’ve been made unemployed, or put on temporary leave (furloughed)"
+            - Yes, I’ve been made unemployed, or might be soon
+            - Yes, I’ve been put on temporary leave (on furlough), or might be soon
+            custom_select_error: Select if you’ve been made unemployed, or put on
+              temporary leave (furloughed)
           are_you_off_work_ill:
-            title: "Are you off work because you’re ill or self-isolating?"
-            title_caption: "Going in to work"
+            title: Are you off work because you’re ill or self-isolating?
+            title_caption: Going in to work
             options:
               option_yes:
-                label: "Yes"
+                label: 'Yes'
               option_no:
-                label: "No"
-            custom_select_error: "Select yes if you’re off work because you’re ill or self-isolating"
+                label: 'No'
+            custom_select_error: Select yes if you’re off work because you’re ill
+              or self-isolating
       going_in_to_work:
-        title: "Going in to work"
+        title: Going in to work
         questions:
           living_with_vulnerable:
-            title: "Are you worried about going in to work?"
+            title: Are you worried about going in to work?
             options:
               option_yes:
-                label: "Yes"
+                label: 'Yes'
               option_no:
-                label: "No"
+                label: 'No'
               not_sure:
-                label: "Not sure"
-            custom_select_error: "Select yes if you’re worried about going in to work"
+                label: Not sure
+            custom_select_error: Select yes if you’re worried about going in to work
       somewhere_to_live:
-        title: "Having somewhere to live"
+        title: Having somewhere to live
         questions:
           have_somewhere_to_live:
-            title: "Do you have somewhere to live?"
+            title: Do you have somewhere to live?
             options:
               option_yes:
-                label: "Yes"
+                label: 'Yes'
               option_may_lose:
-                label: "I do now but I might lose it"
+                label: I do now but I might lose it
               option_no:
-                label: "No"
+                label: 'No'
               not_sure:
-                label: "Not sure"
-            custom_select_error: "Select if you have somewhere to live"
+                label: Not sure
+            custom_select_error: Select if you have somewhere to live
           have_you_been_evicted:
-            title: "Have you been evicted?"
+            title: Have you been evicted?
             options:
               option_yes:
-                label: "Yes"
+                label: 'Yes'
               option_soon:
-                label: "I might be evicted soon"
+                label: I might be evicted soon
               option_no:
-                label: "No"
+                label: 'No'
               not_sure:
-                label: "Not sure"
-            custom_select_error: "Select if you have been evicted or might be soon"
+                label: Not sure
+            custom_select_error: Select if you have been evicted or might be soon
       mental_health:
-        title: "Mental health and wellbeing"
-        need_help_with_label: "Mental health and wellbeing, including information for children"
+        title: Mental health and wellbeing
+        need_help_with_label: Mental health and wellbeing, including information for children
         questions:
           mental_health_worries:
-            title: "Are you worried about your mental health, or another adult or child’s mental health?"
+            title: Are you worried about your mental health, or another adult or child’s mental health?
             options:
               option_yes:
-                label: "Yes, I am"
+                label: Yes, I am
               option_no:
-                label: "No, I’m not"
+                label: No, I’m not
               not_sure:
-                label: "Not sure"
-            custom_select_error: "Select yes if you’re worried about your mental health or someone else’s mental health"
-      leave_home: # Q: Are you able to leave your home if absolutely neccessary?
+                label: Not sure
+            custom_select_error: Select yes if you’re worried about your mental health
+              or someone else’s mental health
+      leave_home:
         questions:
           able_to_leave:
-            title: "Are you able to leave your home for food, medicine, or health reasons?"
+            title: Are you able to leave your home for food, medicine, or health reasons?
             options:
               option_yes:
-                label: "Yes"
+                label: 'Yes'
               option_has_symptoms:
-                label: "I should not leave home because I have coronavirus symptoms, or someone in my household does"
+                label: I should not leave home because I have coronavirus symptoms,
+                  or someone in my household does
               option_high_risk:
-                label: "I should not leave home because I think I’m at high risk of severe illness from coronavirus"
+                label: I should not leave home because I think I’m at high risk of
+                  severe illness from coronavirus
               option_disability:
-                label: "I cannot go out because I have a disability"
+                label: I cannot go out because I have a disability
               option_other:
-                label: "I’m unable to leave my home for another reason"
-            custom_select_error: "Select if you’re able to leave your home or not"
+                label: I’m unable to leave my home for another reason
+            custom_select_error: Select if you’re able to leave your home or not
     results:
       header:
         context: Coronavirus (COVID-19)
@@ -382,7 +397,7 @@ en:
       feedback:
         text: Help us improve
         link_text: Give feedback on this service
-        link_href: "https://www.gov.uk/done/find-coronavirus-support"
+        link_href: https://www.gov.uk/done/find-coronavirus-support
       no_results: |
         <p class="govuk-body">Based on your answers, there’s no specific information for you in this service at the moment. It will be updated regularly.</p>
 
@@ -392,570 +407,624 @@ en:
   results_link:
     feeling_unsafe:
       feel_safe:
-        title: "If you do not feel safe where you live or you’re worried about someone else"
+        title: If you do not feel safe where you live or you’re worried about someone
+          else
         show_options:
-          - "Yes, but I’m worried about the safety of another adult or a child"
-          - "No"
-          - "Not sure"
+        - Yes, but I’m worried about the safety of another adult or a child
+        - 'No'
+        - Not sure
         items:
-          - id: "0001"
-            text: "If you’re in immediate danger call 999 and ask for the Police."
-          - id: "0002"
-            text: "If you’re in danger and unable to talk on the phone, call 999, then press 55 when prompted."
-          - id: "0003"
-            text: 'Call the National Domestic Abuse Helpline on <a href="tel:0808 2000 247" class="govuk-link">0808 2000 247</a>'
-          - id: "0004"
-            text: 'If you’re a child or young person call Childline on <a href="tel:0800 1111" class="govuk-link">0800 1111</a>'
-          - id: "0005"
-            text: 'Find helplines <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse" class="govuk-link">if you’re a victim of domestic abuse or feel at risk of abuse</a>, or if you are a <a href="https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services" class="govuk-link">victim or witness of a crime</a> (these pages have no quick escape)'
-          - id: "0006"
-            text: "Get safety advice for survivors (Women’s Aid)"
-            href: "https://www.womensaid.org.uk/covid-19-coronavirus-safety-advice-for-survivors/"
-          - id: "0007"
-            text: "Get help from Nexus NI"
-            href: "https://nexusni.org/domestic-and-sexual-abuse-24-hour-helpline/"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0008"
-            text: "Get help from Live Fear Free"
-            href: "https://gov.wales/live-fear-free"
-            show_to_nations:
-              - Wales
-          - id: "0009"
-            text: "Get help from Women’s Aid Scotland"
-            href: "https://womensaid.scot/"
-            show_to_nations:
-              - Scotland
-          - id: "0010"
-            text: "Get help from Scotland’s forced marriage and domestic abuse helpline"
-            href: "https://sdafmh.org.uk/"
-            show_to_nations:
-              - Scotland
-          - id: "0011"
-            text: "Get help for children (Childline)"
-            href: "https://www.childline.org.uk/"
-          - id: "0012"
-            text: "Get advice for children (Children’s Commissioner for Wales)"
-            href: "https://www.childcomwales.org.uk/coronavirus/"
-            show_to_nations:
-              - Wales
-          - id: "0013"
-            text: "Contact NSPCC if you’re concerned about a child"
-            href: "https://www.nspcc.org.uk/keeping-children-safe/our-services/nspcc-helpline/"
-          - id: "0014"
-            text: "Find helplines if you’re an older person (Older People’s Commissioner for Wales)"
-            href: "https://www.olderpeoplewales.com/en/coronavirus.aspx"
-            show_to_nations:
-              - Wales
-          - id: "0015"
-            text: "Find victim support helplines (this page is in Welsh)"
-            href: "https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales"
-            show_to_nations:
-              - Wales
+        - id: '0001'
+          text: If you’re in immediate danger call 999 and ask for the Police.
+        - id: '0002'
+          text: If you’re in danger and unable to talk on the phone, call 999, then
+            press 55 when prompted.
+        - id: '0003'
+          text: Call the National Domestic Abuse Helpline on <a href="tel:0808 2000
+            247" class="govuk-link">0808 2000 247</a>
+        - id: '0004'
+          text: If you’re a child or young person call Childline on <a href="tel:0800
+            1111" class="govuk-link">0800 1111</a>
+        - id: '0005'
+          text: Find helplines <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse"
+            class="govuk-link">if you’re a victim of domestic abuse or feel at risk
+            of abuse</a>, or if you are a <a href="https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services"
+            class="govuk-link">victim or witness of a crime</a> (these pages have
+            no quick escape)
+        - id: '0006'
+          text: Get safety advice for survivors (Women’s Aid)
+          href: https://www.womensaid.org.uk/covid-19-coronavirus-safety-advice-for-survivors/
+        - id: '0007'
+          text: Get help from Nexus NI
+          href: https://nexusni.org/domestic-and-sexual-abuse-24-hour-helpline/
+          show_to_nations:
+          - Northern Ireland
+        - id: '0008'
+          text: Get help from Live Fear Free
+          href: https://gov.wales/live-fear-free
+          show_to_nations:
+          - Wales
+        - id: '0009'
+          text: Get help from Women’s Aid Scotland
+          href: https://womensaid.scot/
+          show_to_nations:
+          - Scotland
+        - id: '0010'
+          text: Get help from Scotland’s forced marriage and domestic abuse helpline
+          href: https://sdafmh.org.uk/
+          show_to_nations:
+          - Scotland
+        - id: '0011'
+          text: Get help for children (Childline)
+          href: https://www.childline.org.uk/
+        - id: '0012'
+          text: Get advice for children (Children’s Commissioner for Wales)
+          href: https://www.childcomwales.org.uk/coronavirus/
+          show_to_nations:
+          - Wales
+        - id: '0013'
+          text: Contact NSPCC if you’re concerned about a child
+          href: https://www.nspcc.org.uk/keeping-children-safe/our-services/nspcc-helpline/
+        - id: '0014'
+          text: Find helplines if you’re an older person (Older People’s Commissioner
+            for Wales)
+          href: https://www.olderpeoplewales.com/en/coronavirus.aspx
+          show_to_nations:
+          - Wales
+        - id: '0015'
+          text: Find victim support helplines (this page is in Welsh)
+          href: https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales
+          show_to_nations:
+          - Wales
     paying_bills:
       afford_rent_mortgage_bills:
-        title: "If you’re finding it hard to afford rent, your mortgage or bills"
+        title: If you’re finding it hard to afford rent, your mortgage or bills
         show_options:
-          - "Yes"
-          - "Not sure"
+        - 'Yes'
+        - Not sure
         items:
-          - id: "0016"
-            text: "Your rights if you’re finding it hard to pay rent"
-            href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
-          - id: "0017"
-            text: "What to do if you cannot pay your rent or mortgage (Shelter)"
-            href: "https://england.shelter.org.uk/housing_advice/coronavirus"
-            show_to_nations:
-              - England
-          - id: "0018"
-            text: "What to do if you cannot pay your rent or mortgage (Shelter Scotland)"
-            href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
-            show_to_nations:
-              - Scotland
-          - id: "0019"
-            text: "What to do if you cannot pay your rent or mortgage (Shelter Cymru)"
-            href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-            show_to_nations:
-              - Wales
-          - id: "0020"
-            text: "What to do if you cannot pay your bills or mortgage (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/"
-            show_to_nations:
-              - England
-          - id: "0021"
-            text: "What to do if you cannot pay your bills or mortgage (Citizens Advice Scotland)"
-            href: "https://www.citizensadvice.org.uk/scotland/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/"
-            show_to_nations:
-              - Scotland
-          - id: "0022"
-            text: "What to do if you cannot pay your bills or mortgage (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/wales/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/"
-            show_to_nations:
-              - Wales
-          - id: "0023"
-            text: Get help from Citizens Advice
-            href: "https://www.citizensadvice.org.uk/about-us/northern-ireland/"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0024"
-            text: "Get help from the housing and debt helpline for Northern Ireland (Housing Rights)"
-            href: "https://www.housingrights.org.uk/"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0025"
-            text: "What to do if you’re finding it hard to pay rent (Welsh Government)"
-            href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
-            show_to_nations:
-              - Wales
-          - id: "0026"
-            text: "Find out about your rights if you have a private landlord (mygov.scot)"
-            href: "https://www.mygov.scot/private-rental-rights/"
-            show_to_nations:
-              - Scotland
-          - id: "0027"
-            text: "Find out about your rights if you have a social landlord (mygov.scot)"
-            href: "https://www.mygov.scot/social-rental-rights/"
-            show_to_nations:
-              - Scotland
+        - id: '0016'
+          text: Your rights if you’re finding it hard to pay rent
+          href: https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities
+        - id: '0017'
+          text: What to do if you cannot pay your rent or mortgage (Shelter)
+          href: https://england.shelter.org.uk/housing_advice/coronavirus
+          show_to_nations:
+          - England
+        - id: '0018'
+          text: What to do if you cannot pay your rent or mortgage (Shelter Scotland)
+          href: https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19
+          show_to_nations:
+          - Scotland
+        - id: '0019'
+          text: What to do if you cannot pay your rent or mortgage (Shelter Cymru)
+          href: https://sheltercymru.org.uk/get-advice/coronavirus/
+          show_to_nations:
+          - Wales
+        - id: '0020'
+          text: What to do if you cannot pay your bills or mortgage (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/
+          show_to_nations:
+          - England
+        - id: '0021'
+          text: What to do if you cannot pay your bills or mortgage (Citizens Advice
+            Scotland)
+          href: https://www.citizensadvice.org.uk/scotland/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/
+          show_to_nations:
+          - Scotland
+        - id: '0022'
+          text: What to do if you cannot pay your bills or mortgage (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/wales/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/
+          show_to_nations:
+          - Wales
+        - id: '0023'
+          text: Get help from Citizens Advice
+          href: https://www.citizensadvice.org.uk/about-us/northern-ireland/
+          show_to_nations:
+          - Northern Ireland
+        - id: '0024'
+          text: Get help from the housing and debt helpline for Northern Ireland (Housing
+            Rights)
+          href: https://www.housingrights.org.uk/
+          show_to_nations:
+          - Northern Ireland
+        - id: '0025'
+          text: What to do if you’re finding it hard to pay rent (Welsh Government)
+          href: https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html
+          show_to_nations:
+          - Wales
+        - id: '0026'
+          text: Find out about your rights if you have a private landlord (mygov.scot)
+          href: https://www.mygov.scot/private-rental-rights/
+          show_to_nations:
+          - Scotland
+        - id: '0027'
+          text: Find out about your rights if you have a social landlord (mygov.scot)
+          href: https://www.mygov.scot/social-rental-rights/
+          show_to_nations:
+          - Scotland
     getting_food:
       afford_food:
-        title: "If you’re finding it hard to afford food"
+        title: If you’re finding it hard to afford food
         show_options:
-          - "Yes"
-          - "Not sure"
+        - 'Yes'
+        - Not sure
         items:
-          - id: "0028"
-            text: "Find out if you’re eligible for Universal Credit"
-            href: "https://www.gov.uk/universal-credit/eligibility"
-          - id: "0029"
-            text: "Find out if you can get help from a foodbank (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/wales/benefits/help-if-on-a-low-income/using-a-food-bank/"
-            show_to_nations: 
-              - Wales
-          - id: "0111"
-            text: "Find out if you can get help from a foodbank (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/benefits/help-if-on-a-low-income/using-a-food-bank/"
-            show_to_nations: 
-              - England
-          - id: "0030"
-            text: "Find out about the financial support and benefits you might be able to get (NI direct)"
-            href: "https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits"
-            show_to_nations: 
-              - Northern Ireland 
-          - id: "0113"
-            text: "If you need food urgently and have no other support, find out if you can get help from your council"
-            href: "https://www.gov.uk/coronavirus-local-help"
-          - id: "0031"
-            text: "If you have a child, find out if they can get free school meals"
-            href: "https://www.gov.uk/apply-free-school-meals"
-          - id: "0032"
-            text: "Find out if you can apply for Healthy Start vouchers if you’re 10 or more weeks pregnant or have a child under 4"
-            href: "https://www.healthystart.nhs.uk/healthy-start-vouchers/do-i-qualify/"
-            show_to_nations:
-              - England
-              - Wales
-              - Northern Ireland
-          - id: "0033"
-            text: "Find out if you can apply for Best Start Grant and Best Start Foods if you have a child (mygov.scot)"
-            href: "https://www.mygov.scot/best-start-grant-best-start-foods/"
-            show_to_nations:
-              - Scotland  
-          - id: "0034"
-            text: "Find out if you’re eligible for the Scottish Welfare Fund (mygov.scot)"
-            href: "https://www.mygov.scot/scottish-welfare-fund/"
-            show_to_nations:
-              - Scotland
-          - id: "0035"
-            text: "Find out if you can get a grant if you’re a parent or looking after a child (mygov.scot)"
-            href: "https://www.mygov.scot/best-start-grant-best-start-foods/"
-            show_to_nations:
-              - Scotland
-          - id: "0036"
-            text: "Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)"
-            href: "https://gov.wales/discretionary-assistance-fund-daf"
-            show_to_nations:
-              - Wales
-          - id: "0037"
-            text: "Call the coronavirus Community Helpline for Northern Ireland on <a href=\"tel:+448088020020\" class=\"govuk-link\">0808 802 0020</a>, email <a href=\"mailto:covid19@adviceni.net\" class=\"govuk-link\">covid19@adviceni.net</a> or text ‘ACTION’ to 81025"
-            show_to_nations:
-              - Northern Ireland
+        - id: '0028'
+          text: Find out if you’re eligible for Universal Credit
+          href: https://www.gov.uk/universal-credit/eligibility
+        - id: '0029'
+          text: Find out if you can get help from a foodbank (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/wales/benefits/help-if-on-a-low-income/using-a-food-bank/
+          show_to_nations:
+          - Wales
+        - id: '0111'
+          text: Find out if you can get help from a foodbank (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/benefits/help-if-on-a-low-income/using-a-food-bank/
+          show_to_nations:
+          - England
+        - id: '0030'
+          text: Find out about the financial support and benefits you might be able
+            to get (NI direct)
+          href: https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits
+          show_to_nations:
+          - Northern Ireland
+        - id: '0113'
+          text: If you need food urgently and have no other support, find out if you
+            can get help from your council
+          href: https://www.gov.uk/coronavirus-local-help
+        - id: '0031'
+          text: If you have a child, find out if they can get free school meals
+          href: https://www.gov.uk/apply-free-school-meals
+        - id: '0032'
+          text: Find out if you can apply for Healthy Start vouchers if you’re 10
+            or more weeks pregnant or have a child under 4
+          href: https://www.healthystart.nhs.uk/healthy-start-vouchers/do-i-qualify/
+          show_to_nations:
+          - England
+          - Wales
+          - Northern Ireland
+        - id: '0033'
+          text: Find out if you can apply for Best Start Grant and Best Start Foods
+            if you have a child (mygov.scot)
+          href: https://www.mygov.scot/best-start-grant-best-start-foods/
+          show_to_nations:
+          - Scotland
+        - id: '0034'
+          text: Find out if you’re eligible for the Scottish Welfare Fund (mygov.scot)
+          href: https://www.mygov.scot/scottish-welfare-fund/
+          show_to_nations:
+          - Scotland
+        - id: '0035'
+          text: Find out if you can get a grant if you’re a parent or looking after
+            a child (mygov.scot)
+          href: https://www.mygov.scot/best-start-grant-best-start-foods/
+          show_to_nations:
+          - Scotland
+        - id: '0036'
+          text: Check if you’re eligible for the Discretionary Assistance Fund (Welsh
+            Government)
+          href: https://gov.wales/discretionary-assistance-fund-daf
+          show_to_nations:
+          - Wales
+        - id: '0037'
+          text: Call the coronavirus Community Helpline for Northern Ireland on <a
+            href="tel:+448088020020" class="govuk-link">0808 802 0020</a>, email <a
+            href="mailto:covid19@adviceni.net" class="govuk-link">covid19@adviceni.net</a>
+            or text ‘ACTION’ to 81025
+          show_to_nations:
+          - Northern Ireland
       get_food:
-        title: "If you’re unable to get food"
+        title: If you’re unable to get food
         show_options:
-          - "No"
-          - "Not sure"
+        - 'No'
+        - Not sure
         items:
-          - id: "0112"
-            text: "Find out if you can get support as a clinically extremely vulnerable person."
-            href: "https://www.gov.uk/coronavirus-extremely-vulnerable/"
-            show_to_nations:
-              - England
-            show_to_vulnerable_person: true
-          - id: "0038"
-            text: "Find out if you can get help if you’re clinically at high risk from coronavirus (Gov.scot)."
-            href: "https://www.gov.scot/publications/covid-shielding/pages/overview/"
-            show_to_nations:
-              - Scotland
-          - id: "0039"
-            text: "You might be able to phone or email your local shops to get a food delivery, or get food online."
-          - id: "0040"
-            text: 'If you can, ask friends, family or neighbours to help you get food. <a href="https://www.gov.uk/guidance/coronavirus-covid-19-accessing-food-and-essential-supplies" class="govuk-link">Find out how you can pay for your shopping safely.</a>'
-          - id: "0041"
-            text: 'If there’s no one to help you get food, prescriptions, or other essentials, find out if you can get help from a volunteer through the <a href="https://volunteering.royalvoluntaryservice.org.uk/nhs-volunteer-responders-portal/isolating" class="govuk-link"> NHS Volunteer Responders programme.</a>'
-            show_to_nations: 
-              - England
-              - Wales
-              - Northern Ireland
-          - id: "0042"
-            text: 'If there’s no one to help you get food, prescriptions, or other essentials, <a href="https://www.gov.scot/publications/coronavirus-covid-19-help-for-vulnerable-people/" class="govuk-link"> call the coronavirus helpline for Scotland </a> or find out if you can get help from a volunteer through the <a href="https://volunteering.royalvoluntaryservice.org.uk/nhs-volunteer-responders-portal/isolating" class="govuk-link"> NHS Volunteer Responders programme.</a>'
-            show_to_nations: 
-              - Scotland
-          - id: "0043"
-            text: 'If you need urgent help and have no other support, <a href="https://www.gov.uk/coronavirus-local-help" class="govuk-link">contact your local council</a> to find out what services are available in your area.'
-          - id: "0044"
-            text: "Get more information on accessing food and other essential supplies."
-            href: "https://www.gov.uk/guidance/coronavirus-covid-19-accessing-food-and-essential-supplies"
+        - id: '0112'
+          text: Find out if you can get support as a clinically extremely vulnerable
+            person.
+          href: https://www.gov.uk/coronavirus-extremely-vulnerable/
+          show_to_nations:
+          - England
+          show_to_vulnerable_person: true
+        - id: '0038'
+          text: Find out if you can get help if you’re clinically at high risk from
+            coronavirus (Gov.scot).
+          href: https://www.gov.scot/publications/covid-shielding/pages/overview/
+          show_to_nations:
+          - Scotland
+        - id: '0039'
+          text: You might be able to phone or email your local shops to get a food
+            delivery, or get food online.
+        - id: '0040'
+          text: If you can, ask friends, family or neighbours to help you get food.
+            <a href="https://www.gov.uk/guidance/coronavirus-covid-19-accessing-food-and-essential-supplies"
+            class="govuk-link">Find out how you can pay for your shopping safely.</a>
+        - id: '0041'
+          text: If there’s no one to help you get food, prescriptions, or other essentials,
+            find out if you can get help from a volunteer through the <a href="https://volunteering.royalvoluntaryservice.org.uk/nhs-volunteer-responders-portal/isolating"
+            class="govuk-link"> NHS Volunteer Responders programme.</a>
+          show_to_nations:
+          - England
+          - Wales
+          - Northern Ireland
+        - id: '0042'
+          text: If there’s no one to help you get food, prescriptions, or other essentials,
+            <a href="https://www.gov.scot/publications/coronavirus-covid-19-help-for-vulnerable-people/"
+            class="govuk-link"> call the coronavirus helpline for Scotland </a> or
+            find out if you can get help from a volunteer through the <a href="https://volunteering.royalvoluntaryservice.org.uk/nhs-volunteer-responders-portal/isolating"
+            class="govuk-link"> NHS Volunteer Responders programme.</a>
+          show_to_nations:
+          - Scotland
+        - id: '0043'
+          text: If you need urgent help and have no other support, <a href="https://www.gov.uk/coronavirus-local-help"
+            class="govuk-link">contact your local council</a> to find out what services
+            are available in your area.
+        - id: '0044'
+          text: Get more information on accessing food and other essential supplies.
+          href: https://www.gov.uk/guidance/coronavirus-covid-19-accessing-food-and-essential-supplies
     being_unemployed:
       have_you_been_made_unemployed:
-        title: "If you’ve been made unemployed, or put on temporary leave (furloughed)"
+        title: If you’ve been made unemployed, or put on temporary leave (furloughed)
         show_options:
-          - "Yes, I’ve been made unemployed, or might be soon"
-          - "Yes, I’ve been put on temporary leave (on furlough), or might be soon"
-          - "Not sure"
+        - Yes, I’ve been made unemployed, or might be soon
+        - Yes, I’ve been put on temporary leave (on furlough), or might be soon
+        - Not sure
         items:
-          - id: "0045"
-            text: "What to do if you’ve lost your job"
-            href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-you-were-employed-and-have-lost-your-job"
-          - id: "0046"
-            text: "What to do if you’ve been laid-off"
-            href: "https://www.gov.uk/lay-offs-short-timeworking"
-          - id: "0047"
-            text: "Find out about your rights if you’ve been dismissed"
-            href: "https://www.gov.uk/dismissal"
-          - id: "0048"
-            text: "What to do if you’ve been furloughed"
-            href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work"
-          - id: "0049"
-            text: "What to do if your employer has told you not to work (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/work/coronavirus-if-your-employer-has-told-you-not-to-work/"
-            show_to_nations:
-              - England
-          - id: "0050"
-            text: "What to do if your employer has told you not to work (Citizens Advice Scotland)"
-            href: "https://www.citizensadvice.org.uk/scotland/work/coronavirus-if-your-employer-has-told-you-not-to-work/"
-            show_to_nations:
-              - Scotland
-          - id: "0051"
-            text: "What to do if your employer has told you not to work (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/wales/work/coronavirus-if-your-employer-has-told-you-not-to-work/"
-            show_to_nations:
-              - Wales
-          - id: "0052"
-            text: "Find out about the financial support and benefits you might be able to get (NI direct)"
-            href: "https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits"
-            show_to_nations: 
-              - Northern Ireland 
-          - id: "0053"
-            text: "Find out about your rights if you’ve been furloughed (Acas)"
-            href: "https://www.acas.org.uk/coronavirus/if-the-employer-needs-to-close-the-workplace"
-          - id: "0054"
-            text: "Get information on applying for Universal Credit (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/benefits/universal-credit/"
-            show_to_nations:
-              - England
-          - id: "0055"
-            text: "Get information on applying for Universal Credit (Citizens Advice Scotland)"
-            href: "https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/"
-            show_to_nations:
-              - Scotland
-          - id: "0056"
-            text: "Get information on applying for Universal Credit (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/wales/benefits/universal-credit/"
-            show_to_nations:
-              - Wales
-          - id: "0057"
-            text: Get help from Citizens Advice
-            href: "https://www.citizensadvice.org.uk/about-us/northern-ireland/"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0058"
-            text: "Get advice on benefits (Advice NI)"
-            href: "https://www.adviceni.net/"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0059"
-            text: "Contact Working Wales if you’ve been made redundant"
-            href: "https://workingwales.gov.wales/"
-            show_to_nations:
-              - Wales
-          - id: "0060"
-            text: "Contact Citizens Advice Wales"
-            href: "https://www.citizensadvice.org.uk/wales/about-us/contact-us/contact-us/contact-us/"
-            show_to_nations:
-              - Wales
-          - id: "0061"
-            text: "Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)"
-            href: "https://gov.wales/discretionary-assistance-fund-daf"
-            show_to_nations:
-              - Wales
-          - id: "0062"
-            text: "Get help if you’ve been made redundant (mygov.scot)"
-            href: "https://www.mygov.scot/help-redundancy/"
-            show_to_nations:
-              - Scotland
-          - id: "0063"
-            text: "Find help with benefits (mygov.scot)"
-            href: "https://www.mygov.scot/benefits-support/"
-            show_to_nations:
-              - Scotland
+        - id: '0045'
+          text: What to do if you’ve lost your job
+          href: https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-you-were-employed-and-have-lost-your-job
+        - id: '0046'
+          text: What to do if you’ve been laid-off
+          href: https://www.gov.uk/lay-offs-short-timeworking
+        - id: '0047'
+          text: Find out about your rights if you’ve been dismissed
+          href: https://www.gov.uk/dismissal
+        - id: '0048'
+          text: What to do if you’ve been furloughed
+          href: https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work
+        - id: '0049'
+          text: What to do if your employer has told you not to work (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/work/coronavirus-if-your-employer-has-told-you-not-to-work/
+          show_to_nations:
+          - England
+        - id: '0050'
+          text: What to do if your employer has told you not to work (Citizens Advice
+            Scotland)
+          href: https://www.citizensadvice.org.uk/scotland/work/coronavirus-if-your-employer-has-told-you-not-to-work/
+          show_to_nations:
+          - Scotland
+        - id: '0051'
+          text: What to do if your employer has told you not to work (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/wales/work/coronavirus-if-your-employer-has-told-you-not-to-work/
+          show_to_nations:
+          - Wales
+        - id: '0052'
+          text: Find out about the financial support and benefits you might be able
+            to get (NI direct)
+          href: https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits
+          show_to_nations:
+          - Northern Ireland
+        - id: '0053'
+          text: Find out about your rights if you’ve been furloughed (Acas)
+          href: https://www.acas.org.uk/coronavirus/if-the-employer-needs-to-close-the-workplace
+        - id: '0054'
+          text: Get information on applying for Universal Credit (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/benefits/universal-credit/
+          show_to_nations:
+          - England
+        - id: '0055'
+          text: Get information on applying for Universal Credit (Citizens Advice
+            Scotland)
+          href: https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/
+          show_to_nations:
+          - Scotland
+        - id: '0056'
+          text: Get information on applying for Universal Credit (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/wales/benefits/universal-credit/
+          show_to_nations:
+          - Wales
+        - id: '0057'
+          text: Get help from Citizens Advice
+          href: https://www.citizensadvice.org.uk/about-us/northern-ireland/
+          show_to_nations:
+          - Northern Ireland
+        - id: '0058'
+          text: Get advice on benefits (Advice NI)
+          href: https://www.adviceni.net/
+          show_to_nations:
+          - Northern Ireland
+        - id: '0059'
+          text: Contact Working Wales if you’ve been made redundant
+          href: https://workingwales.gov.wales/
+          show_to_nations:
+          - Wales
+        - id: '0060'
+          text: Contact Citizens Advice Wales
+          href: https://www.citizensadvice.org.uk/wales/about-us/contact-us/contact-us/contact-us/
+          show_to_nations:
+          - Wales
+        - id: '0061'
+          text: Check if you’re eligible for the Discretionary Assistance Fund (Welsh
+            Government)
+          href: https://gov.wales/discretionary-assistance-fund-daf
+          show_to_nations:
+          - Wales
+        - id: '0062'
+          text: Get help if you’ve been made redundant (mygov.scot)
+          href: https://www.mygov.scot/help-redundancy/
+          show_to_nations:
+          - Scotland
+        - id: '0063'
+          text: Find help with benefits (mygov.scot)
+          href: https://www.mygov.scot/benefits-support/
+          show_to_nations:
+          - Scotland
       are_you_off_work_ill:
-        title: "If you’re off work because you’re ill or self isolating"
+        title: If you’re off work because you’re ill or self isolating
         show_options:
-          - "Yes"
+        - 'Yes'
         items:
-          - id: "0064"
-            text: "What to do if you’re employed but cannot work"
-            href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work"
-          - id: "0065"
-            text: "Find out about getting statutory sick pay if you’re self-isolating (Acas)"
-            href: "https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay"
-          - id: "0066"
-            text: "Find out about the help you can get if you’re self-employed or work in the gig economy (Money Advice Service)"
-            href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you"
-          - id: "0067"
-            text: "Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)"
-            href: "https://gov.wales/discretionary-assistance-fund-daf"
-            show_to_nations:
-              - Wales
+        - id: '0064'
+          text: What to do if you’re employed but cannot work
+          href: https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work
+        - id: '0065'
+          text: Find out about getting statutory sick pay if you’re self-isolating
+            (Acas)
+          href: https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay
+        - id: '0066'
+          text: Find out about the help you can get if you’re self-employed or work
+            in the gig economy (Money Advice Service)
+          href: https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you
+        - id: '0067'
+          text: Check if you’re eligible for the Discretionary Assistance Fund (Welsh
+            Government)
+          href: https://gov.wales/discretionary-assistance-fund-daf
+          show_to_nations:
+          - Wales
       self_employed:
-        title: "If you’re self employed or a sole trader"
+        title: If you’re self employed or a sole trader
         show_options:
-          - "Yes"
-          - "Not sure"
+        - 'Yes'
+        - Not sure
         items:
-          - id: "0068"
-            text: "What to do if you’re self-employed and getting less or no work"
-            href: "https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work"
-          - id: "0069"
-            text: "What you can do if you’re self employed or a sole trader (Money Advice Service)"
-            href: "https://www.moneyadviceservice.org.uk/en/articles/coronavirus-if-youre-self-employed"
-          - id: "0070"
-            text: "Find out about the financial support and benefits you might be able to get (NI direct)"
-            href: "https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits"
-            show_to_nations: 
-              - Northern Ireland 
-          - id: "0071"
-            text: "Get information on applying for Universal Credit (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/benefits/universal-credit/"
-            show_to_nations:
-              - England
-          - id: "0072"
-            text: "Get information on applying for Universal Credit (Citizens Advice Scotland)"
-            href: "https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/"
-            show_to_nations:
-              - Scotland
-          - id: "0073"
-            text: "Get information on applying for Universal Credit (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/wales/benefits/universal-credit/"
-            show_to_nations:
-              - Wales
-          - id: "0074"
-            text: "Get help with your business rates and find out about coronavirus loans (nibusinessinfo)"
-            href: "https://www.nibusinessinfo.co.uk/content/coronavirus-support-and-advice-self-employed"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0075"
-            text: Get help from Citizens Advice
-            href: "https://www.citizensadvice.org.uk/about-us/northern-ireland/"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0076"
-            text: "Get advice on benefits (Advice NI)"
-            href: "https://www.adviceni.net/"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0077"
-            text: "Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)"
-            href: "https://gov.wales/discretionary-assistance-fund-daf"
-            show_to_nations:
-              - Wales
-          - id: "0078"
-            text: "Find help with benefits (mygov.scot)"
-            href: "https://www.mygov.scot/benefits-support/"
-            show_to_nations:
-              - Scotland
-          - id: "0079"
-            text: "Find financial support for your business (Scottish Government)"
-            href: "https://findbusinesssupport.gov.scot/coronavirus-advice"
-            show_to_nations:
-              - Scotland
+        - id: '0068'
+          text: What to do if you’re self-employed and getting less or no work
+          href: https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work
+        - id: '0069'
+          text: What you can do if you’re self employed or a sole trader (Money Advice
+            Service)
+          href: https://www.moneyadviceservice.org.uk/en/articles/coronavirus-if-youre-self-employed
+        - id: '0070'
+          text: Find out about the financial support and benefits you might be able
+            to get (NI direct)
+          href: https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits
+          show_to_nations:
+          - Northern Ireland
+        - id: '0071'
+          text: Get information on applying for Universal Credit (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/benefits/universal-credit/
+          show_to_nations:
+          - England
+        - id: '0072'
+          text: Get information on applying for Universal Credit (Citizens Advice
+            Scotland)
+          href: https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/
+          show_to_nations:
+          - Scotland
+        - id: '0073'
+          text: Get information on applying for Universal Credit (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/wales/benefits/universal-credit/
+          show_to_nations:
+          - Wales
+        - id: '0074'
+          text: Get help with your business rates and find out about coronavirus loans
+            (nibusinessinfo)
+          href: https://www.nibusinessinfo.co.uk/content/coronavirus-support-and-advice-self-employed
+          show_to_nations:
+          - Northern Ireland
+        - id: '0075'
+          text: Get help from Citizens Advice
+          href: https://www.citizensadvice.org.uk/about-us/northern-ireland/
+          show_to_nations:
+          - Northern Ireland
+        - id: '0076'
+          text: Get advice on benefits (Advice NI)
+          href: https://www.adviceni.net/
+          show_to_nations:
+          - Northern Ireland
+        - id: '0077'
+          text: Check if you’re eligible for the Discretionary Assistance Fund (Welsh
+            Government)
+          href: https://gov.wales/discretionary-assistance-fund-daf
+          show_to_nations:
+          - Wales
+        - id: '0078'
+          text: Find help with benefits (mygov.scot)
+          href: https://www.mygov.scot/benefits-support/
+          show_to_nations:
+          - Scotland
+        - id: '0079'
+          text: Find financial support for your business (Scottish Government)
+          href: https://findbusinesssupport.gov.scot/coronavirus-advice
+          show_to_nations:
+          - Scotland
     going_in_to_work:
       living_with_vulnerable:
-        title: "If you’re worried about going in to work"
+        title: If you’re worried about going in to work
         show_options:
-          - "Yes"
-          - "Not sure"
+        - 'Yes'
+        - Not sure
         items:
-          - id: "0080"
-            text: "Find out if you should be going to work"
-            href: "https://www.gov.uk/government/publications/staying-alert-and-safe-social-distancing/staying-alert-and-safe-social-distancing"
-          - id: "0081"
-            text: "What to do if you’re worried about going to work because of coronavirus (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/work/coronavirus-if-youre-worried-about-working/"
-            show_to_nations:
-              - England
-          - id: "0082"
-            text: "What to do if you’re worried about going to work because of coronavirus (Citizens Advice Scotland)"
-            href: "https://www.citizensadvice.org.uk/scotland/work/coronavirus-if-youre-worried-about-working/"
-            show_to_nations:
-              - Scotland
-          - id: "0083"
-            text: "What to do if you’re worried about going to work because of coronavirus (Citizens Advice)"
-            href: "https://www.citizensadvice.org.uk/wales/work/coronavirus-if-youre-worried-about-working/"
-            show_to_nations:
-              - Wales
-          - id: "0084"
-            text: Get help from Citizens Advice
-            href: "https://www.citizensadvice.org.uk/about-us/northern-ireland/"
-            show_to_nations:
-              - Northern Ireland
+        - id: '0080'
+          text: Find out if you should be going to work
+          href: https://www.gov.uk/government/publications/staying-alert-and-safe-social-distancing/staying-alert-and-safe-social-distancing
+        - id: '0081'
+          text: What to do if you’re worried about going to work because of coronavirus
+            (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/work/coronavirus-if-youre-worried-about-working/
+          show_to_nations:
+          - England
+        - id: '0082'
+          text: What to do if you’re worried about going to work because of coronavirus
+            (Citizens Advice Scotland)
+          href: https://www.citizensadvice.org.uk/scotland/work/coronavirus-if-youre-worried-about-working/
+          show_to_nations:
+          - Scotland
+        - id: '0083'
+          text: What to do if you’re worried about going to work because of coronavirus
+            (Citizens Advice)
+          href: https://www.citizensadvice.org.uk/wales/work/coronavirus-if-youre-worried-about-working/
+          show_to_nations:
+          - Wales
+        - id: '0084'
+          text: Get help from Citizens Advice
+          href: https://www.citizensadvice.org.uk/about-us/northern-ireland/
+          show_to_nations:
+          - Northern Ireland
     somewhere_to_live:
       have_somewhere_to_live:
-        title: "If you do not have somewhere to live or might become homeless"
+        title: If you do not have somewhere to live or might become homeless
         show_options:
-          - "I do now but I might lose it"
-          - "No"
-          - "Not sure"
+        - I do now but I might lose it
+        - 'No'
+        - Not sure
         items:
-          - id: "0085"
-            text: "Get help if you’re legally homeless (Shelter)"
-            href: "https://england.shelter.org.uk/housing_advice/homelessness/rules/legally_homeless"
-            show_to_nations:
-              - England
-          - id: "0086"
-            text: "Get help if you’re homeless (Shelter Cymru)"
-            href: "https://sheltercymru.org.uk/get-advice/homelessness/"
-            show_to_nations:
-              - Wales
-          - id: "0087"
-            text: 'Call the Northern Ireland Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
-            show_to_nations:
-              - Northern Ireland
-          - id: "0088"
-            text: "Get help from Housing Rights housing and debt helpline"
-            href: "https://www.housingadviceni.org/homeless/coronavirus"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0089"
-            text: "Get coronavirus housing information (Shelter Cymru)"
-            href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-            show_to_nations:
-              - Wales
-          - id: "0090"
-            text: "Get help if you’re homeless (mygov.scot)"
-            href: "https://www.mygov.scot/homelessness/"
-            show_to_nations:
-              - Scotland
-          - id: "0091"
-            text: "Get help if you’re homeless from Shelter Scotland"
-            href: "https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness"
-            show_to_nations:
-              - Scotland
+        - id: '0085'
+          text: Get help if you’re legally homeless (Shelter)
+          href: https://england.shelter.org.uk/housing_advice/homelessness/rules/legally_homeless
+          show_to_nations:
+          - England
+        - id: '0086'
+          text: Get help if you’re homeless (Shelter Cymru)
+          href: https://sheltercymru.org.uk/get-advice/homelessness/
+          show_to_nations:
+          - Wales
+        - id: '0087'
+          text: Call the Northern Ireland Housing Executive on <a href="tel:+443448920908"
+            class="govuk-link">03448 920 908</a>
+          show_to_nations:
+          - Northern Ireland
+        - id: '0088'
+          text: Get help from Housing Rights housing and debt helpline
+          href: https://www.housingadviceni.org/homeless/coronavirus
+          show_to_nations:
+          - Northern Ireland
+        - id: '0089'
+          text: Get coronavirus housing information (Shelter Cymru)
+          href: https://sheltercymru.org.uk/get-advice/coronavirus/
+          show_to_nations:
+          - Wales
+        - id: '0090'
+          text: Get help if you’re homeless (mygov.scot)
+          href: https://www.mygov.scot/homelessness/
+          show_to_nations:
+          - Scotland
+        - id: '0091'
+          text: Get help if you’re homeless from Shelter Scotland
+          href: https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness
+          show_to_nations:
+          - Scotland
       have_you_been_evicted:
-        title: "If you’ve been evicted or might be soon"
+        title: If you’ve been evicted or might be soon
         show_options:
-          - "Yes"
-          - "I might be evicted soon"
-          - "Not sure"
+        - 'Yes'
+        - I might be evicted soon
+        - Not sure
         items:
-          - id: "0092"
-            text: "Find information about your rights as a tenant"
-            href: "https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities"
-            show_to_nations:
-              - England
-          - id: "0093"
-            text: "Get coronavirus housing advice (Shelter)"
-            href: "https://england.shelter.org.uk/housing_advice/coronavirus"
-            show_to_nations:
-              - England
-          - id: "0094"
-            text: "Get coronavirus housing advice (Shelter Scotland)"
-            href: "https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19"
-            show_to_nations:
-              - Scotland
-          - id: "0095"
-            text: 'Call the Northern Ireland Housing Executive on <a href="tel:+443448920908" class="govuk-link">03448 920 908</a>'
-            show_to_nations:
-              - Northern Ireland
-          - id: "0096"
-            text: "Find advice from the Housing Executive"
-            href: "https://www.nihe.gov.uk/My-Housing-Executive/Advice-for-Housing-Executive-Tenants/Covid-19-(Coronavirus)"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0097"
-            text: "Get advice from Housing Rights"
-            href: "https://www.housingadviceni.org/coronavirus"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0098"
-            text: "Get coronavirus housing advice for Wales (Shelter Cymru)"
-            href: "https://sheltercymru.org.uk/get-advice/coronavirus/"
-            show_to_nations:
-              - Wales
-          - id: "0099"
-            text: "Get information on evictions (Welsh Government)"
-            href: "https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html"
-            show_to_nations:
-              - Wales
-          - id: "0100"
-            text: "Find out how to get help if you’re being evicted (mygov.scot)"
-            href: "https://www.mygov.scot/private-tenant-eviction/getting-help/"
-            show_to_nations:
-              - Scotland
-          - id: "0101"
-            text: "Find out about your rights if you have a private landlord (mygov.scot)"
-            href: "https://www.mygov.scot/private-rental-rights/"
-            show_to_nations:
-              - Scotland
-          - id: "0102"
-            text: "Find out about your rights if you have a social landlord (mygov.scot)"
-            href: "https://www.mygov.scot/social-rental-rights/"
-            show_to_nations:
-              - Scotland
+        - id: '0092'
+          text: Find information about your rights as a tenant
+          href: https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities
+          show_to_nations:
+          - England
+        - id: '0093'
+          text: Get coronavirus housing advice (Shelter)
+          href: https://england.shelter.org.uk/housing_advice/coronavirus
+          show_to_nations:
+          - England
+        - id: '0094'
+          text: Get coronavirus housing advice (Shelter Scotland)
+          href: https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19
+          show_to_nations:
+          - Scotland
+        - id: '0095'
+          text: Call the Northern Ireland Housing Executive on <a href="tel:+443448920908"
+            class="govuk-link">03448 920 908</a>
+          show_to_nations:
+          - Northern Ireland
+        - id: '0096'
+          text: Find advice from the Housing Executive
+          href: https://www.nihe.gov.uk/My-Housing-Executive/Advice-for-Housing-Executive-Tenants/Covid-19-(Coronavirus)
+          show_to_nations:
+          - Northern Ireland
+        - id: '0097'
+          text: Get advice from Housing Rights
+          href: https://www.housingadviceni.org/coronavirus
+          show_to_nations:
+          - Northern Ireland
+        - id: '0098'
+          text: Get coronavirus housing advice for Wales (Shelter Cymru)
+          href: https://sheltercymru.org.uk/get-advice/coronavirus/
+          show_to_nations:
+          - Wales
+        - id: '0099'
+          text: Get information on evictions (Welsh Government)
+          href: https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html
+          show_to_nations:
+          - Wales
+        - id: '0100'
+          text: Find out how to get help if you’re being evicted (mygov.scot)
+          href: https://www.mygov.scot/private-tenant-eviction/getting-help/
+          show_to_nations:
+          - Scotland
+        - id: '0101'
+          text: Find out about your rights if you have a private landlord (mygov.scot)
+          href: https://www.mygov.scot/private-rental-rights/
+          show_to_nations:
+          - Scotland
+        - id: '0102'
+          text: Find out about your rights if you have a social landlord (mygov.scot)
+          href: https://www.mygov.scot/social-rental-rights/
+          show_to_nations:
+          - Scotland
     mental_health:
       mental_health_worries:
-        title: "If you’re worried about your mental health or someone else’s mental health"
+        title: If you’re worried about your mental health or someone else’s mental
+          health
         show_options:
-          - "Yes, I am"
-          - "Not sure"
+        - Yes, I am
+        - Not sure
         items:
-          - id: "0103"
-            text: "Where to get urgent help for mental health"
-            href: "https://www.nhs.uk/using-the-nhs/nhs-services/mental-health-services/dealing-with-a-mental-health-crisis-or-emergency/"
-          - id: "0104"
-            text: "Get information on coronavirus and your wellbeing (Mind)"
-            href: "https://www.mind.org.uk/information-support/coronavirus/coronavirus-and-your-wellbeing/#collapse838f8"
-          - id: "0105"
-            text: "Looking after your mental health during coronavirus"
-            href: "https://www.gov.uk/government/publications/covid-19-guidance-for-the-public-on-mental-health-and-wellbeing"
-          - id: "0106"
-            text: "Looking after your mental health (NHS)"
-            href: "https://www.nhs.uk/oneyou/every-mind-matters"
-          - id: "0107"
-            text: "Supporting the mental health and wellbeing of children and young people"
-            href: "https://www.gov.uk/government/publications/covid-19-guidance-on-supporting-children-and-young-peoples-mental-health-and-wellbeing/guidance-for-parents-and-carers-on-supporting-children-and-young-peoples-mental-health-and-wellbeing-during-the-coronavirus-covid-19-outbreak"
-          - id: "0108"
-            text: "Additional information about taking care of your mental health (NI direct)"
-            href: "https://www.nidirect.gov.uk/articles/coronavirus-covid-19-taking-care-your-mental-health-and-wellbeing"
-            show_to_nations:
-              - Northern Ireland
-          - id: "0109"
-            text: "Additional information about taking care of your mental health (Public Health Wales)"
-            href: "https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/"
-            show_to_nations:
-              - Wales
-          - id: "0110"
-            text: "Additional information about coronavirus and your mental wellbeing from the Scottish Association for Mental Health"
-            href: "https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing"
-            show_to_nations:
-              - Scotland
+        - id: '0103'
+          text: Where to get urgent help for mental health
+          href: https://www.nhs.uk/using-the-nhs/nhs-services/mental-health-services/dealing-with-a-mental-health-crisis-or-emergency/
+        - id: '0104'
+          text: Get information on coronavirus and your wellbeing (Mind)
+          href: https://www.mind.org.uk/information-support/coronavirus/coronavirus-and-your-wellbeing/#collapse838f8
+        - id: '0105'
+          text: Looking after your mental health during coronavirus
+          href: https://www.gov.uk/government/publications/covid-19-guidance-for-the-public-on-mental-health-and-wellbeing
+        - id: '0106'
+          text: Looking after your mental health (NHS)
+          href: https://www.nhs.uk/oneyou/every-mind-matters
+        - id: '0107'
+          text: Supporting the mental health and wellbeing of children and young people
+          href: https://www.gov.uk/government/publications/covid-19-guidance-on-supporting-children-and-young-peoples-mental-health-and-wellbeing/guidance-for-parents-and-carers-on-supporting-children-and-young-peoples-mental-health-and-wellbeing-during-the-coronavirus-covid-19-outbreak
+        - id: '0108'
+          text: Additional information about taking care of your mental health (NI
+            direct)
+          href: https://www.nidirect.gov.uk/articles/coronavirus-covid-19-taking-care-your-mental-health-and-wellbeing
+          show_to_nations:
+          - Northern Ireland
+        - id: '0109'
+          text: Additional information about taking care of your mental health (Public
+            Health Wales)
+          href: https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/
+          show_to_nations:
+          - Wales
+        - id: '0110'
+          text: Additional information about coronavirus and your mental wellbeing
+            from the Scottish Association for Mental Health
+          href: https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing
+          show_to_nations:
+          - Scotland

--- a/lib/content_exporter.rb
+++ b/lib/content_exporter.rb
@@ -2,16 +2,14 @@ require "csv"
 
 module ContentExporter
   extend self
-
   def extract_results_links
     result_links = I18n.t("results_link")
     result_links.each_with_object([]) do |group, row|
       group[1].each do |subgroup|
         group_key = group[0]
-        subgroup_title = subgroup[1].fetch(:title)
-        subgroup[1].fetch(:items).each { |result| row << format_result_item_row(result, group_key, subgroup_title) }
+        subgroup[1].fetch(:items).each { |result| row << format_result_item_row(result, group_key, subgroup) }
         subgroup[1].fetch(:support_and_advice_items, []).each do |result|
-          row << format_result_item_row(result, group_key, subgroup_title, true)
+          row << format_result_item_row(result, group_key, subgroup, true)
         end
       end
     end
@@ -29,16 +27,24 @@ module ContentExporter
 
 private
 
-  def format_result_item_row(result, group_key, subgroup_title, support_and_advice = false)
-    groups = I18n.t("coronavirus_form.groups")
+  def format_result_item_row(result, group_key, subgroup, support_and_advice = false)
     {
       id: result.fetch(:id),
-      group_title: groups[group_key].fetch(:title),
-      subgroup_title: subgroup_title,
-      support_and_advice: support_and_advice,
+      status: "Live",
+      group_and_subgroup: group_and_subgroup_string(group_key, subgroup, support_and_advice),
       text: result.fetch(:text),
       href: result.fetch(:href, ""),
       show_to_nations: result.fetch(:show_to_nations, []).join(" OR "),
+      group_key: group_key.to_s,
+      subgroup_key: subgroup[0].to_s,
+      support_and_advice: support_and_advice,
     }
+  end
+
+  def group_and_subgroup_string(group_key, subgroup, support_and_advice)
+    groups = I18n.t("coronavirus_form.groups")
+    titles = [groups[group_key].fetch(:title), subgroup[1].fetch(:title)]
+    titles << "Support and Advice" if support_and_advice
+    titles.join(" | ")
   end
 end

--- a/lib/content_importer.rb
+++ b/lib/content_importer.rb
@@ -1,0 +1,53 @@
+require "csv"
+
+module ContentImporter
+module_function
+
+  def import_results_links(csv_path)
+    csv = CSV.read(csv_path, { headers: true })
+    output = csv.each_with_object({}) do |csv_row, results_links|
+      support_and_advice = csv_row.fetch("support_and_advice")
+      group_key = csv_row.fetch("group_key").to_sym
+      subgroup_key = csv_row.fetch("subgroup_key").to_sym
+
+      link_type = support_and_advice.downcase == "true" ? "support_and_advice" : "items"
+      results_links[group_key] = {} if results_links.dig(group_key).nil?
+      results_links[group_key][subgroup_key] = {} if results_links.dig(group_key, subgroup_key).nil?
+      if results_links.dig(group_key, subgroup_key, link_type).nil?
+        results_links[group_key][subgroup_key][link_type] = []
+      end
+
+      show_to_nations = csv_row.fetch("show_to_nations")
+      nations = show_to_nations.split(" OR ") if show_to_nations.present?
+
+      show_to_vulnerable_person = csv_row.fetch("show_to_vulnerable_person")
+      show_vulnerable_link = show_to_vulnerable_person.downcase == "true" if show_to_vulnerable_person.present?
+
+      results_links[group_key][subgroup_key][link_type] << {
+        id: sprintf("%04d", csv_row.fetch("id")), # Zero pad it!
+        text: csv_row.fetch("text"),
+        href: csv_row.fetch("href"),
+        show_to_nations: nations,
+        show_to_vulnerable_person: show_vulnerable_link,
+      }.reject { |_key, value| value.blank? }
+    end
+    output.deep_stringify_keys
+  end
+
+  def overwrite_locale_links(input_locale_path, locale_hash, output_locale_path = input_locale_path)
+    existing_locale_file = YAML.load_file(input_locale_path)
+    existing_locale_file["en"]["results_link"].keys.each do |group_key|
+      existing_locale_file["en"]["results_link"][group_key].keys.each do |subgroup_key|
+        subgroup = existing_locale_file["en"]["results_link"][group_key][subgroup_key]
+        subgroup["items"] = [] # Clear out old items in case we removed some on the sheet
+        subgroup["support_and_advice"] = [] unless subgroup["support_and_advice"].nil? # ditto s&a links
+        merged_locale = subgroup.merge(locale_hash[group_key][subgroup_key])
+        existing_locale_file["en"]["results_link"][group_key][subgroup_key] = merged_locale
+      end
+    end
+
+    File.open(output_locale_path, "w") do |file|
+      file.write(existing_locale_file.to_yaml)
+    end
+  end
+end

--- a/lib/tasks/content.rake
+++ b/lib/tasks/content.rake
@@ -1,7 +1,15 @@
 namespace :content do
   desc "Exports results link content from en.yml to a csv"
-  task "export_results_to_csv" => :environment do
+  task export_results_to_csv: :environment do
     csv_data = ContentExporter.generate_results_link_csv
     File.open("tmp/results_links.csv", "w") { |file| file.write(csv_data) }
+  end
+
+  desc "Imports results link content from en.yml to a csv"
+  task :import_locale_links, [:file_path] => :environment do |_, args|
+    new_result_links = ContentImporter.import_results_links(args.fetch(:file_path))
+    ContentImporter.overwrite_locale_links("config/locales/en.yml", new_result_links)
+  rescue KeyError
+    puts "Please provide a file path"
   end
 end

--- a/spec/fixtures/en.test.yml
+++ b/spec/fixtures/en.test.yml
@@ -1,0 +1,12 @@
+en:
+  other_stuff:
+    key: "This never changes"
+  results_link:
+    group_one:
+      subgroup_one:
+        title: "I am the title for Group one - Subgroup One"
+        show_options: ["Yes"]
+        items:
+          - id: "0001"
+            text: "If you’re in immediate danger call 999 and ask for the Police."
+        

--- a/spec/fixtures/result_links_test.csv
+++ b/spec/fixtures/result_links_test.csv
@@ -1,0 +1,7 @@
+id,group_title,subgroup_title,support_and_advice,text,href,show_to_nations,show_to_vulnerable_person,group_key,subgroup_key,support_and_advice,
+0001,I am the title for Group one,I am the title for Group one subgroup one,false,"This is a row that only has text, it will appear like a paragraph","","","",group_one,subgroup_one,false
+0002,I am the title for Group one,I am the title for Group one subgroup one,false,"This is a row has text and an href, it will appear as an anchor tag",http://test.stubbed.gov.uk,"","",group_one,subgroup_one,false
+0003,I am the title for Group one,I am the title for Group one subgroup one,false,"This is a row has text, an href and group criteria, it will appear as an anchor tag if the user's answers match the criteria",http://test.stubbed.llyw.cymru,Wales,"",group_one,subgroup_one,false
+0004,I am the title for Group one,I am the title for Group one subgroup one,true,"This is a row has text, an href and multiple group criteria, it will appear as an anchor tag if the user's answers match the more complex criteria",http://test.stubbed.gb.gov.uk,Wales OR Scotland OR England,"",group_one,subgroup_one,true
+0005,I am the title for Group one,I am the title for Group one subgroup two,false,"This is a row that only has text, it will appear like a paragraph","","","",group_one,subgroup_two,false
+0006,I am the title for Group two,I am the title for Group two subgroup one,false,"This is a row that only has text, it will appear like a paragraph","","",true,group_two,subgroup_one,false

--- a/spec/lib/content_exporter_spec.rb
+++ b/spec/lib/content_exporter_spec.rb
@@ -5,18 +5,15 @@ locale_results_link_fixture = {
       items: [
         {
           id: "0001",
-          support_and_advice: false,
           text: "This is a row that only has text, it will appear like a paragraph",
         },
         {
           id: "0002",
-          support_and_advice: false,
           text: "This is a row and has text and an href, it will appear as an anchor tag",
           href: "http://test.stubbed.gov.uk",
         },
         {
           id: "0003",
-          support_and_advice: false,
           text: "This is a row and has text, an href and group criteria, it will appear as an anchor tag if the user's answers match the criteria",
           href: "http://test.stubbed.llyw.cymru",
           show_to_nations: %w[Wales],
@@ -25,7 +22,6 @@ locale_results_link_fixture = {
       support_and_advice_items: [
         {
           id: "0004",
-          support_and_advice: false,
           text: "This is a row and has text, an href and multiple group criteria, it will appear as an anchor tag if the user's answers match the more complex criteria",
           href: "http://test.stubbed.gb.gov.uk",
           show_to_nations: %w[Wales Scotland England],
@@ -55,48 +51,72 @@ RSpec.describe "ContentExporter" do
     let(:results_rows) { ContentExporter.extract_results_links }
 
     results_row_fixture = [
-      { id: "0001",
-        group_title: "I am the title for Group one",
+      {
+        id: "0001",
+        status: "Live",
+        group_and_subgroup: "I am the title for Group one | I am the title for Group one subgroup one",
         href: "",
         show_to_nations: "",
-        subgroup_title: "I am the title for Group one subgroup one",
         support_and_advice: false,
-        text: "This is a row that only has text, it will appear like a paragraph" },
-      { id: "0002",
-        group_title: "I am the title for Group one",
+        text: "This is a row that only has text, it will appear like a paragraph",
+        group_key: "group_one",
+        subgroup_key: "subgroup_one",
+      },
+      {
+        id: "0002",
+        status: "Live",
+        group_and_subgroup: "I am the title for Group one | I am the title for Group one subgroup one",
         href: "http://test.stubbed.gov.uk",
         show_to_nations: "",
-        subgroup_title: "I am the title for Group one subgroup one",
         support_and_advice: false,
-        text: "This is a row and has text and an href, it will appear as an anchor tag" },
-      { id: "0003",
-        group_title: "I am the title for Group one",
+        text: "This is a row and has text and an href, it will appear as an anchor tag",
+        group_key: "group_one",
+        subgroup_key: "subgroup_one",
+      },
+      {
+        id: "0003",
+        status: "Live",
+        group_and_subgroup: "I am the title for Group one | I am the title for Group one subgroup one",
         href: "http://test.stubbed.llyw.cymru",
         show_to_nations: "Wales",
-        subgroup_title: "I am the title for Group one subgroup one",
         support_and_advice: false,
-        text: "This is a row and has text, an href and group criteria, it will appear as an anchor tag if the user's answers match the criteria" },
-      { id: "0004",
-        group_title: "I am the title for Group one",
+        text: "This is a row and has text, an href and group criteria, it will appear as an anchor tag if the user's answers match the criteria",
+        group_key: "group_one",
+        subgroup_key: "subgroup_one",
+      },
+      {
+        id: "0004",
+        status: "Live",
+        group_and_subgroup: "I am the title for Group one | I am the title for Group one subgroup one | Support and Advice",
         href: "http://test.stubbed.gb.gov.uk",
         show_to_nations: "Wales OR Scotland OR England",
-        subgroup_title: "I am the title for Group one subgroup one",
         support_and_advice: true,
-        text: "This is a row and has text, an href and multiple group criteria, it will appear as an anchor tag if the user's answers match the more complex criteria" },
-      { id: "0005",
-        group_title: "I am the title for Group one",
+        text: "This is a row and has text, an href and multiple group criteria, it will appear as an anchor tag if the user's answers match the more complex criteria",
+        group_key: "group_one",
+        subgroup_key: "subgroup_one",
+      },
+      {
+        id: "0005",
+        status: "Live",
+        group_and_subgroup: "I am the title for Group one | I am the title for Group one subgroup two",
         href: "",
         show_to_nations: "",
-        subgroup_title: "I am the title for Group one subgroup two",
         support_and_advice: false,
-        text: "This is a row that only has text, it will appear like a paragraph" },
-      { id: "0006",
-        group_title: "I am the title for Group two",
+        text: "This is a row that only has text, it will appear like a paragraph",
+        group_key: "group_one",
+        subgroup_key: "subgroup_two",
+      },
+      {
+        id: "0006",
+        status: "Live",
+        group_and_subgroup: "I am the title for Group two | I am the title for Group two subgroup one",
         href: "",
         show_to_nations: "",
-        subgroup_title: "I am the title for Group two subgroup one",
         support_and_advice: false,
-        text: "This is a row that only has text, it will appear like a paragraph" },
+        text: "This is a row that only has text, it will appear like a paragraph",
+        group_key: "group_two",
+        subgroup_key: "subgroup_one",
+      },
     ]
 
     before do
@@ -128,12 +148,12 @@ RSpec.describe "ContentExporter" do
       expect(results_rows[0][:href]).to eq("")
     end
 
-    it "returns a heading string when a link has a group_title value" do
-      expect(results_rows[0][:group_title]).to eq("I am the title for Group one")
+    it "returns a concatenated heading string if there is a group and subgroup title" do
+      expect(results_rows[0][:group_and_subgroup]).to eq("I am the title for Group one | I am the title for Group one subgroup one")
     end
 
-    it "returns a heading string when a link has a subgroup_title value" do
-      expect(results_rows[0][:subgroup_title]).to eq("I am the title for Group one subgroup one")
+    it "returns a concatenated heading string with Support and Advice on the end if it's a support and advice link" do
+      expect(results_rows[3][:group_and_subgroup]).to eq("I am the title for Group one | I am the title for Group one subgroup one | Support and Advice")
     end
 
     it "returns a text string when a link has a text value" do
@@ -174,13 +194,14 @@ RSpec.describe "ContentExporter" do
   end
 
   describe "#generate_results_link_csv" do
-    csv_fixture = "id,group_title,subgroup_title,support_and_advice,text,href,show_to_nations\n" \
-      "0001,I am the title for Group one,I am the title for Group one subgroup one,false,\"This is a row that only has text, it will appear like a paragraph\",\"\",\"\"\n" \
-      "0002,I am the title for Group one,I am the title for Group one subgroup one,false,\"This is a row and has text and an href, it will appear as an anchor tag\",http://test.stubbed.gov.uk,\"\"\n" \
-      "0003,I am the title for Group one,I am the title for Group one subgroup one,false,\"This is a row and has text, an href and group criteria, it will appear as an anchor tag if the user's answers match the criteria\",http://test.stubbed.llyw.cymru,Wales\n" \
-      "0004,I am the title for Group one,I am the title for Group one subgroup one,true,\"This is a row and has text, an href and multiple group criteria, it will appear as an anchor tag if the user's answers match the more complex criteria\",http://test.stubbed.gb.gov.uk,Wales OR Scotland OR England\n" \
-      "0005,I am the title for Group one,I am the title for Group one subgroup two,false,\"This is a row that only has text, it will appear like a paragraph\",\"\",\"\"\n" \
-      "0006,I am the title for Group two,I am the title for Group two subgroup one,false,\"This is a row that only has text, it will appear like a paragraph\",\"\",\"\"\n"
+    csv_fixture = "id,status,group_and_subgroup,text,href,show_to_nations,group_key,subgroup_key,support_and_advice\n"\
+    "0001,Live,I am the title for Group one | I am the title for Group one subgroup one,\"This is a row that only has text, it will appear like a paragraph\",\"\",\"\",group_one,subgroup_one,false\n"\
+    "0002,Live,I am the title for Group one | I am the title for Group one subgroup one,\"This is a row and has text and an href, it will appear as an anchor tag\",http://test.stubbed.gov.uk,\"\",group_one,subgroup_one,false\n"\
+    "0003,Live,I am the title for Group one | I am the title for Group one subgroup one,\"This is a row and has text, an href and group criteria, it will appear as an anchor tag if the user's answers match the criteria\",http://test.stubbed.llyw.cymru,Wales,group_one,subgroup_one,false\n"\
+    "0004,Live,I am the title for Group one | I am the title for Group one subgroup one | Support and Advice,\"This is a row and has text, an href and multiple group criteria, it will appear as an anchor tag if the user's answers match the more complex criteria\",http://test.stubbed.gb.gov.uk,Wales OR Scotland OR England,group_one,subgroup_one,true\n"\
+    "0005,Live,I am the title for Group one | I am the title for Group one subgroup two,\"This is a row that only has text, it will appear like a paragraph\",\"\",\"\",group_one,subgroup_two,false\n"\
+    "0006,Live,I am the title for Group two | I am the title for Group two subgroup one,\"This is a row that only has text, it will appear like a paragraph\",\"\",\"\",group_two,subgroup_one,false\n"
+
     let(:csv) { ContentExporter.generate_results_link_csv }
 
     before do
@@ -189,7 +210,7 @@ RSpec.describe "ContentExporter" do
     end
 
     it "outputs a csv with correct headers" do
-      expect(csv.split("\n").first).to eql("id,group_title,subgroup_title,support_and_advice,text,href,show_to_nations")
+      expect(csv.split("\n").first).to eql("id,status,group_and_subgroup,text,href,show_to_nations,group_key,subgroup_key,support_and_advice")
     end
 
     it "outputs a well formatted csv" do

--- a/spec/lib/content_importer_spec.rb
+++ b/spec/lib/content_importer_spec.rb
@@ -1,0 +1,158 @@
+require "tempfile"
+
+locale_data_fixture = {
+  "group_one" => {
+    "subgroup_one" => {
+      "items" => [
+        {
+          "id" => "0001",
+          "text" => "This is a row that only has text, it will appear like a paragraph",
+        },
+        {
+          "href" => "http://test.stubbed.gov.uk",
+          "id" => "0002",
+          "text" => "This is a row has text and an href, it will appear as an anchor tag",
+        },
+        {
+          "href" => "http://test.stubbed.llyw.cymru",
+          "id" => "0003",
+          "show_to_nations" => %w[
+            Wales
+          ],
+          "text" => "This is a row has text, an href and group criteria, it will appear as an anchor tag if the user's answers match the criteria",
+        },
+      ],
+      "support_and_advice" => [
+        {
+          "href" => "http://test.stubbed.gb.gov.uk",
+          "id" => "0004",
+          "show_to_nations" => %w[
+            Wales
+            Scotland
+            England
+          ],
+          "text" => "This is a row has text, an href and multiple group criteria, it will appear as an anchor tag if the user's answers match the more complex criteria",
+        },
+      ],
+    },
+    "subgroup_two" => {
+      "items" => [
+        {
+          "id" => "0005",
+          "text" => "This is a row that only has text, it will appear like a paragraph",
+        },
+      ],
+    },
+  },
+  "group_two" => {
+    "subgroup_one" => {
+      "items" => [
+        {
+          "id" => "0006",
+          "text" => "This is a row that only has text, it will appear like a paragraph",
+          "show_to_vulnerable_person" => true,
+        },
+      ],
+    },
+  },
+}
+
+RSpec.describe "ContentImporter" do
+  describe "#import_results_links" do
+    let(:test_csv_path) { Rails.root.join("spec/fixtures/result_links_test.csv").to_s }
+    let(:output_locale) { ContentImporter.import_results_links(test_csv_path) }
+
+    it "outputs result links nested under the correct groups" do
+      expect(output_locale.keys).to eql(locale_data_fixture.keys)
+    end
+
+    it "outputs results links nested under the correct subgroups" do
+      output_subgroups = output_locale.keys.map { |group_key| output_locale[group_key].keys }
+      expected_subgroups = locale_data_fixture.keys.map { |group_key| locale_data_fixture[group_key].keys }
+
+      expect(output_subgroups).to eql(expected_subgroups)
+    end
+
+    it "outputs text only items with id and text key value pairs" do
+      output_item = output_locale["group_one"]["subgroup_one"]["items"].first
+      expected_item = locale_data_fixture["group_one"]["subgroup_one"]["items"].first
+      expect(output_item.keys).to match_array(%w[id text])
+      expect(output_item.values).to eql(expected_item.values)
+    end
+
+    it "outputs hyperlink text with id, href and text key value pairs" do
+      output_item = output_locale["group_one"]["subgroup_one"]["items"][1]
+      expected_item = locale_data_fixture["group_one"]["subgroup_one"]["items"][1]
+      expect(output_item.keys).to match_array(%w[id text href])
+      expect(output_item.values).to match_array(expected_item.values)
+    end
+
+    it "outputs conditional hyperlink text with id, href, text key, national criteria value pairs" do
+      output_item = output_locale["group_one"]["subgroup_one"]["items"][2]
+      expect(output_item.keys).to match_array(%w[id text href show_to_nations])
+      expect(output_item["show_to_nations"]).to match_array(%w[Wales])
+    end
+
+    it "outputs support and advice link as a sibling of items" do
+      output_item = output_locale["group_one"]["subgroup_one"]
+      expected_item = locale_data_fixture["group_one"]["subgroup_one"]
+      expect(output_item.keys).to match_array(%w[items support_and_advice])
+      expect(output_item["support_and_advice"]).to match_array(expected_item["support_and_advice"])
+    end
+
+    it "outputs multiple OR conditional hyperlink text with id, href, text key, national criteria value pairs" do
+      output_item = output_locale["group_one"]["subgroup_one"]["support_and_advice"].first
+      expect(output_item.keys).to match_array(%w[id text href show_to_nations])
+      expect(output_item["show_to_nations"]).to match_array(%w[Wales Scotland England])
+    end
+
+    it "outputs a show_to_vulnerable_person true toggle if true in csv" do
+      output_item = output_locale["group_two"]["subgroup_one"]["items"].first
+      expect(output_item["show_to_vulnerable_person"]).to be(true)
+    end
+
+    it "should prune show_to_vulnerable_person keys that are empty" do
+      output_item = output_locale["group_one"]["subgroup_two"]["items"].first
+      expect(output_item["show_to_vulnerable_person"]).to be(nil)
+    end
+  end
+
+  describe "#overwrite_locale_links" do
+    let(:test_input_file) { "spec/fixtures/en.test.yml" }
+    let(:temp_test_output_file) { Tempfile.new("en.temp_test.yml") }
+    let(:test_csv_path) { Rails.root.join("spec/fixtures/result_links_test.csv").to_s }
+
+    after(:each) do
+      temp_test_output_file.delete
+    end
+
+    it "writes out to a YAML file" do
+      lines_written = ContentImporter.overwrite_locale_links(
+        test_input_file,
+        locale_data_fixture,
+        temp_test_output_file,
+      )
+      expect(lines_written).to be > 1 # check we write more than 1 line, amount varies as we add to locale
+    end
+
+    it "changes the YAML file that is already there" do
+      expect(YAML.load_file(temp_test_output_file)).to eql(false)
+      ContentImporter.overwrite_locale_links(
+        test_input_file,
+        locale_data_fixture,
+        temp_test_output_file,
+      )
+      expect(YAML.load_file(temp_test_output_file)).not_to eql(YAML.load_file(test_input_file))
+    end
+
+    it "other parts of the locale file remain unchanged" do
+      expect(YAML.load_file(temp_test_output_file)).to eql(false)
+      ContentImporter.overwrite_locale_links(
+        test_input_file,
+        locale_data_fixture,
+        temp_test_output_file,
+      )
+      expect(YAML.load_file(temp_test_output_file)["en"]["other_stuff"]["key"]).to eql("This never changes")
+    end
+  end
+end

--- a/spec/lib/tasks/content_export_results_to_csv_spec.rb
+++ b/spec/lib/tasks/content_export_results_to_csv_spec.rb
@@ -1,10 +1,6 @@
 RSpec.describe "content:export_results_to_csv" do
   include_context "rake"
 
-  before do
-    allow(ContentExporter).to receive(:generate_results_link_csv).and_return("csv\n woop")
-  end
-
   it "should include environment as a prerequisite" do
     expect(subject.prerequisites).to include("environment")
   end

--- a/spec/lib/tasks/content_import_locale_links_spec.rb
+++ b/spec/lib/tasks/content_import_locale_links_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe "content:import_locale_links" do
+  include_context "rake"
+
+  it "should include environment as a prerequsite" do
+    expect(subject.prerequisites).to include("environment")
+  end
+
+  before do
+    allow(ContentImporter).to receive(:import_results_links)
+    allow(ContentImporter).to receive(:overwrite_locale_links)
+  end
+
+  it "imports result links from a csv" do
+    subject.invoke("spec/fixtures/result_links_test.csv")
+    expect(ContentImporter).to have_received(:import_results_links)
+  end
+
+  it "imports overwrites the existing file with the results" do
+    subject.invoke("spec/fixtures/result_links_test.csv")
+    expect(ContentImporter).to have_received(:overwrite_locale_links)
+  end
+
+  it "should print warning to the console if no path is provided" do
+    expect { subject.invoke }.to output("Please provide a file path\n").to_stdout
+  end
+end


### PR DESCRIPTION
What
----

- Some further tweaks to the exporter spec (I realised some stuff was missing i'd need to import!)
- Adds a task that imports from a CSV and overwrites the locale file

Why
----

There are regular content updates to the triage tool, but we don't have a publishing interface.
Given the fiddly nature of these updates there is less chance for Human Error if we can do the updates in a google sheet compared to using a doc as current.

This PR adds an import task that takes a csv exported from the content spreadsheet, import it and use it to overwrite the locale file.

Currently that is a manual process (it saves the CSV to tmp) but this can be automated in future for a dev to run and update locally via rake and the Google API.

How to review
-------------

- Check Rubocop Passes
- Reivew the test suite and check it makes sense
- Check the tests pass
- Look over the logic and offer any comments.

Links
-----

- Trello [Results page update (3/3): Rearrange content](https://trello.com/c/rbRyihX0/401-results-page-update-3-3-rearrange-content)
- Spreadsheet - [Find Support - Results Content Sheet](https://docs.google.com/spreadsheets/d/11jtiwMovC9736F7ZV9k3gDbOpMMGqnSsiRmlD0JFCpQ/edit#gid=0)

