### PR TITLE
Restrict components guide to development env

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,6 @@ Rails.application.routes.draw do
     get "/data-export", to: "data_export#show"
   end
 
-  mount GovukPublishingComponents::Engine, at: "/component-guide"
+  mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
   mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
 end

--- a/spec/requests/components_guide_spec.rb
+++ b/spec/requests/components_guide_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe "Components guide", type: :request do
+  describe "GET /components-guide" do
+    context "in test" do
+      it "raises an error" do
+        expect {
+          get "/component-guide"
+        }.to(raise_error ActionController::RoutingError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Now `/component-guide` won't be available in production.

https://trello.com/c/6QWT52eB/496-prevent-production-apps-rendering-component-guide?menu=filter&filter=label:Tech