### PR TITLE
Auto-remove content if marked as "Withdrawn" in the Content google sheet

### DIFF
--- a/lib/content_importer.rb
+++ b/lib/content_importer.rb
@@ -56,6 +56,7 @@ module_function
     csv = CSV.read(csv_path, { headers: true })
     output = csv.each_with_object({}) do |csv_row, results_links|
       next if blank_row?(csv_row)
+      next if csv_row.fetch("change_status") == "Withdrawn"
 
       support_and_advice_items = csv_row.fetch("support_and_advice")
       group_key = csv_row.fetch("group_key").to_sym

--- a/spec/fixtures/result_links_test.csv
+++ b/spec/fixtures/result_links_test.csv
@@ -1,8 +1,8 @@
-id,group_title,subgroup_title,support_and_advice,text,href,show_to_nations,show_to_vulnerable_person,group_key,subgroup_key,support_and_advice,
-0001,I am the title for Group one,I am the title for Group one subgroup one,false,"This is a row that only has text, it will appear like a paragraph","","","",group_one,subgroup_one,false
-0002,I am the title for Group one,I am the title for Group one subgroup one,false,"This is a row has text and an href, it will appear as an anchor tag",http://test.stubbed.gov.uk,"","",group_one,subgroup_one,false
-0003,I am the title for Group one,I am the title for Group one subgroup one,false,"This is a row has text, an href and group criteria, it will appear as an anchor tag if the user's answers match the criteria",http://test.stubbed.llyw.cymru,Wales,"",group_one,subgroup_one,false
-0004,I am the title for Group one,I am the title for Group one subgroup one,true,"This is a row has text, an href and multiple group criteria, it will appear as an anchor tag if the user's answers match the more complex criteria",http://test.stubbed.gb.gov.uk,Wales OR Scotland OR England,"",group_one,subgroup_one,true
-0005,I am the title for Group one,I am the title for Group one subgroup two,false,"This is a row that only has text, it will appear like a paragraph","","","",group_one,subgroup_two,false
-0006,I am the title for Group two,I am the title for Group two subgroup one,false,"This is a row that only has text, it will appear like a paragraph","","",true,group_two,subgroup_one,false
-,,,,,,,#N/A,#N/A,#N/A,#N/A
+change_status,id,group_title,subgroup_title,support_and_advice,text,href,show_to_nations,show_to_vulnerable_person,group_key,subgroup_key,support_and_advice,
+,0001,I am the title for Group one,I am the title for Group one subgroup one,false,"This is a row that only has text, it will appear like a paragraph","","","",group_one,subgroup_one,false
+,0002,I am the title for Group one,I am the title for Group one subgroup one,false,"This is a row has text and an href, it will appear as an anchor tag",http://test.stubbed.gov.uk,"","",group_one,subgroup_one,false
+,0003,I am the title for Group one,I am the title for Group one subgroup one,false,"This is a row has text, an href and group criteria, it will appear as an anchor tag if the user's answers match the criteria",http://test.stubbed.llyw.cymru,Wales,"",group_one,subgroup_one,false
+,0004,I am the title for Group one,I am the title for Group one subgroup one,true,"This is a row has text, an href and multiple group criteria, it will appear as an anchor tag if the user's answers match the more complex criteria",http://test.stubbed.gb.gov.uk,Wales OR Scotland OR England,"",group_one,subgroup_one,true
+,0005,I am the title for Group one,I am the title for Group one subgroup two,false,"This is a row that only has text, it will appear like a paragraph","","","",group_one,subgroup_two,false
+,0006,I am the title for Group two,I am the title for Group two subgroup one,false,"This is a row that only has text, it will appear like a paragraph","","",true,group_two,subgroup_one,false
+,,,,,,,,#N/A,#N/A,#N/A,#N/A


### PR DESCRIPTION
Why
---
Content marked as withdrawn in the Content google sheet, is not being removed from the page.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Describe the steps required to review and test the changes.

Best not to try testing this as it requires amending the live content sheet.

Links
-----

https://trello.com/c/Nf0Dba27/588-auto-remove-withdrawn-content-from-the-app
