### PR TITLE
Handle empty rows in the form.

### DIFF
--- a/lib/content_importer.rb
+++ b/lib/content_importer.rb
@@ -55,6 +55,8 @@ module_function
   def import_results_links(csv_path)
     csv = CSV.read(csv_path, { headers: true })
     output = csv.each_with_object({}) do |csv_row, results_links|
+      next if blank_row?(csv_row)
+
       support_and_advice_items = csv_row.fetch("support_and_advice")
       group_key = csv_row.fetch("group_key").to_sym
       subgroup_key = csv_row.fetch("subgroup_key").to_sym
@@ -98,5 +100,9 @@ module_function
     File.open(output_locale_path, "w") do |file|
       file.write(existing_locale_file.to_yaml)
     end
+  end
+
+  def blank_row?(row)
+    row.fields.all? { |v| [nil, "#N/A"].include?(v) }
   end
 end

--- a/spec/fixtures/result_links_test.csv
+++ b/spec/fixtures/result_links_test.csv
@@ -5,3 +5,4 @@ id,group_title,subgroup_title,support_and_advice,text,href,show_to_nations,show_
 0004,I am the title for Group one,I am the title for Group one subgroup one,true,"This is a row has text, an href and multiple group criteria, it will appear as an anchor tag if the user's answers match the more complex criteria",http://test.stubbed.gb.gov.uk,Wales OR Scotland OR England,"",group_one,subgroup_one,true
 0005,I am the title for Group one,I am the title for Group one subgroup two,false,"This is a row that only has text, it will appear like a paragraph","","","",group_one,subgroup_two,false
 0006,I am the title for Group two,I am the title for Group two subgroup one,false,"This is a row that only has text, it will appear like a paragraph","","",true,group_two,subgroup_one,false
+,,,,,,,#N/A,#N/A,#N/A,#N/A


### PR DESCRIPTION
Why
---
The google sheet has some pre-filled formulae in the hidden columns of the spreadsheet, ready for new content to be added. If a row contains only empty or '#N/A' we should ignore these rows.

What
----
Ignore rows which contain only blank or '#N/A' error values.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Follow instructions here to run an import into local dev environment. There should be no errors during the import.
https://github.com/alphagov/govuk-coronavirus-find-support/blob/master/docs/result_links_imports.md

Links
-----

https://trello.com/c/Tx1P5tbk/559-fix-google-sheet-import-export-process-for-content
