### PR TITLE
Fix flakey smoke test

### DIFF
--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -93,24 +93,24 @@ RSpec.feature "Fill in the find support form" do
   scenario "Ensure we can perform a healthcheck" do
     visit healthcheck_path
 
-    expect(page.body).to have_content("OK")
+    expect(page).to have_content("OK")
   end
 
   scenario "Ensure the privacy notice page is visible" do
     visit privacy_path
 
-    expect(page.body).to have_content(I18n.t("privacy_page.title"))
+    expect(page).to have_content(I18n.t("privacy_page.title"))
   end
 
   scenario "Ensure the accessibility statement page is visible" do
     visit accessibility_statement_path
 
-    expect(page.body).to have_content(I18n.t("accessibility_statement.title"))
+    expect(page).to have_content(I18n.t("accessibility_statement.title"))
   end
 
   scenario "Ensure the session expired page is visible" do
     visit session_expired_path
 
-    expect(page.body).to have_content(I18n.t("session_expired.title"))
+    expect(page).to have_content(I18n.t("session_expired.title"))
   end
 end

--- a/spec/requests/able_to_leave_spec.rb
+++ b/spec/requests/able_to_leave_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "able-to-leave" do
       it "shows the form" do
         visit able_to_leave_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
         I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe "able-to-leave" do
       it "shows the form without prefilled response" do
         visit able_to_leave_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/requests/afford_food_spec.rb
+++ b/spec/requests/afford_food_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "afford-food" do
       it "shows the form" do
         visit afford_food_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
         I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe "afford-food" do
       it "shows the form without prefilled response" do
         visit afford_food_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
+++ b/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "afford-rent-mortgage-bills" do
       it "shows the form" do
         visit afford_rent_mortgage_bills_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.title"))
         I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe "afford-rent-mortgage-bills" do
       it "shows the form without prefilled response" do
         visit afford_rent_mortgage_bills_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/requests/are_you_off_work_ill_spec.rb
+++ b/spec/requests/are_you_off_work_ill_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "still-working" do
       it "shows the form" do
         visit are_you_off_work_ill_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
         I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe "still-working" do
       it "shows the form without prefilled response" do
         visit are_you_off_work_ill_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/requests/feel_safe_spec.rb
+++ b/spec/requests/feel_safe_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "feel-safe" do
       it "shows the form" do
         visit feel_safe_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
         I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe "feel-safe" do
       it "shows the form without prefilled response" do
         visit feel_safe_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/requests/get_food_spec.rb
+++ b/spec/requests/get_food_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "get-food" do
       it "shows the form" do
         visit get_food_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.get_food.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.get_food.title"))
         I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe "get-food" do
       it "shows the form without prefilled response" do
         visit get_food_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.get_food.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.get_food.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/requests/have_somewhere_to_live_spec.rb
+++ b/spec/requests/have_somewhere_to_live_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "have-somewhere-to-live" do
       it "shows the form" do
         visit have_somewhere_to_live_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.title"))
         I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe "have-somewhere-to-live" do
       it "shows the form without prefilled response" do
         visit have_somewhere_to_live_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/requests/have_you_been_evicted_spec.rb
+++ b/spec/requests/have_you_been_evicted_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "have-you-been-evicted" do
       it "shows the form" do
         visit have_you_been_evicted_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.title"))
         I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe "have-you-been-evicted" do
       it "shows the form without prefilled response" do
         visit have_you_been_evicted_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/requests/have_you_been_made_unemployed_spec.rb
+++ b/spec/requests/have_you_been_made_unemployed_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "have-you-been-made-unemployed" do
       it "shows the form" do
         visit have_you_been_made_unemployed_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
         I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe "have-you-been-made-unemployed" do
       it "shows the form without prefilled response" do
         visit have_you_been_made_unemployed_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/requests/living_with_vulnerable_spec.rb
+++ b/spec/requests/living_with_vulnerable_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "living-with-vulnerable" do
       it "shows the form" do
         visit living_with_vulnerable_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.title"))
         I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe "living-with-vulnerable" do
       it "shows the form without prefilled response" do
         visit living_with_vulnerable_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/requests/mental_health_worries_spec.rb
+++ b/spec/requests/mental_health_worries_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe "mental-health-worries" do
       it "shows the form" do
         visit mental_health_worries_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.title"))
         I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe "mental-health-worries" do
       it "shows the form without prefilled response" do
         visit mental_health_worries_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/requests/need_help_with_spec.rb
+++ b/spec/requests/need_help_with_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "need-help-with" do
       it "shows the form without prefilled response" do
         visit need_help_with_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.title"))
         expect(page.find("input#option_#{selected.first.parameterize.underscore}")).not_to be_checked
       end
     end

--- a/spec/requests/self_employed_spec.rb
+++ b/spec/requests/self_employed_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "self-employed" do
       it "shows the form" do
         visit self_employed_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
         I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options").each do |_, option|
-          expect(page.body).to have_content(option[:label])
+          expect(page).to have_content(option[:label])
         end
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe "self-employed" do
       it "shows the form without prefilled response" do
         visit self_employed_path
 
-        expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -6,14 +6,14 @@ module FillInTheFormSteps
   end
 
   def and_they_live_in_england
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.location.questions.nation.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.location.questions.nation.title"))
 
     choose I18n.t("coronavirus_form.groups.location.questions.nation.options.option_england.label")
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_needs_help_with_all_options
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.title"))
 
     check I18n.t("coronavirus_form.groups.feeling_unsafe.need_help_with_label")
     check I18n.t("coronavirus_form.groups.paying_bills.title")
@@ -44,7 +44,7 @@ module FillInTheFormSteps
   end
 
   def and_feels_unsafe_where_they_live
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
 
     choose I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.option_no.label")
 
@@ -52,7 +52,7 @@ module FillInTheFormSteps
   end
 
   def and_is_finding_it_hard_to_afford_rent_mortgage_bills
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.title"))
 
     choose I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.option_yes.label")
 
@@ -60,7 +60,7 @@ module FillInTheFormSteps
   end
 
   def and_is_finding_it_hard_to_afford_food
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
 
     choose I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options.option_yes.label")
 
@@ -68,7 +68,7 @@ module FillInTheFormSteps
   end
 
   def and_is_not_finding_it_hard_to_afford_food
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.title"))
 
     choose I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options.option_no.label")
 
@@ -76,7 +76,7 @@ module FillInTheFormSteps
   end
 
   def and_is_unable_to_get_food
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.get_food.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.get_food.title"))
 
     choose I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label")
 
@@ -84,7 +84,7 @@ module FillInTheFormSteps
   end
 
   def and_has_been_told_to_stop_working
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
 
     choose I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_yes.label")
 
@@ -100,7 +100,7 @@ module FillInTheFormSteps
   end
 
   def and_is_off_work_because_ill_or_self_isolating
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
 
     choose I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_yes.label")
 
@@ -108,7 +108,7 @@ module FillInTheFormSteps
   end
 
   def and_is_self_employed_or_a_sole_trader
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
 
     choose I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label")
 
@@ -124,7 +124,7 @@ module FillInTheFormSteps
   end
 
   def and_is_worried_about_going_to_work_because_of_living_with_someone_vulnerable
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.title"))
 
     choose I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.options.option_yes.label")
 
@@ -132,7 +132,7 @@ module FillInTheFormSteps
   end
 
   def and_has_nowhere_to_live
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.title"))
 
     choose I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_somewhere_to_live.options.option_no.label")
 
@@ -140,7 +140,7 @@ module FillInTheFormSteps
   end
 
   def and_has_been_evicted
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.title"))
 
     choose I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options.option_yes.label")
 
@@ -148,7 +148,7 @@ module FillInTheFormSteps
   end
 
   def and_is_worried_about_mental_health
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.title"))
 
     choose I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options.option_yes.label")
 
@@ -156,7 +156,7 @@ module FillInTheFormSteps
   end
 
   def and_is_not_able_to_leave_home_if_absolutely_necessary
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
 
     choose I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_has_symptoms.label")
 
@@ -164,7 +164,7 @@ module FillInTheFormSteps
   end
 
   def and_is_not_able_to_leave_home_as_they_are_vulnerable
-    expect(page.body).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
 
     choose I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_high_risk.label")
 
@@ -172,29 +172,29 @@ module FillInTheFormSteps
   end
 
   def they_view_the_results_page
-    expect(page.body).to have_content(I18n.t("coronavirus_form.results.header.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.results.header.title"))
     expect(current_path).to eq "/results"
   end
 
   def they_are_provided_with_information_about_feeling_unsafe
-    expect(page.body).to have_content(I18n.t("results_link.feeling_unsafe.feel_safe.title"))
+    expect(page).to have_content(I18n.t("results_link.feeling_unsafe.feel_safe.title"))
   end
 
   def they_are_provided_with_information_about_paying_bills
-    expect(page.body).to have_content(I18n.t("results_link.paying_bills.afford_rent_mortgage_bills.title"))
+    expect(page).to have_content(I18n.t("results_link.paying_bills.afford_rent_mortgage_bills.title"))
   end
 
   def they_are_provided_with_information_about_getting_food
-    expect(page.body).to have_content(I18n.t("results_link.getting_food.afford_food.title"))
-    expect(page.body).to have_content(I18n.t("results_link.getting_food.get_food.title"))
+    expect(page).to have_content(I18n.t("results_link.getting_food.afford_food.title"))
+    expect(page).to have_content(I18n.t("results_link.getting_food.get_food.title"))
   end
 
   def they_are_provided_with_information_about_getting_support_when_vulnerable
-    expect(page.body).to have_content(I18n.t("results_link.getting_food.get_food.items")[0][:text])
+    expect(page).to have_content(I18n.t("results_link.getting_food.get_food.items")[0][:text])
   end
 
   def they_are_not_provided_with_information_about_getting_support_when_vulnerable
-    expect(page.body).not_to have_content(I18n.t("results_link.getting_food.get_food.items")[0][:text])
+    expect(page).not_to have_content(I18n.t("results_link.getting_food.get_food.items")[0][:text])
   end
 
   def they_are_provided_with_information_about_being_self_employed
@@ -210,19 +210,19 @@ module FillInTheFormSteps
   end
 
   def they_are_provided_with_information_about_going_in_to_work
-    expect(page.body).to have_content(I18n.t("results_link.going_in_to_work.living_with_vulnerable.title"))
+    expect(page).to have_content(I18n.t("results_link.going_in_to_work.living_with_vulnerable.title"))
   end
 
   def they_are_provided_with_information_about_having_somewhere_to_live
-    expect(page.body).to have_content(I18n.t("results_link.somewhere_to_live.have_somewhere_to_live.title"))
-    expect(page.body).to have_content(I18n.t("results_link.somewhere_to_live.have_you_been_evicted.title"))
+    expect(page).to have_content(I18n.t("results_link.somewhere_to_live.have_somewhere_to_live.title"))
+    expect(page).to have_content(I18n.t("results_link.somewhere_to_live.have_you_been_evicted.title"))
   end
 
   def they_are_provided_with_information_about_mental_health
-    expect(page.body).to have_content(I18n.t("results_link.mental_health.mental_health_worries.title"))
+    expect(page).to have_content(I18n.t("results_link.mental_health.mental_health_worries.title"))
   end
 
   def they_are_given_a_link_for_providing_feedback
-    expect(page.body).to have_content(I18n.t("coronavirus_form.results.feedback.link_text"))
+    expect(page).to have_content(I18n.t("coronavirus_form.results.feedback.link_text"))
   end
 end


### PR DESCRIPTION
What
----

The smoke tests were failing as a result of the javascript not being able to execute in time. The use of `page.body` as introduced in this [commit](https://github.com/alphagov/govuk-coronavirus-find-support/pull/138/commits/9466d919d14d4027ff22be2719ed480cb699f02b) returns a string and queries against that, rather than querying in the browser you're testing in. Changing it back to `page` should mean that the tests should be able to make asynchronous checks.

How to review
-------------

This change does not cause any of the existing test suite to fail. We should see an end to builds failing at deployment once this change is merged 

Links
-----
[Trello card](https://trello.com/c/IevL2dqd/464-fix-flaky-smoke-test)

