### PR TITLE
Add no results page info that is specific to selected nation

### DIFF
--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -21,6 +21,7 @@
 
 <% if result_groups(session).empty? %>
   <%= sanitize(t("coronavirus_form.results.no_results")) %>
+  <%= sanitize(t("coronavirus_form.results.no_results_#{session[:nation].downcase.gsub(" ", "_")}")) %>
 <% else %>
   <div data-track-ec-list="Find coronavirus support">
     <% result_groups(session).each do |group| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,8 +403,22 @@ en:
         <p class="govuk-body">Based on your answers, there’s no specific information for you in this service at the moment. It will be updated regularly.</p>
 
         <p class="govuk-body"><a href="https://www.gov.uk/coronavirus" class="govuk-link">Find all information on coronavirus, including how to protect yourself and get financial support</a></p>
-
+      no_results_england: |
         <p class="govuk-body"><a href="https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/" class="govuk-link">Find information about what you can do from Citizens Advice</a></p>
+      no_results_northern_ireland: |
+        <p class="govuk-body"><a href="https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19" class="govuk-link">Additional information for Northern Ireland</a></p>
+
+        <p class="govuk-body"><a href="https://www.citizensadvice.org.uk/about-us/northern-ireland/" class="govuk-link">Get advice from Citizens Advice</a></p>
+      no_results_scotland: |
+        <p class="govuk-body"><a href="https://www.mygov.scot/coronavirus-covid-19/" class="govuk-link">Additional information for Scotland (mygov.scot)</a></p>
+
+        <p class="govuk-body"><a href="https://www.readyscotland.org/coronavirus/where-to-find-additional-support/" class="govuk-link">Find other organisations who might be able to help you (Ready Scotland)</a></p>
+
+        <p class="govuk-body"><a href="https://www.citizensadvice.org.uk/scotland/health/coronavirus-what-it-means-for-you-s/" class="govuk-link">Get advice from Citizens Advice Scotland</a></p>
+      no_results_wales: |
+        <p class="govuk-body"><a href="https://gov.wales/coronavirus" class="govuk-link">Additional information for Wales</a></p>
+
+        <p class="govuk-body"><a href="https://www.citizensadvice.org.uk/wales/health/coronavirus-what-it-means-for-you/" class="govuk-link">Get advice from Citizens Advice</a></p>
   results_link:
     feeling_unsafe:
       feel_safe:


### PR DESCRIPTION
This provides one section in the "no_results" bit of the copy that will be repeated for all nations. It also adds another for each of the other nations and displays what is appropriate given the users answer to the first question.

Trello - https://trello.com/c/req0jUcK/455-add-content-to-no-results-page-for-devolved-nations