### PR TITLE
Expose results links csv via http

### DIFF
--- a/app/controllers/coronavirus_form/data_export_results_links_controller.rb
+++ b/app/controllers/coronavirus_form/data_export_results_links_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class CoronavirusForm::DataExportResultsLinksController < ApplicationController
+  if ENV.key?("DATA_EXPORT_BASIC_AUTH_USERNAME") && ENV.key?("DATA_EXPORT_BASIC_AUTH_PASSWORD")
+    http_basic_authenticate_with(
+      name: ENV.fetch("DATA_EXPORT_BASIC_AUTH_USERNAME"),
+      password: ENV.fetch("DATA_EXPORT_BASIC_AUTH_PASSWORD"),
+    )
+  end
+
+  def show
+    respond_to do |format|
+      format.html
+      format.csv do
+        render csv: ContentExporter.generate_results_link_csv
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
     get "/session-expired", to: "session_expired#show"
 
     get "/data-export", to: "data_export#show"
+    get "/data-export-results-links", to: "data_export_results_links#show"
   end
 
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?

--- a/spec/requests/data_export_results_links_spec.rb
+++ b/spec/requests/data_export_results_links_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe "data-export-results-links", type: :request do
+  let(:csv_fixture) do
+    "id,status,group_and_subgroup,text,href,show_to_nations,group_key,subgroup_key,support_and_advice\n"\
+    "0001,Live,I am the title for Group one | I am the title for Group one subgroup one,\"This is a row that only has text, it will appear like a paragraph\",\"\",\"\",group_one,subgroup_one,false\n"\
+    "0002,Live,I am the title for Group one | I am the title for Group one subgroup one,\"This is a row and has text and an href, it will appear as an anchor tag\",http://test.stubbed.gov.uk,\"\",group_one,subgroup_one,false\n"\
+    "0003,Live,I am the title for Group one | I am the title for Group one subgroup one,\"This is a row and has text, an href and group criteria, it will appear as an anchor tag if the user's answers match the criteria\",http://test.stubbed.llyw.cymru,Wales,group_one,subgroup_one,false\n"\
+    "0004,Live,I am the title for Group one | I am the title for Group one subgroup one | Support and Advice,\"This is a row and has text, an href and multiple group criteria, it will appear as an anchor tag if the user's answers match the more complex criteria\",http://test.stubbed.gb.gov.uk,Wales OR Scotland OR England,group_one,subgroup_one,true\n"\
+    "0005,Live,I am the title for Group one | I am the title for Group one subgroup two,\"This is a row that only has text, it will appear like a paragraph\",\"\",\"\",group_one,subgroup_two,false\n"\
+    "0006,Live,I am the title for Group two | I am the title for Group two subgroup one,\"This is a row that only has text, it will appear like a paragraph\",\"\",\"\",group_two,subgroup_one,false\n"
+  end
+
+  before do
+    allow(ContentExporter).to receive(:generate_results_link_csv) { csv_fixture }
+  end
+
+  describe "GET /data-export-results-links" do
+    context "with basic auth enabled" do
+      it "rejects unauthenticated users" do
+        get data_export_results_links_path,
+            headers: {
+              "HTTP_ACCEPT" => "text/csv",
+            }
+        expect(response).to have_http_status(401)
+      end
+
+      it "permits authenticated users" do
+        username = ENV["DATA_EXPORT_BASIC_AUTH_USERNAME"]
+        password = ENV["DATA_EXPORT_BASIC_AUTH_PASSWORD"]
+        get data_export_results_links_path,
+            headers: {
+              "HTTP_ACCEPT" => "text/csv",
+              "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password),
+            }
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    it "returns all results links in CSV format" do
+      username = ENV["DATA_EXPORT_BASIC_AUTH_USERNAME"]
+      password = ENV["DATA_EXPORT_BASIC_AUTH_PASSWORD"]
+      get data_export_results_links_path,
+          headers: {
+            "HTTP_ACCEPT" => "text/csv",
+            "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password),
+          }
+      csv_fixture.split("\n").each { |line| expect(response.body).to have_content(line) }
+    end
+  end
+end


### PR DESCRIPTION
What
----

Adds a basic authenticated HTTP endpoint for the exported CSV of the results links. This can then be scraped via the [content sheet]('https://docs.google.com/spreadsheets/d/11jtiwMovC9736F7ZV9k3gDbOpMMGqnSsiRmlD0JFCpQ/edit?userstoinvite=adam.robertson%40digital.cabinet-office.gov.uk&ts=5ec26dc5&actionButton=1#gid=754001789') on the copy-of-live tab

Why
----

This will give us a way of communicating when changes have been made within the Google Sheet to content editors, and also let them know the moment their work has gone live


How to review
-------------

Check over the code and tests, check it makes sense.
And check an HTTP authed endpoint exists on production that serves a CSV.

Links
-----
- Trello: [Content as data + loading from a google sheet](https://trello.com/c/xRZn6njn/126-content-as-data-loading-from-a-google-sheet)
