### PR TITLE
Remove unwanted fields from form response submission

### DIFF
--- a/app/controllers/coronavirus_form/able_to_leave_controller.rb
+++ b/app/controllers/coronavirus_form/able_to_leave_controller.rb
@@ -34,7 +34,8 @@ private
   end
 
   def write_responses
-    redacted_session = session.to_hash.without("session_id", "_csrf_token")
+    unwanted_fields = %w[_csrf_token check_answers_seen current_path previous_path session_id]
+    redacted_session = session.to_hash.without(*unwanted_fields)
     unless smoke_tester?
       FormResponse.create(
         form_response: redacted_session,


### PR DESCRIPTION
This removes some extra fields so that they are not passed on to the database. This means that going forward we will not be storing these fields but may want to write a rake task that removes the ones that have already been written.

Trello - https://trello.com/c/hVwdVzKm/494-remove-unnecessary-fields-from-formresponse