### PR TITLE
Export data for number of times checkboxes on need-help-with are selected per day

### DIFF
--- a/app/controllers/coronavirus_form/data_export_checkbox_controller.rb
+++ b/app/controllers/coronavirus_form/data_export_checkbox_controller.rb
@@ -1,0 +1,43 @@
+require "csv"
+
+class CoronavirusForm::DataExportCheckboxController < ApplicationController
+  include DataExportCheckboxHelper
+
+  if ENV.key?("DATA_EXPORT_BASIC_AUTH_USERNAME") && ENV.key?("DATA_EXPORT_BASIC_AUTH_PASSWORD")
+    http_basic_authenticate_with(
+      name: ENV.fetch("DATA_EXPORT_BASIC_AUTH_USERNAME"),
+      password: ENV.fetch("DATA_EXPORT_BASIC_AUTH_PASSWORD"),
+    )
+  end
+
+  def show
+    respond_to do |format|
+      format.html
+      format.csv do
+        render csv: produce_csv(usage_statistics(params[:start_date], params[:end_date])),
+               filename: "data-export"
+      end
+    end
+  end
+
+private
+
+  def produce_csv(results)
+    question = I18n.t("coronavirus_form.groups")[:filter_questions][:questions][:need_help_with][:title]
+    csv_data = CSV.generate(col_sep: "|") do |csv|
+      csv << %w[question answer date count]
+      results.each do |_question, value|
+        value.each do |k|
+          csv << [
+            question,
+            k[:response],
+            k[:date],
+            k[:count],
+          ]
+        end
+      end
+    end
+
+    csv_data
+  end
+end

--- a/app/helpers/data_export_checkbox_helper.rb
+++ b/app/helpers/data_export_checkbox_helper.rb
@@ -1,0 +1,46 @@
+module DataExportCheckboxHelper
+  def usage_statistics(start_date, end_date)
+    start_date = start_date ? Date.parse(sanitize(start_date)).beginning_of_day : service_start_date
+    end_date = end_date ? Date.parse(sanitize(end_date)).end_of_day : nil
+
+    results = {}
+    counts = Hash.new(0)
+
+    responses(start_date, end_date).each do |response|
+      counts[response] += 1
+    end
+
+    counts.each do |(option_text, created_date), count|
+      results.merge!(result(option_text, created_date, count))
+    end
+
+    results
+  end
+
+private
+
+  def service_start_date
+    Date.parse("2020-03-23").beginning_of_day
+  end
+
+  def result(option_text, created_date, count)
+    {
+      [option_text, created_date].join(" ").to_s => [{
+        response: option_text,
+        date: created_date,
+        count: count,
+      }],
+    }
+  end
+
+  def responses(start_date, end_date)
+    FormResponse
+    .where(created_at: start_date..end_date)
+    .pluck(Arel.sql("created_at::date, form_response -> 'need_help_with'"))
+    .flat_map do |created_date, selected_options|
+      selected_options.map do |option|
+        [option, created_date.to_date]
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,8 @@ Rails.application.routes.draw do
 
     get "/data-export", to: "data_export#show"
     get "/data-export-results-links", to: "data_export_results_links#show"
+
+    get "/data-export-checkbox", to: "data_export_checkbox#show"
   end
 
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?

--- a/spec/helpers/data_export_checkbox_helper_spec.rb
+++ b/spec/helpers/data_export_checkbox_helper_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+
+RSpec.describe DataExportCheckboxHelper, type: :helper do
+  before do
+    FormResponse.create(
+      form_response: {
+        need_help_with: [I18n.t("coronavirus_form.groups.getting_food.title")],
+      },
+      created_at: "2020-04-10 12:00:00",
+    )
+    FormResponse.create(
+      form_response: {
+        need_help_with: [I18n.t("coronavirus_form.groups.getting_food.title")],
+      },
+      created_at: "2020-04-10 12:00:00",
+    )
+    FormResponse.create(
+      form_response: {
+        need_help_with: [I18n.t("coronavirus_form.groups.paying_bills.title")],
+      },
+      created_at: "2020-04-10 12:00:00",
+    )
+    FormResponse.create(
+      form_response: {
+        need_help_with: [I18n.t("coronavirus_form.groups.paying_bills.title")],
+      },
+      created_at: "2020-04-15 12:00:00",
+    )
+    FormResponse.create(
+      form_response: {
+        need_help_with: [I18n.t("coronavirus_form.groups.paying_bills.title")],
+      },
+      created_at: "2020-04-20 12:00:00",
+    )
+  end
+
+  describe "#usage_statistics" do
+    it "returns data in correct format with no start_date or end_date" do
+      expected = { "Getting food 2020-04-10" => [{ response: "Getting food", date: "Fri, 10 Apr 2020".to_date, count: 2 }],
+                   "Paying bills 2020-04-10" => [{ response: "Paying bills", date: "Fri, 10 Apr 2020".to_date, count: 1 }],
+                   "Paying bills 2020-04-15" => [{ response: "Paying bills", date: "Wed, 15 Apr 2020".to_date, count: 1 }],
+                   "Paying bills 2020-04-20" => [{ response: "Paying bills", date: "Mon, 20 Apr 2020".to_date, count: 1 }] }
+
+      expect(helper.usage_statistics(nil, nil)).to eq(expected)
+    end
+
+    it "returns data in correct format with start_date and end_date" do
+      expected = { "Getting food 2020-04-10" => [{ response: "Getting food", date: "Fri, 10 Apr 2020".to_date, count: 2 }],
+                   "Paying bills 2020-04-10" => [{ response: "Paying bills", date: "Fri, 10 Apr 2020".to_date, count: 1 }],
+                   "Paying bills 2020-04-15" => [{ response: "Paying bills", date: "Wed, 15 Apr 2020".to_date, count: 1 }] }
+
+      expect(helper.usage_statistics("2020-04-10", "2020-04-16")).to eq(expected)
+    end
+
+    it "returns data in correct format with start_date" do
+      expected = { "Paying bills 2020-04-15" => [{ response: "Paying bills", date: "Wed, 15 Apr 2020".to_date, count: 1 }],
+                   "Paying bills 2020-04-20" => [{ response: "Paying bills", date: "Mon, 20 Apr 2020".to_date, count: 1 }]  }
+
+      expect(helper.usage_statistics("2020-04-14", nil)).to eq(expected)
+    end
+
+    it "returns data in correct format with end_date" do
+      expected = { "Getting food 2020-04-10" => [{ response: "Getting food", date: "Fri, 10 Apr 2020".to_date, count: 2 }],
+                   "Paying bills 2020-04-10" => [{ response: "Paying bills", date: "Fri, 10 Apr 2020".to_date, count: 1 }]  }
+
+      expect(helper.usage_statistics(nil, "2020-04-14")).to eq(expected)
+    end
+
+    it "returns data in correct format with checkbox option selected" do
+      FormResponse.create(
+        form_response: {
+          need_help_with: [I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.options").first],
+        },
+        created_at: "2020-04-10 12:00:00",
+      )
+
+      expected = { "Getting food 2020-04-10" => [{ response: "Getting food", date: "Fri, 10 Apr 2020".to_date, count: 2 }],
+                   "Paying bills 2020-04-10" => [{ response: "Paying bills", date: "Fri, 10 Apr 2020".to_date, count: 1 }],
+                   "Paying bills 2020-04-15" => [{ response: "Paying bills", date: "Wed, 15 Apr 2020".to_date, count: 1 }],
+                   "Paying bills 2020-04-20" => [{ response: "Paying bills", date: "Mon, 20 Apr 2020".to_date, count: 1 }],
+                   "I’m not sure 2020-04-10" => [{ response: "I’m not sure", date: "Fri, 10 Apr 2020".to_date, count: 1 }] }
+
+      expect(helper.usage_statistics(nil, nil)).to eq(expected)
+    end
+  end
+end

--- a/spec/requests/data_export_checkbox_spec.rb
+++ b/spec/requests/data_export_checkbox_spec.rb
@@ -1,0 +1,113 @@
+RSpec.describe "data-export-checkbox", type: :request do
+  let(:start_date) { "2020-04-10" }
+  let(:end_date) { "2020-04-13" }
+
+  before do
+    FormResponse.create(
+      form_response: {
+        need_help_with: [I18n.t("coronavirus_form.groups.getting_food.title")],
+      },
+      created_at: "2020-04-10 10:00:00",
+    )
+    FormResponse.create(
+      form_response: {
+        need_help_with: [I18n.t("coronavirus_form.groups.getting_food.title")],
+      },
+      created_at: "2020-04-10 12:00:00",
+    )
+    FormResponse.create(
+      form_response: {
+        need_help_with: [I18n.t("coronavirus_form.groups.paying_bills.title")],
+      },
+      created_at: "2020-04-10 12:00:00",
+    )
+    FormResponse.create(
+      form_response: {
+        need_help_with: [I18n.t("coronavirus_form.groups.paying_bills.title")],
+      },
+      created_at: "2020-04-15 12:00:00",
+    )
+  end
+
+  describe "GET /data-export-checkbox" do
+    context "with basic auth enabled" do
+      it "rejects unauthenticated users" do
+        get data_export_checkbox_path,
+            headers: {
+              "HTTP_ACCEPT" => "text/csv",
+            }
+        expect(response).to have_http_status(401)
+      end
+
+      it "permits authenticated users" do
+        username = ENV["DATA_EXPORT_BASIC_AUTH_USERNAME"]
+        password = ENV["DATA_EXPORT_BASIC_AUTH_PASSWORD"]
+        get data_export_checkbox_path,
+            headers: {
+              "HTTP_ACCEPT" => "text/csv",
+              "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password),
+            }
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  let(:expected_all_time) do
+    [
+      "question|answer|date|count",
+      "#{I18n.t('coronavirus_form.groups')[:filter_questions][:questions][:need_help_with][:title]}|" \
+      "#{I18n.t('coronavirus_form.groups.paying_bills.title')}|" \
+        "2020-04-10|" \
+        "1",
+      "#{I18n.t('coronavirus_form.groups.paying_bills.title')}|" \
+        "2020-04-15|" \
+        "1",
+      "#{I18n.t('coronavirus_form.groups.getting_food.title')}|" \
+        "2020-04-10|" \
+        "2",
+    ]
+  end
+
+  let(:expected_partial) do
+    [
+      "question|answer|date|count",
+      "#{I18n.t('coronavirus_form.groups')[:filter_questions][:questions][:need_help_with][:title]}|" \
+      "#{I18n.t('coronavirus_form.groups.paying_bills.title')}|" \
+        "2020-04-10|" \
+        "1",
+      "#{I18n.t('coronavirus_form.groups.getting_food.title')}|" \
+        "2020-04-10|" \
+        "2",
+    ]
+  end
+
+  it "shows all expected responses in CSV format for all available dates" do
+    username = ENV["DATA_EXPORT_BASIC_AUTH_USERNAME"]
+    password = ENV["DATA_EXPORT_BASIC_AUTH_PASSWORD"]
+    get data_export_checkbox_path,
+        headers: {
+          "HTTP_ACCEPT" => "text/csv",
+          "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password),
+        }
+    expected_all_time.each do |line|
+      expect(response.body).to have_content(line)
+    end
+  end
+
+  it "shows all expected responses in CSV format for a given date range" do
+    username = ENV["DATA_EXPORT_BASIC_AUTH_USERNAME"]
+    password = ENV["DATA_EXPORT_BASIC_AUTH_PASSWORD"]
+    get data_export_checkbox_path,
+        params: { start_date: start_date, end_date: end_date },
+        headers: {
+          "HTTP_ACCEPT" => "text/csv",
+          "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password),
+        }
+
+    expected_partial.each do |line|
+      expect(response.body).to have_content(line)
+    end
+
+    expect(response.body).not_to have_content("2020-04-15|")
+  end
+end


### PR DESCRIPTION
What
----
- Export data for number of times checkboxes on `/need-help-with` are selected per day.

Describe what you have changed and why.

- Decided with Business Analyst to keep this separate to the [main data-export](https://github.com/alphagov/govuk-coronavirus-find-support/blob/master/app/controllers/coronavirus_form/data_export_controller.rb). This makes reporting easier for her in Datastudio. The main data-export reports on the count per combination of checkboxes selected, rather than on individual selections.

- [Automating daily reporting to Google sheets](https://github.com/alphagov/govuk-coronavirus-find-support/blob/master/docs/result_links_imports.md) will happen in a follow on task.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Describe the steps required to review and test the changes.

- Export data locally by visiting the following end point: http://localhost:5000/data-export-checkbox.csv

- Run the tests.

- Any refactoring ideas appreciated!

Links
-----

[Trello](https://trello.com/c/C0F7RP6P/260-spike-on-analytics-for-question-with-checkboxes)

