### PR TITLE
Update options for "need help with question"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,7 +212,7 @@ en:
             custom_select_error: "Select what you need to find help with, or ‘I’m not sure’"
       feeling_unsafe:
         title: "Feeling unsafe"
-        need_help_with_label: "Feeling unsafe where you live, or being worried about someone else"
+        need_help_with_label: "Feeling unsafe where you live, or what to do if you’re worried about the safety of another adult or child"
         questions:
           feel_safe:
             title: "Do you feel safe where you live?"
@@ -345,6 +345,7 @@ en:
             custom_select_error: "Select if you have been evicted or might be soon"
       mental_health:
         title: "Mental health and wellbeing"
+        need_help_with_label: "Mental health and wellbeing, including information for children"
         questions:
           mental_health_worries:
             title: "Are you worried about your mental health, or another adult or child’s mental health?"

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -21,7 +21,7 @@ module FillInTheFormSteps
     check I18n.t("coronavirus_form.groups.being_unemployed.title")
     check I18n.t("coronavirus_form.groups.going_in_to_work.title")
     check I18n.t("coronavirus_form.groups.somewhere_to_live.title")
-    check I18n.t("coronavirus_form.groups.mental_health.title")
+    check I18n.t("coronavirus_form.groups.mental_health.need_help_with_label")
     check I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.options").first
 
     click_on I18n.t("coronavirus_form.submit_and_next")


### PR DESCRIPTION
What
----

Updating the alias for two groups to make it clearer that these options are also for children.

This will not affect the analytics in Data Studio, since we are exporting the group names rather than their alias.

![Screenshot 2020-05-24 at 11 25 02](https://user-images.githubusercontent.com/6329861/82751832-f1d10100-9db1-11ea-80d0-80d1d1195701.png)

How to review
-------------

- Review code changes
- Run application locally and navigate to `/need-help-with`

Links
-----

Trello card: https://trello.com/c/4DPQaytD