### PR TITLE
Add escape-link to the 'Need help with' page

### DIFF
--- a/app/views/coronavirus_form/need_help_with.html.erb
+++ b/app/views/coronavirus_form/need_help_with.html.erb
@@ -25,3 +25,10 @@
 
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>
+
+<% content_for :escape_link do %>
+  <%= render "components/escape-link", {
+    text: t("leave_this_website.link_text"),
+    href: t("leave_this_website.link_href"),
+  } %>
+<% end %>


### PR DESCRIPTION
What
----

Add escape-link to the 'Need help with' page (the only page missing it). All the radio-button question pages are benefiting from using the same template file; on this page, we need to add it separately using the same `escape_link` slot in layout. 

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Check the escape link is shown when accessing [`/need-help-with`](https://coronavirus-add-escape--yi8svu.herokuapp.com/need-help-with).

Links
-----
Requested by the product manager.


