### PR TITLE
Remove cf routing from concourse job

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -57,14 +57,3 @@ run:
 
       cf v3-zdt-push govuk-coronavirus-find-support --wait-for-deploy-complete --no-route
       cf map-route govuk-coronavirus-find-support cloudapps.digital --hostname "$HOSTNAME"
-
-      if [[ "${CF_SPACE:-}" = "staging" ]]; then
-        cf map-route govuk-coronavirus-find-support cloudapps.digital --hostname govuk-coronavirus-find-support-stg --path metrics
-        cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname govuk-coronavirus-find-support-stg --path metrics
-      fi
-      if [[ "${CF_SPACE:-}" = "production" ]]; then
-        cf map-route govuk-coronavirus-find-support find-coronavirus-support.service.gov.uk --path metrics
-        cf map-route govuk-coronavirus-find-support cloudapps.digital --hostname govuk-coronavirus-find-support-prod --path metrics
-        cf bind-route-service find-coronavirus-support.service.gov.uk re-ip-whitelist-service --path metrics
-        cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname govuk-coronavirus-find-support-prod --path metrics
-      fi


### PR DESCRIPTION
Doing a 'cf bind-route-service' multiple times leads to duplicate bindings.

We could keep the map-route calls in here, but they don't make sense without the context of the bind-route, which will have to be done manually.