### PR TITLE
Fix date range selector in data export

### DIFF
--- a/app/controllers/coronavirus_form/data_export_controller.rb
+++ b/app/controllers/coronavirus_form/data_export_controller.rb
@@ -29,8 +29,13 @@ class CoronavirusForm::DataExportController < ApplicationController
     results = {}
     questions.each_key do |question|
       question_text = questions.dig(question, :title)
-      counts = FormResponse
-        .tap { |q| q.where(created_at: start_date..end_date) if start_date && end_date }
+      responses = if start_date && end_date
+                    FormResponse.where(created_at: start_date..end_date)
+                  else
+                    FormResponse.all
+                  end
+
+      counts = responses
         .select(Arel.sql("created_at::date, form_response -> '#{question}', COUNT(*)"))
         .group(Arel.sql("created_at::date, form_response -> '#{question}'"))
         .pluck(Arel.sql("created_at::date, form_response -> '#{question}', COUNT(*)"))

--- a/spec/requests/data_export_spec.rb
+++ b/spec/requests/data_export_spec.rb
@@ -137,6 +137,8 @@ RSpec.describe "data-export", type: :request do
       expected_partial.each do |line|
         expect(response.body).to have_content(line)
       end
+
+      expect(response.body).not_to have_content("2020-04-10|")
     end
   end
 end


### PR DESCRIPTION
#What's changed?

The date range wasn't being used to filter out the results.

The tests were only checking for what is there, but not what isn’t
there, so it didn’t check that a date that should be filtered out isn’t
being returned anymore.

It was the guard around the `where` clause that was causing the problem.
So it has been split out of the main query.

Thanks to @Rosa-Fox for spotting the bug and writing the test to catch
it.
