### PR TITLE
Can you leave home update

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -378,15 +378,13 @@ en:
               option_yes:
                 label: 'Yes'
               option_has_symptoms:
-                label: I should not leave home because I have coronavirus symptoms,
-                  or someone in my household does
+                label: No, I should not leave home because I have coronavirus symptoms, or someone in my household does
               option_high_risk:
-                label: I should not leave home because I think I’m at high risk of
-                  severe illness from coronavirus
+                label: No, I should not leave home because I have a medical condition which means I’m extremely vulnerable to coronavirus
               option_disability:
-                label: I cannot go out because I have a disability
+                label: No, I’m unable to go out because I have a disability
               option_other:
-                label: I’m unable to leave my home for another reason
+                label: No, I’m unable to leave my home for another reason
             custom_select_error: Select if you’re able to leave your home or not
     results:
       header:


### PR DESCRIPTION
https://trello.com/c/aXMaw8Ng/405-improve-the-are-you-able-to-leave-your-home-for-food-medicine-or-health-reasons-question

What
----
Changed options on are you able to leave home question.

Why - easier to understand and better signpost people to the right services 

How to review
-------------
Check that the answer to point people who are extremely vulnerable to food, if they can't leave home, still shows and works - line 629   'show_to_vulnerable_person: true'

I put the radio button content all on one line, but before it seemed to have been made to wrap on 2 lines. Will this still work?

-----

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Describe the steps required to review and test the changes.

Links
-----

Add links to any relevant [Trello cards](https://trello.com/b/9Pvq5z2n/govuk-coronavirus-services-team-doing-board),
Zendesk tickets or Sentry issues.

