### PR TITLE
Add event tracking

### DIFF
--- a/app/assets/javascripts/analytics-track-form.js
+++ b/app/assets/javascripts/analytics-track-form.js
@@ -1,0 +1,46 @@
+/* eslint-env jquery */
+/* global ga:readonly */
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (global, GOVUK) {
+  'use strict'
+
+  var $ = global.jQuery
+
+  GOVUK.Modules.TrackForm = function () {
+    this.start = function (element) {
+      track(element)
+    }
+
+    function track (element) {
+      element.on('submit', function (event) {
+        var $checkedOption, questionValue
+        var $submittedForm = $(event.target)
+        var $checkedOptions = $submittedForm.find('input:checked')
+        var questionKey = $submittedForm.data('question-key')
+
+        if ($checkedOptions.length) {
+          $checkedOptions.each(function (index) {
+            $checkedOption = $(this)
+            var checkedOptionId = $checkedOption.attr('id')
+            var checkedOptionLabel = $submittedForm.find('label[for="' + checkedOptionId + '"]').text().trim()
+            questionValue = checkedOptionLabel.length
+              ? checkedOptionLabel
+              : $checkedOption.val()
+
+            if (typeof ga === 'function') {
+              ga('send', {
+                hitType: 'event',
+                eventCategory: 'question_answer',
+                eventAction: questionValue,
+                eventLabel: questionKey
+              })
+            }
+          })
+        }
+      })
+    }
+  }
+})(window, window.GOVUK)

--- a/app/assets/javascripts/analytics-track-link.js
+++ b/app/assets/javascripts/analytics-track-link.js
@@ -1,0 +1,34 @@
+/* eslint-env jquery */
+/* global ga:readonly */
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (global, GOVUK) {
+  'use strict'
+
+  var $ = global.jQuery
+
+  GOVUK.Modules.TrackLink = function () {
+    this.start = function (element) {
+      track(element)
+    }
+
+    function track (element) {
+      element.on('click', function (event) {
+        var eventCategory = $(this).data('track-category')
+        var eventAction = $(this).data('track-action')
+        var eventLabel = $(this).data('track-label')
+
+        if (typeof ga === 'function') {
+          ga('send', {
+            hitType: 'event',
+            eventCategory: eventCategory,
+            eventAction: eventAction,
+            eventLabel: eventLabel
+          })
+        }
+      })
+    }
+  }
+})(window, window.GOVUK)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 //= require govuk_publishing_components/components/radio
 //= require analytics
 //= require analytics-enhancedEcommerce
+//= require analytics-track-form
 //= require cookies
 //= require components/escape-link
 window.CookieSettings.start()

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,6 +9,7 @@
 //= require analytics
 //= require analytics-enhancedEcommerce
 //= require analytics-track-form
+//= require analytics-track-link
 //= require cookies
 //= require components/escape-link
 window.CookieSettings.start()

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,11 +1,21 @@
 //= require jquery
-//= require govuk/all.js
-//= require govuk_publishing_components/components/cookie-banner
+//= require govuk_publishing_components/modules
 //= require govuk_publishing_components/lib/cookie-functions
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/checkboxes
+//= require govuk_publishing_components/components/cookie-banner
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/radio
 //= require analytics
 //= require analytics-enhancedEcommerce
 //= require cookies
 //= require components/escape-link
 window.CookieSettings.start()
-window.GOVUK.analyticsInit()
-window.GOVUKFrontend.initAll()
+
+if (window.GOVUK.analyticsInit) {
+  window.GOVUK.analyticsInit()
+}
+
+$(document).ready(function () {
+  window.GOVUK.modules.start()
+})

--- a/app/assets/javascripts/components/escape-link.js
+++ b/app/assets/javascripts/components/escape-link.js
@@ -1,3 +1,5 @@
+/* global ga:readonly */
+
 function EscapeLink ($module) {
   this.$module = $module
 }
@@ -16,9 +18,22 @@ EscapeLink.prototype.handleClick = function (event) {
 
   var url = event.target.getAttribute('href')
   var rel = event.target.getAttribute('rel')
+  var trackLabel = event.target.getAttribute('data-track-label')
 
+  this.trackLink(trackLabel)
   this.openNewPage(url, rel)
   this.replaceCurrentPage(url)
+}
+
+EscapeLink.prototype.trackLink = function (trackLabel) {
+  if (typeof ga === 'function' && trackLabel) {
+    ga('send', {
+      hitType: 'event',
+      eventCategory: 'leave_site',
+      eventAction: '',
+      eventLabel: trackLabel
+    })
+  }
 }
 
 EscapeLink.prototype.openNewPage = function (url, rel) {

--- a/app/views/application/_question_radio_buttons.html.erb
+++ b/app/views/application/_question_radio_buttons.html.erb
@@ -8,9 +8,9 @@
 <% end %>
 
 <%= form_tag({},
-  "data-module": "track-coronavirus-form-find-support-#{question.sub('_','-')}",
-  "data-question-key": question,
-  "id": question,
+  "data-module": "track-form",
+  "data-question-key": question.dasherize,
+  "id": question.dasherize,
   "novalidate": "true"
 ) do %>
   <%= render "govuk_publishing_components/components/radio", {

--- a/app/views/application/_question_radio_buttons.html.erb
+++ b/app/views/application/_question_radio_buttons.html.erb
@@ -4,7 +4,15 @@
 <% end %>
 
 <% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: previous_path,
+    data_attributes: {
+      "module": "track-link",
+      "track-category": "question_back",
+      "track-action": "back #{question.dasherize}",
+      "track-label": question.dasherize
+    }
+  } %>
 <% end %>
 
 <%= form_tag({},

--- a/app/views/application/_question_radio_buttons.html.erb
+++ b/app/views/application/_question_radio_buttons.html.erb
@@ -43,5 +43,8 @@
   <%= render "components/escape-link", {
     text: t("leave_this_website.link_text"),
     href: t("leave_this_website.link_href"),
+    data_attributes: {
+      "track-label": question.dasherize
+    }
   } %>
 <% end %>

--- a/app/views/coronavirus_form/accessibility_statement.html.erb
+++ b/app/views/coronavirus_form/accessibility_statement.html.erb
@@ -1,7 +1,15 @@
 <% content_for :title do %><%= t("accessibility_statement.title") %><% end %>
 
 <% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", { href: @previous_page } %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: @previous_page,
+    data_attributes: {
+      "module": "track-link",
+      "track-category": "question_back",
+      "track-action": "back #{controller_name.dasherize}",
+      "track-label": controller_name.dasherize
+    }
+  } %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {

--- a/app/views/coronavirus_form/cookies.html.erb
+++ b/app/views/coronavirus_form/cookies.html.erb
@@ -4,7 +4,15 @@
 <% end %>
 
 <% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", { href: @previous_page } %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: @previous_page,
+    data_attributes: {
+      "module": "track-link",
+      "track-category": "question_back",
+      "track-action": "back #{controller_name.dasherize}",
+      "track-label": controller_name.dasherize
+    }
+  } %>
 <% end %>
 
 <main class="cookies-content">

--- a/app/views/coronavirus_form/need_help_with.html.erb
+++ b/app/views/coronavirus_form/need_help_with.html.erb
@@ -36,5 +36,8 @@
   <%= render "components/escape-link", {
     text: t("leave_this_website.link_text"),
     href: t("leave_this_website.link_href"),
+    data_attributes: {
+      "track-label": controller_name.dasherize
+    }
   } %>
 <% end %>

--- a/app/views/coronavirus_form/need_help_with.html.erb
+++ b/app/views/coronavirus_form/need_help_with.html.erb
@@ -4,7 +4,15 @@
 <% end %>
 
 <% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: previous_path,
+    data_attributes: {
+      "module": "track-link",
+      "track-category": "question_back",
+      "track-action": "back #{controller_name.dasherize}",
+      "track-label": controller_name.dasherize
+    }
+  } %>
 <% end %>
 
 <%= form_tag({},

--- a/app/views/coronavirus_form/need_help_with.html.erb
+++ b/app/views/coronavirus_form/need_help_with.html.erb
@@ -8,22 +8,20 @@
 <% end %>
 
 <%= form_tag({},
-  "data-module": "track-coronavirus-form-find-support-#{controller_name.sub('_','-')}",
-  "data-question-key": controller_name,
-  "id": "need_help_with",
+  "data-module": "track-form",
+  "data-question-key": controller_name.dasherize,
+  "id": controller_name.dasherize,
   "novalidate": "true"
 ) do %>
-
-<%= render "govuk_publishing_components/components/checkboxes", {
-  heading: t("coronavirus_form.groups.#{group}.questions.#{controller_name}.title"),
-  is_page_heading: true,
-  name: "#{controller_name}[]",
-  error: error_items(controller_name),
-  hint_text: t("coronavirus_form.groups.#{group}.questions.#{controller_name}.hint_text"),
-  items: items
-} %>
-
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    heading: t("coronavirus_form.groups.#{group}.questions.#{controller_name}.title"),
+    is_page_heading: true,
+    name: "#{controller_name}[]",
+    error: error_items(controller_name),
+    hint_text: t("coronavirus_form.groups.#{group}.questions.#{controller_name}.hint_text"),
+    items: items
+  } %>
+  <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>
 
 <% content_for :escape_link do %>

--- a/app/views/coronavirus_form/privacy.html.erb
+++ b/app/views/coronavirus_form/privacy.html.erb
@@ -1,7 +1,15 @@
 <% content_for :title do %><%= t("privacy_page.title") %><% end %>
 
 <% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", { href: @previous_page } %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: @previous_page,
+    data_attributes: {
+      "module": "track-link",
+      "track-category": "question_back",
+      "track-action": "back #{controller_name.dasherize}",
+      "track-label": controller_name.dasherize
+    }
+  } %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -16,7 +16,16 @@
     margin_top: 0,
     margin_bottom: 6,
   } %>
-  <%= link_to t("coronavirus_form.results.header.start_again_text"), clear_session_path, class: "govuk-link", onclick: "ga('send', 'event', 'StartAgain', 'StartAgainClicked', '/results');" %>
+  <%= link_to t("coronavirus_form.results.header.start_again_text"),
+    clear_session_path,
+    class: "govuk-link",
+    data: {
+      module: "track-link",
+      "track-category": "StartAgain",
+      "track-action": "StartAgainClicked",
+      "track-label": "/results"
+    }
+  %>
 <% end %>
 
 <% if result_groups(session).empty? %>

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -43,5 +43,8 @@
   <%= render "components/escape-link", {
     text: t("leave_this_website.link_text"),
     href: t("leave_this_website.link_href"),
+    data_attributes: {
+      "track-label": controller_name.dasherize
+    }
   } %>
 <% end %>

--- a/spec/javascripts/analytics-track-form.spec.js
+++ b/spec/javascripts/analytics-track-form.spec.js
@@ -1,0 +1,43 @@
+/* eslint-env jasmine, jquery */
+
+var $ = window.jQuery
+
+describe('Form tracker', function () {
+  var GOVUK = window.GOVUK || {}
+  var $form
+
+  beforeEach(function () {
+    spyOn(window, 'ga')
+
+    $form = $(
+      '<div>' +
+        '<form data-module="track-from" data-question-key="need-help-with" onsubmit="event.preventDefault()">' +
+          '<input type="radio" name="afford_rent_mortgage_bills" id="option_yes" value="Yes">' +
+          '<label for="option_yes">Yes</label>' +
+          '<input type="radio" name="afford_rent_mortgage_bills" id="option_no" value="No">' +
+          '<label for="option_no">No</label>' +
+          '<input type="checkbox" name="need_help_with[]" id="option_paying_bills" value="Paying bills">' +
+          '<label for="option_paying_bills">Paying bills</label>' +
+          '<button type="submit">Continue</button>' +
+        '</form>' +
+      '</div>'
+    )
+
+    var tracker = new GOVUK.Modules.TrackForm()
+    tracker.start($form)
+  })
+
+  it('sends chosen options to Google Analytics when submitting the form', function () {
+    $form.find('input[value="Yes"]').trigger('click')
+    $form.find('input[value="No"]').trigger('click')
+    $form.find('input[value="Paying bills"]').trigger('click')
+    $form.find('form').trigger('submit')
+
+    expect(window.ga).toHaveBeenCalledWith(
+      'send', { hitType: 'event', eventCategory: 'question_answer', eventAction: 'No', eventLabel: 'need-help-with' }
+    )
+    expect(window.ga).toHaveBeenCalledWith(
+      'send', { hitType: 'event', eventCategory: 'question_answer', eventAction: 'Paying bills', eventLabel: 'need-help-with' }
+    )
+  })
+})

--- a/spec/javascripts/analytics-track-link.spec.js
+++ b/spec/javascripts/analytics-track-link.spec.js
@@ -1,0 +1,25 @@
+/* eslint-env jasmine, jquery */
+
+var $ = window.jQuery
+
+describe('Link tracker', function () {
+  var GOVUK = window.GOVUK || {}
+  var $backLink
+
+  beforeEach(function () {
+    spyOn(window, 'ga')
+
+    $backLink = $('<a data-module="track-link" data-track-category="question_back" data-track-action="back need-help-with" data-track-label="need-help-with" href="/nation" onclick="event.preventDefault()">Back</a>')
+
+    var tracker = new GOVUK.Modules.TrackLink()
+    tracker.start($backLink)
+  })
+
+  it('sends data to Google Analytics when back link is clicked', function () {
+    $backLink.trigger('click')
+
+    expect(window.ga).toHaveBeenCalledWith(
+      'send', { hitType: 'event', eventCategory: 'question_back', eventAction: 'back need-help-with', eventLabel: 'need-help-with' }
+    )
+  })
+})

--- a/spec/javascripts/components/escape-link.spec.js
+++ b/spec/javascripts/components/escape-link.spec.js
@@ -1,4 +1,5 @@
-/* eslint-env jasmine, jquery,  EscapeLink, */
+/* eslint-env jasmine, jquery */
+/* global EscapeLink */
 
 describe('Escape link component', function () {
   'use strict'
@@ -9,7 +10,7 @@ describe('Escape link component', function () {
 
   beforeEach(function () {
     container = document.createElement('div')
-    container.innerHTML = '<a class="app-c-escape-link govuk-link" rel="nofollow noreferrer noopener" target="_blank" data-module="app-escape-link" href="https://www.gov.uk/">Leave this site</a>'
+    container.innerHTML = '<a class="app-c-escape-link govuk-link" rel="nofollow noreferrer noopener" target="_blank" data-module="app-escape-link" data-track-label="need-help-with" href="https://www.gov.uk/">Leave this site</a>'
     document.body.appendChild(container)
     escapeLinkElement = document.querySelector('[data-module="app-escape-link"]')
     escapeLinkModule = new EscapeLink(escapeLinkElement)
@@ -19,6 +20,14 @@ describe('Escape link component', function () {
 
   afterEach(function () {
     document.body.removeChild(container)
+  })
+
+  it('sends data to Google Analytics', function () {
+    spyOn(window, 'ga')
+    escapeLinkElement.click()
+    expect(window.ga).toHaveBeenCalledWith(
+      'send', { hitType: 'event', eventCategory: 'leave_site', eventAction: '', eventLabel: 'need-help-with' }
+    )
   })
 
   it('opens a new page', function () {


### PR DESCRIPTION
What
----

Add event tracking on actions across the journey so we can segment data by users and journeys by the answers they select.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Check the expected data is sent to Google Analytics (using GA Debugger or similar)

### Examples below for each event tracking type:

Answers
<img width="1440" alt="track-answers" src="https://user-images.githubusercontent.com/788096/83874310-2be4c000-a72d-11ea-818d-db0084e47c78.png">

Back link
<img width="1440" alt="track-back-link" src="https://user-images.githubusercontent.com/788096/83874317-2e471a00-a72d-11ea-88b9-5f157936b929.png">

Escape link
<img width="1440" alt="track-escape-link" src="https://user-images.githubusercontent.com/788096/83874321-2edfb080-a72d-11ea-94bc-5a5caea212f5.png">


Links
-----

[Trello card](https://trello.com/c/rPmxYqhP)

