### PR TITLE
GA cross government domain tracking with test ID

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -11,6 +11,7 @@ catch(error) {
 var analyticsInit = function () {
   <% if Rails.application.config.analytics_tracking_id.present? %>
     var trackingId = "<%= Rails.application.config.analytics_tracking_id %>"
+    var crossDomainTrackingId = "<%= Rails.application.config.analytics_cross_domain_id %>"
 
   // Start analytics only if we have user consent
   var consentCookie = window.GOVUK.getConsentCookie()
@@ -41,6 +42,14 @@ var analyticsInit = function () {
     window.GOVUK.enhancedEcommerceTracking(document)
 
     ga('send', 'pageview')
+
+    // Cross Government Domain Google Analytics
+    ga('create', crossDomainTrackingId, 'auto', 'govuk_shared', {'allowLinker': true});
+    ga('govuk_shared.require', 'linker');
+    ga('govuk_shared.set', 'anonymizeIp', true);
+    ga('govuk_shared.set', 'allowAdFeatures', false);
+    ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
+    ga('govuk_shared.send', 'pageview');
   }
   <% end %>
  }

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -26,6 +26,7 @@ params:
   DATA_EXPORT_BASIC_AUTH_USERNAME:
   DATA_EXPORT_BASIC_AUTH_PASSWORD:
   GA_VIEW_ID: UA-43115970-1
+  GA_CROSS_DOMAIN_ID: UA-145652997-7
 run:
   dir: src
   path: sh
@@ -53,6 +54,7 @@ run:
       cf set-env govuk-coronavirus-find-support SENTRY_DSN "$SENTRY_DSN"
       cf set-env govuk-coronavirus-find-support SENTRY_CURRENT_ENV "$CF_SPACE"
       cf set-env govuk-coronavirus-find-support GA_VIEW_ID "$GA_VIEW_ID"
+      cf set-env govuk-coronavirus-find-support GA_CROSS_DOMAIN_ID "$GA_CROSS_DOMAIN_ID"
       cf set-env govuk-coronavirus-find-support AWS_ACCESS_KEY_ID "$AWS_ACCESS_KEY_ID"
       cf set-env govuk-coronavirus-find-support AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
       cf set-env govuk-coronavirus-find-support SECRET_KEY_BASE "$SECRET_KEY_BASE"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,5 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.analytics_tracking_id = "DEV-123456"
+  config.analytics_cross_domain_id = "DEV-54321"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,6 +42,7 @@ Rails.application.configure do
   end
 
   config.analytics_tracking_id = ENV["GA_VIEW_ID"]
+  config.analytics_cross_domain_id = ENV["GA_CROSS_DOMAIN_ID"]
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,6 +10,7 @@ Rails.application.configure do
   # config/application.rb.
 
   config.analytics_tracking_id = "12345"
+  config.analytics_cross_domain_id = "54321"
 
   config.cache_classes = true
 


### PR DESCRIPTION
Trello: https://trello.com/c/fHkFUG0P

# What's changed?

- Adds Google Analytics cross domain tracking.
- Currently uses a test ID. This will need to be updated in a future PR once testing with a business analyst is complete.

Replicates the set-up in: https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/pull/336

# Why?
To help understand more clearly the flow and journeys that users take through the service.

# How to review

Instructions for adding X-domain GA tracking are linked to the [Trello](https://trello.com/c/fHkFUG0P) card. This also gives information as to the process of testing with an analyst.

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

