### PR TITLE
need_help_with: Change 'I’m not sure' to 'Not sure' checkbox

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,8 +210,8 @@ en:
             title: What do you need help with because of coronavirus?
             hint_text: Select all that apply
             options:
-            - I’m not sure
-            custom_select_error: Select what you need to find help with, or ‘I’m not
+            - Not sure
+            custom_select_error: Select what you need to find help with, or ‘Not
               sure’
       feeling_unsafe:
         title: Feeling unsafe

--- a/spec/helpers/data_export_checkbox_helper_spec.rb
+++ b/spec/helpers/data_export_checkbox_helper_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe DataExportCheckboxHelper, type: :helper do
                    "Paying bills 2020-04-10" => [{ response: "Paying bills", date: "Fri, 10 Apr 2020".to_date, count: 1 }],
                    "Paying bills 2020-04-15" => [{ response: "Paying bills", date: "Wed, 15 Apr 2020".to_date, count: 1 }],
                    "Paying bills 2020-04-20" => [{ response: "Paying bills", date: "Mon, 20 Apr 2020".to_date, count: 1 }],
-                   "I’m not sure 2020-04-10" => [{ response: "I’m not sure", date: "Fri, 10 Apr 2020".to_date, count: 1 }] }
+                   "Not sure 2020-04-10" => [{ response: "Not sure", date: "Fri, 10 Apr 2020".to_date, count: 1 }] }
 
       expect(helper.usage_statistics(nil, nil)).to eq(expected)
     end

--- a/spec/requests/need_help_with_spec.rb
+++ b/spec/requests/need_help_with_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "need-help-with" do
       before do
         allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[feel_safe get_food])
       end
-      let(:selected) { ["I’m not sure"] }
+      let(:selected) { ["Not sure"] }
 
       it "updates the session with all questions" do
         post need_help_with_path, params: { need_help_with: selected }


### PR DESCRIPTION

What
----

- This is for consistency with other 'Not sure' checkboxes in the form.

How to review
-------------

Observe that this looks good still:

<img width="758" alt="Screenshot 2020-06-03 at 11 42 06" src="https://user-images.githubusercontent.com/355033/83629117-75000d00-a591-11ea-9492-2ae42cc967a7.png">


Links
-----

https://trello.com/c/OoPcZFvR/473-make-not-sure-answers-consistent-small-content-change-but-needs-dev
