### PR TITLE
Add brakeman

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,16 +5,17 @@ ruby File.read(".ruby-version").strip
 source "https://rubygems.org"
 
 gem "asset_sync"
+gem "aws-sdk-s3", "~> 1.68"
 gem "bootsnap", "~> 1"
 gem "fog-aws"
 gem "govuk_app_config", "~> 2.2.0"
 gem "govuk_publishing_components", "~> 21.55.3"
 gem "lograge"
 gem "pg", "~> 1"
+gem "prometheus-client", "~> 2.0"
 gem "puma", "~> 4.3"
 gem "rack_session_access", "~> 0.2"
 gem "rails", "~> 6.0.3"
-
 gem "sass-rails", "< 6"
 gem "sentry-raven", "~> 3.0"
 gem "uglifier", "~> 4.2"
@@ -35,6 +36,7 @@ end
 
 group :development, :test do
   gem "awesome_print", "~> 1.8"
+  gem "brakeman", "~> 4.8"
   gem "byebug", "~> 11"
   gem "dotenv-rails"
   gem "foreman", "~> 0.87.1"
@@ -51,7 +53,3 @@ group :development, :test do
   gem "webdrivers", "~> 4.4"
   gem "webmock", "~> 3.8.3"
 end
-
-gem "prometheus-client", "~> 2.0"
-
-gem "aws-sdk-s3", "~> 1.68"

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,13 @@ ruby File.read(".ruby-version").strip
 
 source "https://rubygems.org"
 
-gem "asset_sync"
+gem "asset_sync", "~> 2.11.0"
 gem "aws-sdk-s3", "~> 1.68"
 gem "bootsnap", "~> 1"
-gem "fog-aws"
+gem "fog-aws", "~> 3.6.5"
 gem "govuk_app_config", "~> 2.2.0"
 gem "govuk_publishing_components", "~> 21.55.3"
-gem "lograge"
+gem "lograge", "~> 0.11.2"
 gem "pg", "~> 1"
 gem "prometheus-client", "~> 2.0"
 gem "puma", "~> 4.3"
@@ -30,26 +30,26 @@ group :test do
   gem "mini_racer", "~> 0.2"
   gem "selenium-webdriver", "~> 3.142"
   gem "simplecov", "~> 0.16"
-  gem "simplecov-cobertura"
-  gem "timecop"
+  gem "simplecov-cobertura", "~> 1.3.1"
+  gem "timecop", "~> 0.9.1"
 end
 
 group :development, :test do
   gem "awesome_print", "~> 1.8"
   gem "brakeman", "~> 4.8"
   gem "byebug", "~> 11"
-  gem "dotenv-rails"
+  gem "dotenv-rails", "~> 2.7.5"
   gem "foreman", "~> 0.87.1"
   gem "google-api-client"
   gem "govuk_test", "~> 1.0"
-  gem "jasmine"
-  gem "jasmine_selenium_runner", require: false
+  gem "jasmine", "~> 3.5.1"
+  gem "jasmine_selenium_runner", "~> 3.0.0", require: false
   gem "pry", "~> 0.13.1"
   gem "pry-rails", "~> 0.3.9"
   gem "rails-controller-testing", "~> 1.0"
   gem "rspec-rails", "~> 4.0.1"
-  gem "rubocop-govuk"
-  gem "scss_lint-govuk"
+  gem "rubocop-govuk", "~> 3.15.0"
+  gem "scss_lint-govuk", "~> 0.2.0"
   gem "webdrivers", "~> 4.4"
   gem "webmock", "~> 3.8.3"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       fog-core
       mime-types (>= 2.99)
       unf
-    ast (2.4.0)
+    ast (2.4.1)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
     aws-partitions (1.328.0)
@@ -98,7 +98,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    coderay (1.1.2)
+    coderay (1.1.3)
     concurrent-ruby (1.1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -118,7 +118,7 @@ GEM
     execjs (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.2)
+    ffi (1.13.1)
     fog-aws (3.6.5)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
@@ -336,7 +336,7 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
-    rubocop (0.85.1)
+    rubocop (0.85.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
@@ -347,11 +347,11 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.0.3)
       parser (>= 2.7.0.1)
-    rubocop-govuk (3.16.0)
-      rubocop (= 0.85.1)
-      rubocop-rails (= 2.6.0)
-      rubocop-rake (= 0.5.1)
-      rubocop-rspec (= 1.39.0)
+    rubocop-govuk (3.15.0)
+      rubocop (= 0.85.0)
+      rubocop-rails (~> 2)
+      rubocop-rake (~> 0.5.1)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.6.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -438,24 +438,24 @@ PLATFORMS
 
 DEPENDENCIES
   apparition (~> 0.5.0)
-  asset_sync
+  asset_sync (~> 2.11.0)
   awesome_print (~> 1.8)
   aws-sdk-s3 (~> 1.68)
   bootsnap (~> 1)
   brakeman (~> 4.8)
   byebug (~> 11)
   capybara (~> 3.32.2)
-  dotenv-rails
-  fog-aws
+  dotenv-rails (~> 2.7.5)
+  fog-aws (~> 3.6.5)
   foreman (~> 0.87.1)
   google-api-client
   govuk_app_config (~> 2.2.0)
   govuk_publishing_components (~> 21.55.3)
   govuk_test (~> 1.0)
-  jasmine
-  jasmine_selenium_runner
+  jasmine (~> 3.5.1)
+  jasmine_selenium_runner (~> 3.0.0)
   listen (~> 3)
-  lograge
+  lograge (~> 0.11.2)
   mini_racer (~> 0.2)
   pg (~> 1)
   prometheus-client (~> 2.0)
@@ -466,14 +466,14 @@ DEPENDENCIES
   rails (~> 6.0.3)
   rails-controller-testing (~> 1.0)
   rspec-rails (~> 4.0.1)
-  rubocop-govuk
+  rubocop-govuk (~> 3.15.0)
   sass-rails (< 6)
-  scss_lint-govuk
+  scss_lint-govuk (~> 0.2.0)
   selenium-webdriver (~> 3.142)
   sentry-raven (~> 3.0)
   simplecov (~> 0.16)
-  simplecov-cobertura
-  timecop
+  simplecov-cobertura (~> 1.3.1)
+  timecop (~> 0.9.1)
   uglifier (~> 4.2)
   webdrivers (~> 4.4)
   webmock (~> 3.8.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -442,6 +442,7 @@ DEPENDENCIES
   awesome_print (~> 1.8)
   aws-sdk-s3 (~> 1.68)
   bootsnap (~> 1)
+  brakeman (~> 4.8)
   byebug (~> 11)
   capybara (~> 3.32.2)
   dotenv-rails

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-task default: %i[spec spec:javascript lint]
+task default: %i[spec spec:javascript lint brakeman]

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+desc "Run static analysis using brakeman gem"
+task brakeman: :environment do
+  sh "brakeman -q"
+end


### PR DESCRIPTION
[Brakeman](https://github.com/presidentbeef/brakeman) enables us to do static analysis of the codebase for security issues. It'll run as part of the default rake task or simply `bundle exec brakeman`.