### PR TITLE
Remove `get_help_from_nhs` content

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,10 +114,6 @@ en:
     link_text: Leave this site
     link_href: "/clear-session?ext_r=true"
     link_redirect_to: https://www.bbc.co.uk/
-  get_help_from_nhs:
-    title: Get urgent help from the NHS now
-    link_text: Go to NHS 111 online
-    link_href: https://111.nhs.uk/
   cookies:
     title: Cookies
     banner:


### PR DESCRIPTION
### What
Remove `get_help_from_nhs` content as it's not used anymore. Missed in #150 when the associated view file was removed.

### How to review

Searching for `get_help_from_nhs` will return no results.

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:


