### PR TITLE
(2/2) Conditional Support + Advice Section in results page.

### DIFF
--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -22,8 +22,8 @@ module ResultsHelper
   end
 
   def filter_results_by_multiple_questions(question_results)
-    question_results[:items] = question_results[:items].select do |item|
-      show_to_nations_check(item) && show_to_vulnerable_check(item)
+    %i[items support_and_advice_items].each do |item_type|
+      question_results[item_type] = filter_item_type_results_by_multiple_questions(item_type, question_results)
     end
     question_results
   end
@@ -54,6 +54,13 @@ module ResultsHelper
   end
 
 private
+
+  def filter_item_type_results_by_multiple_questions(item_type, question_results)
+    question_results[item_type] ||= []
+    question_results[item_type].select do |item|
+      show_to_nations_check(item) && show_to_vulnerable_check(item)
+    end
+  end
 
   def show_to_nations_check(item)
     item[:show_to_nations].nil? || item[:show_to_nations].include?(session[:nation])

--- a/app/views/components/_actions-group.html.erb
+++ b/app/views/components/_actions-group.html.erb
@@ -14,7 +14,7 @@
           <% %i[items support_and_advice_items].each do |item_type| %>
             <% if subsection[item_type]&.any? %>
               <% if item_type == :support_and_advice_items %>
-                <h3 class="govuk-heading-s"><%= t("coronavirus_form.results.support_and_advice_text") %></h3>
+                <h4 class="govuk-heading-s"><%= t("coronavirus_form.results.support_and_advice_text") %></h4>
               <% end %>
               <ul class="govuk-list">
               <% subsection[item_type].each do |item| %>

--- a/app/views/components/_actions-group.html.erb
+++ b/app/views/components/_actions-group.html.erb
@@ -11,9 +11,13 @@
       <% subsections.each do |subsection| %>
         <div data-ec-list-subsection="<%= subsection[:title] %>">
           <h3 class="govuk-heading-m"><%= subsection[:title] %></h3>
-          <% if subsection[:items].any? %>
-            <ul class="govuk-list">
-              <% subsection[:items].each do |item| %>
+          <% %i[items support_and_advice_items].each do |item_type| %>
+            <% if subsection[item_type]&.any? %>
+              <% if item_type == :support_and_advice_items %>
+                <h3 class="govuk-heading-s"><%= t("coronavirus_form.results.support_and_advice_text") %></h3>
+              <% end %>
+              <ul class="govuk-list">
+              <% subsection[item_type].each do |item| %>
                 <li>
                   <% if item[:href] %>
                     <%= link_to item[:text], item[:href], class: "govuk-link" %>
@@ -22,7 +26,8 @@
                   <% end %>
                 </li>
               <% end %>
-            </ul>
+              </ul>
+            <% end %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/components/docs/actions-group.yml
+++ b/app/views/components/docs/actions-group.yml
@@ -14,6 +14,9 @@ examples:
             - text: "Get information on getting referred to a food bank from Citizens Advice"
               href: "#"
             - text: 'Get information on getting support from a food bank from the <a href="#" class="govuk-link">Trussell Trust</a>'
+          support_and_advice_items:
+            - text: "Help if you are finding it hard to afford food"
+              href: "#"
         - title: "If you’re you unable to get food:"
           items:
             - text: "Find your local council to contact them for support"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -378,6 +378,7 @@ en:
         title: Information based on your answers
         title_no_results: Information based on your answers - no specific information
         start_again_text: Start again
+      support_and_advice_text: Support and advice
       feedback:
         text: Help us improve
         link_text: Give feedback on this service

--- a/spec/helpers/result_helper_spec.rb
+++ b/spec/helpers/result_helper_spec.rb
@@ -78,6 +78,22 @@ RSpec.describe ResultsHelper, type: :helper do
       expect(filter_results_by_multiple_questions(test_hash.dup)[:items]).to eq([{ show_to_nations: "nation 1" }])
     end
 
+    it "should return support_items using same mechanism as items" do
+      session.merge!({
+        "nation": "nation 1",
+      })
+      test_hash = {
+        items: [
+          { show_to_nations: "nation 1" },
+        ],
+        support_and_advice_items: [
+          { show_to_nations: "nation 1" },
+          { show_to_nations: "nation 2" },
+        ],
+      }
+      expect(filter_results_by_multiple_questions(test_hash.dup)[:support_and_advice_items]).to eq([{ show_to_nations: "nation 1" }])
+    end
+
     let(:vulnerable_person_label) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_high_risk.label") }
     let(:not_vulnerable_label) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_other.label") }
 


### PR DESCRIPTION
What
----
The results page needs to distinguish between different types of links and offer users clearer expectations of onwards journeys.

Add markup with a condition for "Support and Advice" sections within a group.

For a given group, if there are "Support and Advice" links, then render the heading + any links. If there are no links then do not show the heading.

NB: A "group" may not have any Support + Advice links. But if there are Support and advice links there will always be "main" links directly under the `h3`

How
---

Support and advice items are listed in the en.yml file and are handled in the same way as regular items. The support items will appear below the regular items.

How to review
-------------

In development, manual testing can be done by adding `support_and_advice_items` at the same level as `items` in the results section of the en.yml file.

In staging or production, testing will need to be coordinated with the cards
https://trello.com/c/Am4icV9a/399-results-page-update-1-3-change-heading-sizes
https://trello.com/c/rbRyihX0/401-results-page-update-3-3-rearrange-content

Links
-----

https://trello.com/c/RWmAHtdt/400-results-page-update-2-3-conditional-support-advice-section

