### PR TITLE
Altered deploy to account for staging and production metrics routes

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -58,7 +58,13 @@ run:
       cf v3-zdt-push govuk-coronavirus-find-support --wait-for-deploy-complete --no-route
       cf map-route govuk-coronavirus-find-support cloudapps.digital --hostname "$HOSTNAME"
 
-      cf map-route govuk-coronavirus-find-support find-coronavirus-support.service.gov.uk --path metrics
-      cf map-route govuk-coronavirus-find-support cloudapps.digital --hostname govuk-coronavirus-find-support-prod --path metrics
-      cf bind-route-service find-coronavirus-support.service.gov.uk re-ip-whitelist-service --path metrics
-      cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname govuk-coronavirus-find-support-prod --path metrics
+      if [[ "${CF_SPACE:-}" = "staging" ]]; then
+        cf map-route govuk-coronavirus-find-support cloudapps.digital --hostname govuk-coronavirus-find-support-stg --path metrics
+        cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname govuk-coronavirus-find-support-stg --path metrics
+      fi
+      if [[ "${CF_SPACE:-}" = "production" ]]; then
+        cf map-route govuk-coronavirus-find-support find-coronavirus-support.service.gov.uk --path metrics
+        cf map-route govuk-coronavirus-find-support cloudapps.digital --hostname govuk-coronavirus-find-support-prod --path metrics
+        cf bind-route-service find-coronavirus-support.service.gov.uk re-ip-whitelist-service --path metrics
+        cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname govuk-coronavirus-find-support-prod --path metrics
+      fi


### PR DESCRIPTION
Very minor change to fix the route mappings, which applied production routes to staging, in the same manner as https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/pull/324

Presumably the same note applies here too:
> We should manually fix the issue in staging prior to merging.