### PR TITLE
Add nicer looking apostrophes to cookie page

### DIFF
--- a/app/views/coronavirus_form/cookies.html.erb
+++ b/app/views/coronavirus_form/cookies.html.erb
@@ -34,7 +34,7 @@
   <div class="cookie-settings__form-wrapper">
     <p>
       We use <%= t("cookies.settings_page.cookies").count %> types of cookie.
-      You can choose which cookies you're happy for us to use.
+      You can choose which cookies you’re happy for us to use.
     </p>
 
     <form data-module="cookie-settings">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,7 +133,7 @@ en:
           <li>turning on Javascript in your browser</li>
         </ul>
       intro_html: |
-        <p class="govuk-body">This service puts small files (known as 'cookies') onto your computer.</p>
+        <p class="govuk-body">This service puts small files (known as ‘cookies’) onto your computer.</p>
         <p class="govuk-body">Cookies are used to:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>keep which question you’re up to and how you’ve answered previous questions</li>


### PR DESCRIPTION
What
----

Replaced `'` with the appropriate curly quote mark `‘` or `’`

How to review
-------------

This change only affects the cookie page - `/cookies` - so that's the only page that needs to be checked.

Check that there aren't `'` on the page.

Visual differences
---
Before:

![image](https://user-images.githubusercontent.com/1732331/82669289-1a7ebc80-9c33-11ea-8ae8-eda9c2978294.png)

After:

![image](https://user-images.githubusercontent.com/1732331/82669236-ff13b180-9c32-11ea-853a-7bcd3836c98f.png)
