### PR TITLE
Alert Slack when Concourse tasks fail

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -117,6 +117,17 @@ jobs:
           DATA_EXPORT_BASIC_AUTH_USERNAME: ((data-export-basic-auth-username))
           DATA_EXPORT_BASIC_AUTH_PASSWORD: ((data-export-basic-auth-password))
           HOSTNAME: govuk-coronavirus-find-support-stg
+        on_failure:
+          put: govuk-coronavirus-services-tech-slack
+          params:
+            channel: '#govuk-corona-services-tech'
+            username: 'Concourse (Find Support Service)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Deploy to staging for the Find Support service has failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
   - name: smoke-test-staging
     plan:
@@ -169,6 +180,17 @@ jobs:
           DATA_EXPORT_BASIC_AUTH_USERNAME: ((data-export-basic-auth-username))
           DATA_EXPORT_BASIC_AUTH_PASSWORD: ((data-export-basic-auth-password))
           HOSTNAME: govuk-coronavirus-find-support-prod
+        on_failure:
+          put: govuk-coronavirus-services-tech-slack
+          params:
+            channel: '#govuk-corona-services-tech'
+            username: 'Concourse (Find Support Service)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Deploy to production for the Find Support service has failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
   - name: smoke-test-prod
     serial: true

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -1,4 +1,11 @@
 ---
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
 resources:
   - name: git-master
     type: git
@@ -29,6 +36,11 @@ resources:
     source:
       repository: ((readonly_private_ecr_repo_url))
       tag: govuk-coronavirus-find-support-tests-image
+
+  - name: govuk-coronavirus-services-tech-slack
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/((slack_webhook_url))
 
 jobs:
   - name: update-pipeline

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -136,6 +136,17 @@ jobs:
         file: git-master/concourse/tasks/run-smoke-tests.yml
         params:
           TEST_URL: 'https://gds:((basic-auth-password))@govuk-coronavirus-find-support-stg.cloudapps.digital'
+        on_failure:
+          put: govuk-coronavirus-services-tech-slack
+          params:
+            channel: '#govuk-corona-services-tech'
+            username: 'Concourse (Find Support Service)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Staging smoke tests for the Find Support service have failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
   - name: deploy-to-prod
     serial: true
@@ -179,3 +190,14 @@ jobs:
         file: git-master/concourse/tasks/run-smoke-tests.yml
         params:
           TEST_URL: 'https://find-coronavirus-support.service.gov.uk'
+        on_failure:
+          put: govuk-coronavirus-services-tech-slack
+          params:
+            channel: '#govuk-corona-services-tech'
+            username: 'Concourse (Find Support Service)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Production smoke tests for the Find Support service have failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME


### PR DESCRIPTION
What
----

Posts a message to #govuk-corona-services-tech on Slack when Concourse tasks fail.

Makes the same change as in https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/364.

Example:
![Screenshot 2020-05-26 at 14 08 39](https://user-images.githubusercontent.com/6329861/82904498-79f20a80-9f5a-11ea-8c69-e410ec1756f2.png)

Links
-----

Trello card: https://trello.com/c/TSaLQkQp