### PR TITLE
Move the able to leave home question

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
   include QuestionsHelper
+  include WriteResponsesHelper
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :session_expired
 
@@ -72,6 +73,6 @@ private
   end
 
   def check_session_exists
-    session_expired unless last_question_seen?
+    session_expired unless first_question_seen?
   end
 end

--- a/app/controllers/coronavirus_form/able_to_leave_controller.rb
+++ b/app/controllers/coronavirus_form/able_to_leave_controller.rb
@@ -20,41 +20,19 @@ class CoronavirusForm::AbleToLeaveController < ApplicationController
       render controller_path
     else
       update_session_store
-      write_responses
-      redirect_to results_url
+      write_responses if last_question == controller_name
+      redirect_to polymorphic_url(next_question(controller_name))
     end
   end
 
 private
-
-  # We're using this method to reduce the precision of timekeeping so that
-  # responses cannot be correlated with analytics data
-  def time_hour_floor
-    Time.current.beginning_of_hour
-  end
-
-  def write_responses
-    unwanted_fields = %w[_csrf_token check_answers_seen current_path previous_path session_id]
-    redacted_session = session.to_hash.without(*unwanted_fields)
-    unless smoke_tester?
-      FormResponse.create(
-        form_response: redacted_session,
-        created_at: time_hour_floor,
-      )
-    end
-  end
-
-  def smoke_tester?
-    smoke_test_header = request.env["HTTP_SMOKE_TEST"]
-    smoke_test_header.present? && smoke_test_header == "true"
-  end
 
   def update_session_store
     session[:able_to_leave] = @form_responses[:able_to_leave]
   end
 
   def group
-    "leave_home"
+    "getting_food"
   end
 
   def previous_path

--- a/app/controllers/coronavirus_form/afford_rent_mortgage_bills_controller.rb
+++ b/app/controllers/coronavirus_form/afford_rent_mortgage_bills_controller.rb
@@ -21,6 +21,7 @@ class CoronavirusForm::AffordRentMortgageBillsController < ApplicationController
       render controller_path
     else
       update_session_store
+      write_responses if last_question == controller_name
       redirect_to polymorphic_url(next_question(controller_name))
     end
   end

--- a/app/controllers/coronavirus_form/feel_safe_controller.rb
+++ b/app/controllers/coronavirus_form/feel_safe_controller.rb
@@ -21,6 +21,7 @@ class CoronavirusForm::FeelSafeController < ApplicationController
       render controller_path
     else
       update_session_store
+      write_responses if last_question == controller_name
       redirect_to polymorphic_url(next_question(controller_name))
     end
   end

--- a/app/controllers/coronavirus_form/have_you_been_evicted_controller.rb
+++ b/app/controllers/coronavirus_form/have_you_been_evicted_controller.rb
@@ -21,6 +21,7 @@ class CoronavirusForm::HaveYouBeenEvictedController < ApplicationController
       render controller_path
     else
       update_session_store
+      write_responses if last_question == controller_name
       redirect_to polymorphic_url(next_question(controller_name))
     end
   end

--- a/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
+++ b/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
@@ -22,7 +22,10 @@ class CoronavirusForm::HaveYouBeenMadeUnemployedController < ApplicationControll
     elsif I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.skip_next_question_options").include? @form_responses[:have_you_been_made_unemployed]
       update_session_store
       session[:questions_to_ask] = remove_questions(%w[are_you_off_work_ill])
-      redirect_to polymorphic_url(next_question(controller_name))
+      redirect_path = next_question(controller_name)
+      redirect_path == "results" ? redirect_to_results : redirect_to(polymorphic_url(redirect_path))
+    elsif last_question == controller_name
+      redirect_to_results
     else
       update_session_store
       session[:questions_to_ask] = add_questions(%w[are_you_off_work_ill], controller_name)
@@ -31,6 +34,12 @@ class CoronavirusForm::HaveYouBeenMadeUnemployedController < ApplicationControll
   end
 
 private
+
+  def redirect_to_results
+    update_session_store
+    write_responses
+    redirect_to results_url
+  end
 
   def update_session_store
     session[:have_you_been_made_unemployed] = @form_responses[:have_you_been_made_unemployed]

--- a/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
+++ b/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
@@ -19,26 +19,22 @@ class CoronavirusForm::HaveYouBeenMadeUnemployedController < ApplicationControll
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
-    elsif I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.skip_next_question_options").include? @form_responses[:have_you_been_made_unemployed]
-      update_session_store
-      session[:questions_to_ask] = remove_questions(%w[are_you_off_work_ill])
-      redirect_path = next_question(controller_name)
-      redirect_path == "results" ? redirect_to_results : redirect_to(polymorphic_url(redirect_path))
-    elsif last_question == controller_name
-      redirect_to_results
     else
       update_session_store
-      session[:questions_to_ask] = add_questions(%w[are_you_off_work_ill], controller_name)
+      write_responses if last_question == controller_name
+      update_questions_to_ask
       redirect_to polymorphic_url(next_question(controller_name))
     end
   end
 
 private
 
-  def redirect_to_results
-    update_session_store
-    write_responses
-    redirect_to results_url
+  def update_questions_to_ask
+    session[:questions_to_ask] = if I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.skip_next_question_options").include? @form_responses[:have_you_been_made_unemployed]
+                                   remove_questions(%w[are_you_off_work_ill])
+                                 else
+                                   add_questions(%w[are_you_off_work_ill], controller_name)
+                                 end
   end
 
   def update_session_store

--- a/app/controllers/coronavirus_form/mental_health_worries_controller.rb
+++ b/app/controllers/coronavirus_form/mental_health_worries_controller.rb
@@ -21,6 +21,7 @@ class CoronavirusForm::MentalHealthWorriesController < ApplicationController
       render controller_path
     else
       update_session_store
+      write_responses if last_question == controller_name
       redirect_to polymorphic_url(next_question(controller_name))
     end
   end

--- a/app/controllers/coronavirus_form/self_employed_controller.rb
+++ b/app/controllers/coronavirus_form/self_employed_controller.rb
@@ -27,7 +27,6 @@ class CoronavirusForm::SelfEmployedController < ApplicationController
     end
   end
 
-
 private
 
   def update_questions_to_ask

--- a/app/controllers/coronavirus_form/self_employed_controller.rb
+++ b/app/controllers/coronavirus_form/self_employed_controller.rb
@@ -22,7 +22,10 @@ class CoronavirusForm::SelfEmployedController < ApplicationController
     elsif I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.skip_next_question_options").include? @form_responses[:self_employed]
       update_session_store
       session[:questions_to_ask] = remove_questions(%w[have_you_been_made_unemployed are_you_off_work_ill])
-      redirect_to polymorphic_url(next_question(controller_name))
+      redirect_path = next_question(controller_name)
+      redirect_path == "results" ? redirect_to_results : redirect_to(polymorphic_url(redirect_path))
+    elsif last_question == controller_name
+      redirect_to_results
     else
       update_session_store
       session[:questions_to_ask] = add_questions(%w[have_you_been_made_unemployed are_you_off_work_ill], controller_name)
@@ -31,6 +34,12 @@ class CoronavirusForm::SelfEmployedController < ApplicationController
   end
 
 private
+
+  def redirect_to_results
+    update_session_store
+    write_responses
+    redirect_to results_url
+  end
 
   def update_session_store
     session[:self_employed] = @form_responses[:self_employed]

--- a/app/controllers/coronavirus_form/self_employed_controller.rb
+++ b/app/controllers/coronavirus_form/self_employed_controller.rb
@@ -19,26 +19,23 @@ class CoronavirusForm::SelfEmployedController < ApplicationController
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
-    elsif I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.skip_next_question_options").include? @form_responses[:self_employed]
-      update_session_store
-      session[:questions_to_ask] = remove_questions(%w[have_you_been_made_unemployed are_you_off_work_ill])
-      redirect_path = next_question(controller_name)
-      redirect_path == "results" ? redirect_to_results : redirect_to(polymorphic_url(redirect_path))
-    elsif last_question == controller_name
-      redirect_to_results
     else
       update_session_store
-      session[:questions_to_ask] = add_questions(%w[have_you_been_made_unemployed are_you_off_work_ill], controller_name)
+      write_responses if last_question == controller_name
+      update_questions_to_ask
       redirect_to polymorphic_url(next_question(controller_name))
     end
   end
 
+
 private
 
-  def redirect_to_results
-    update_session_store
-    write_responses
-    redirect_to results_url
+  def update_questions_to_ask
+    session[:questions_to_ask] = if I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.skip_next_question_options").include? @form_responses[:self_employed]
+                                   remove_questions(%w[have_you_been_made_unemployed are_you_off_work_ill])
+                                 else
+                                   add_questions(%w[have_you_been_made_unemployed are_you_off_work_ill], controller_name)
+                                 end
   end
 
   def update_session_store

--- a/app/controllers/coronavirus_form/worried_about_work_controller.rb
+++ b/app/controllers/coronavirus_form/worried_about_work_controller.rb
@@ -21,6 +21,7 @@ class CoronavirusForm::WorriedAboutWorkController < ApplicationController
       render controller_path
     else
       update_session_store
+      write_responses if last_question == controller_name
       redirect_to polymorphic_url(next_question(controller_name))
     end
   end

--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -1,5 +1,4 @@
 module QuestionsHelper
-  FINAL_QUESTION = "able_to_leave".freeze
   FILTER_QUESTION = "need_help_with".freeze
 
   def determine_user_questions(groups)
@@ -15,14 +14,12 @@ module QuestionsHelper
 
   def next_question(current_question)
     return first_question if current_question == FILTER_QUESTION
-    return FINAL_QUESTION if current_question == last_question
 
     current_question_index = questions_to_ask.index(current_question)
-    questions_to_ask[current_question_index + 1]
+    questions_to_ask[current_question_index + 1] || "results"
   end
 
   def previous_question(current_question)
-    return last_question if current_question == FINAL_QUESTION
     return FILTER_QUESTION if current_question == first_question
 
     current_question_index = questions_to_ask.index(current_question)
@@ -47,10 +44,6 @@ module QuestionsHelper
 
   def last_question
     questions_to_ask.last
-  end
-
-  def last_question_seen?
-    session[FINAL_QUESTION.to_sym].present?
   end
 
   def all_questions

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -35,7 +35,7 @@ module ResultsHelper
     # :help and :filter_questions which are not really groups
     # empty.
     if selected_groups.blank?
-      return I18n.t("coronavirus_form.groups").keys - %i[filter_questions help leave_home location]
+      return I18n.t("coronavirus_form.groups").keys - %i[filter_questions help location]
     end
 
     selected_groups # Otherwise we can use selected groups

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -68,6 +68,6 @@ private
 
   def show_to_vulnerable_check(item)
     item[:show_to_vulnerable_person].nil? ||
-      I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_high_risk.label") == session[:able_to_leave]
+      I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_high_risk.label") == session[:able_to_leave]
   end
 end

--- a/app/helpers/write_responses_helper.rb
+++ b/app/helpers/write_responses_helper.rb
@@ -1,0 +1,25 @@
+module WriteResponsesHelper
+  def write_responses
+    unwanted_fields = %w[_csrf_token check_answers_seen current_path previous_path session_id]
+    redacted_session = session.to_hash.without(*unwanted_fields)
+    unless smoke_tester?
+      FormResponse.create(
+        form_response: redacted_session,
+        created_at: time_hour_floor,
+      )
+    end
+  end
+
+private
+
+  def smoke_tester?
+    smoke_test_header = request.env["HTTP_SMOKE_TEST"]
+    smoke_test_header.present? && smoke_test_header == "true"
+  end
+
+  # We're using this method to reduce the precision of timekeeping so that
+  # responses cannot be correlated with analytics data
+  def time_hour_floor
+    Time.current.beginning_of_hour
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,6 +268,22 @@ en:
               not_sure:
                 label: Not sure
             custom_select_error: Select yes if you’re able to get food
+          able_to_leave:
+            title: Are you able to leave your home for food, medicine, or health reasons?
+            options:
+              option_yes:
+                label: 'Yes'
+              option_has_symptoms:
+                label: No, I should not leave home because I have coronavirus symptoms,
+                  or someone in my household does
+              option_high_risk:
+                label: No, I should not leave home because I have a medical condition
+                  which means I’m extremely vulnerable to coronavirus
+              option_disability:
+                label: No, I’m unable to go out because I have a disability
+              option_other:
+                label: No, I’m unable to leave my home for another reason
+            custom_select_error: Select if you’re able to leave your home or not
       being_unemployed:
         title: Being unemployed or not having any work
         questions:
@@ -369,24 +385,6 @@ en:
                 label: Not sure
             custom_select_error: Select yes if you’re worried about your mental health
               or someone else’s mental health
-      leave_home:
-        questions:
-          able_to_leave:
-            title: Are you able to leave your home for food, medicine, or health reasons?
-            options:
-              option_yes:
-                label: 'Yes'
-              option_has_symptoms:
-                label: No, I should not leave home because I have coronavirus symptoms,
-                  or someone in my household does
-              option_high_risk:
-                label: No, I should not leave home because I have a medical condition
-                  which means I’m extremely vulnerable to coronavirus
-              option_disability:
-                label: No, I’m unable to go out because I have a disability
-              option_other:
-                label: No, I’m unable to leave my home for another reason
-            custom_select_error: Select if you’re able to leave your home or not
     results:
       header:
         context: Coronavirus (COVID-19)

--- a/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
@@ -5,44 +5,22 @@ require "spec_helper"
 RSpec.describe CoronavirusForm::AbleToLeaveController, type: :controller do
   describe "POST" do
     context "if able to leave is the last question" do
-      before do
-        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[get_food able_to_leave])
-        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
-      end
-
-      after do
-        Timecop.return
-      end
-
       it "saves the form response to the database" do
-        session[:questions_to_ask] = %w[get_food able_to_leave]
-
-        post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
-
-        expect(FormResponse.first.form_response).to eq(
-          "questions_to_ask" => %w[get_food able_to_leave],
-          "able_to_leave" => I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label"),
-        )
-        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
-      end
-
-      it "does not save the form response to the database when the SMOKE_TEST header is present" do
-        session[:questions_to_ask] = %w[get_food able_to_leave]
-        request.env["HTTP_SMOKE_TEST"] = "true"
+        session[:questions_to_ask] = %w[able_to_leave]
         before_count = FormResponse.count
-
         post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
+
+        expect(FormResponse.count).to be > before_count
+      end
+    end
+
+    context "if able to leave is not the last question" do
+      it "does not save the form response to the database" do
+        session[:questions_to_ask] = %w[afford_food able_to_leave mental_health_worries]
+        before_count = FormResponse.count
+        post :submit, params: { afford_rent_mortgage_bills: I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.option_yes.label") }
 
         expect(FormResponse.count).to eq(before_count)
-      end
-
-      it "does not save the session id or csrf token to the database" do
-        session[:questions_to_ask] = %w[get_food able_to_leave]
-
-        post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
-
-        expect(FormResponse.first.form_response["session_id"]).to be_nil
-        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
       end
     end
   end

--- a/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
@@ -13,31 +13,31 @@ RSpec.describe CoronavirusForm::AbleToLeaveController, type: :controller do
     end
 
     it "saves the form response to the database" do
-      session[:questions_to_ask] = %w[get_food]
+      session[:questions_to_ask] = %w[get_food able_to_leave]
 
-      post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label") }
+      post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
 
       expect(FormResponse.first.form_response).to eq(
-        "questions_to_ask" => %w[get_food],
-        "able_to_leave" => I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
+        "questions_to_ask" => %w[get_food able_to_leave],
+        "able_to_leave" => I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label"),
       )
       expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
     end
 
     it "does not save the form response to the database when the SMOKE_TEST header is present" do
-      session[:questions_to_ask] = %w[get_food]
+      session[:questions_to_ask] = %w[get_food able_to_leave]
       request.env["HTTP_SMOKE_TEST"] = "true"
       before_count = FormResponse.count
 
-      post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label") }
+      post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
 
       expect(FormResponse.count).to eq(before_count)
     end
 
     it "does not save the session id or csrf token to the database" do
-      session[:questions_to_ask] = %w[get_food]
+      session[:questions_to_ask] = %w[get_food able_to_leave]
 
-      post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label") }
+      post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
 
       expect(FormResponse.first.form_response["session_id"]).to be_nil
       expect(FormResponse.first.form_response["_csrf_token"]).to be_nil

--- a/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/able_to_leave_controller_spec.rb
@@ -4,43 +4,46 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::AbleToLeaveController, type: :controller do
   describe "POST" do
-    before do
-      Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
-    end
+    context "if able to leave is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[get_food able_to_leave])
+        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
+      end
 
-    after do
-      Timecop.return
-    end
+      after do
+        Timecop.return
+      end
 
-    it "saves the form response to the database" do
-      session[:questions_to_ask] = %w[get_food able_to_leave]
+      it "saves the form response to the database" do
+        session[:questions_to_ask] = %w[get_food able_to_leave]
 
-      post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
+        post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
 
-      expect(FormResponse.first.form_response).to eq(
-        "questions_to_ask" => %w[get_food able_to_leave],
-        "able_to_leave" => I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label"),
-      )
-      expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
-    end
+        expect(FormResponse.first.form_response).to eq(
+          "questions_to_ask" => %w[get_food able_to_leave],
+          "able_to_leave" => I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label"),
+        )
+        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+      end
 
-    it "does not save the form response to the database when the SMOKE_TEST header is present" do
-      session[:questions_to_ask] = %w[get_food able_to_leave]
-      request.env["HTTP_SMOKE_TEST"] = "true"
-      before_count = FormResponse.count
+      it "does not save the form response to the database when the SMOKE_TEST header is present" do
+        session[:questions_to_ask] = %w[get_food able_to_leave]
+        request.env["HTTP_SMOKE_TEST"] = "true"
+        before_count = FormResponse.count
 
-      post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
+        post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
 
-      expect(FormResponse.count).to eq(before_count)
-    end
+        expect(FormResponse.count).to eq(before_count)
+      end
 
-    it "does not save the session id or csrf token to the database" do
-      session[:questions_to_ask] = %w[get_food able_to_leave]
+      it "does not save the session id or csrf token to the database" do
+        session[:questions_to_ask] = %w[get_food able_to_leave]
 
-      post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
+        post :submit, params: { able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label") }
 
-      expect(FormResponse.first.form_response["session_id"]).to be_nil
-      expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
+        expect(FormResponse.first.form_response["session_id"]).to be_nil
+        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
+      end
     end
   end
 end

--- a/spec/controllers/coronavirus_form/afford_rent_mortgage_bills_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/afford_rent_mortgage_bills_controller_spec.rb
@@ -5,44 +5,22 @@ require "spec_helper"
 RSpec.describe CoronavirusForm::AffordRentMortgageBillsController, type: :controller do
   describe "POST" do
     context "if afford rent mortgage bills is the last question" do
-      before do
-        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[afford_rent_mortgage_bills])
-        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
-      end
-
-      after do
-        Timecop.return
-      end
-
       it "saves the form response to the database" do
         session[:questions_to_ask] = %w[afford_rent_mortgage_bills]
-
+        before_count = FormResponse.count
         post :submit, params: { afford_rent_mortgage_bills: I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.option_yes.label") }
 
-        expect(FormResponse.first.form_response).to eq(
-          "questions_to_ask" => %w[afford_rent_mortgage_bills],
-          "afford_rent_mortgage_bills" => I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.option_yes.label"),
-        )
-        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+        expect(FormResponse.count).to be > before_count
       end
+    end
 
-      it "does not save the form response to the database when the SMOKE_TEST header is present" do
-        session[:questions_to_ask] = %w[afford_rent_mortgage_bills]
-        request.env["HTTP_SMOKE_TEST"] = "true"
+    context "if afford rent mortgage bills is not the last question" do
+      it "does not save the form response to the database" do
+        session[:questions_to_ask] = %w[afford_rent_mortgage_bills mental_health_worries]
         before_count = FormResponse.count
-
         post :submit, params: { afford_rent_mortgage_bills: I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.option_yes.label") }
 
         expect(FormResponse.count).to eq(before_count)
-      end
-
-      it "does not save the session id or csrf token to the database" do
-        session[:questions_to_ask] = %w[afford_rent_mortgage_bills]
-
-        post :submit, params: { afford_rent_mortgage_bills: I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.option_yes.label") }
-
-        expect(FormResponse.first.form_response["session_id"]).to be_nil
-        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
       end
     end
   end

--- a/spec/controllers/coronavirus_form/afford_rent_mortgage_bills_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/afford_rent_mortgage_bills_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::AffordRentMortgageBillsController, type: :controller do
+  describe "POST" do
+    context "if afford rent mortgage bills is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[afford_rent_mortgage_bills])
+        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "saves the form response to the database" do
+        session[:questions_to_ask] = %w[afford_rent_mortgage_bills]
+
+        post :submit, params: { afford_rent_mortgage_bills: I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response).to eq(
+          "questions_to_ask" => %w[afford_rent_mortgage_bills],
+          "afford_rent_mortgage_bills" => I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.option_yes.label"),
+        )
+        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+      end
+
+      it "does not save the form response to the database when the SMOKE_TEST header is present" do
+        session[:questions_to_ask] = %w[afford_rent_mortgage_bills]
+        request.env["HTTP_SMOKE_TEST"] = "true"
+        before_count = FormResponse.count
+
+        post :submit, params: { afford_rent_mortgage_bills: I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.option_yes.label") }
+
+        expect(FormResponse.count).to eq(before_count)
+      end
+
+      it "does not save the session id or csrf token to the database" do
+        session[:questions_to_ask] = %w[afford_rent_mortgage_bills]
+
+        post :submit, params: { afford_rent_mortgage_bills: I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response["session_id"]).to be_nil
+        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/coronavirus_form/feel_safe_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/feel_safe_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::FeelSafeController, type: :controller do
+  describe "POST" do
+    context "if do you feel safe is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[feel_safe])
+        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "saves the form response to the database" do
+        session[:questions_to_ask] = %w[feel_safe]
+
+        post :submit, params: { feel_safe: I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response).to eq(
+          "questions_to_ask" => %w[feel_safe],
+          "feel_safe" => I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.option_yes.label"),
+        )
+        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+      end
+
+      it "does not save the form response to the database when the SMOKE_TEST header is present" do
+        session[:questions_to_ask] = %w[feel_safe]
+        request.env["HTTP_SMOKE_TEST"] = "true"
+        before_count = FormResponse.count
+
+        post :submit, params: { feel_safe: I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.option_yes.label") }
+
+        expect(FormResponse.count).to eq(before_count)
+      end
+
+      it "does not save the session id or csrf token to the database" do
+        session[:questions_to_ask] = %w[feel_safe]
+
+        post :submit, params: { feel_safe: I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response["session_id"]).to be_nil
+        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/coronavirus_form/feel_safe_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/feel_safe_controller_spec.rb
@@ -5,44 +5,22 @@ require "spec_helper"
 RSpec.describe CoronavirusForm::FeelSafeController, type: :controller do
   describe "POST" do
     context "if do you feel safe is the last question" do
-      before do
-        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[feel_safe])
-        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
-      end
-
-      after do
-        Timecop.return
-      end
-
       it "saves the form response to the database" do
         session[:questions_to_ask] = %w[feel_safe]
-
-        post :submit, params: { feel_safe: I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.option_yes.label") }
-
-        expect(FormResponse.first.form_response).to eq(
-          "questions_to_ask" => %w[feel_safe],
-          "feel_safe" => I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.option_yes.label"),
-        )
-        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
-      end
-
-      it "does not save the form response to the database when the SMOKE_TEST header is present" do
-        session[:questions_to_ask] = %w[feel_safe]
-        request.env["HTTP_SMOKE_TEST"] = "true"
         before_count = FormResponse.count
-
         post :submit, params: { feel_safe: I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.option_yes.label") }
 
-        expect(FormResponse.count).to eq(before_count)
+        expect(FormResponse.count).to be > before_count
       end
 
-      it "does not save the session id or csrf token to the database" do
-        session[:questions_to_ask] = %w[feel_safe]
+      context "if do you feel safe is not the last question" do
+        it "does not save the form response to the database" do
+          session[:questions_to_ask] = %w[feel_safe mental_health_worries]
+          before_count = FormResponse.count
+          post :submit, params: { feel_safe: I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.option_yes.label") }
 
-        post :submit, params: { feel_safe: I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.options.option_yes.label") }
-
-        expect(FormResponse.first.form_response["session_id"]).to be_nil
-        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
+          expect(FormResponse.count).to eq(before_count)
+        end
       end
     end
   end

--- a/spec/controllers/coronavirus_form/have_you_been_evicted_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/have_you_been_evicted_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::HaveYouBeenEvictedController, type: :controller do
+  describe "POST" do
+    context "if have you been evicted is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[have_you_been_evicted])
+        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "saves the form response to the database" do
+        session[:questions_to_ask] = %w[have_you_been_evicted]
+
+        post :submit, params: { have_you_been_evicted: I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response).to eq(
+          "questions_to_ask" => %w[have_you_been_evicted],
+          "have_you_been_evicted" => I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options.option_yes.label"),
+        )
+        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+      end
+
+      it "does not save the form response to the database when the SMOKE_TEST header is present" do
+        session[:questions_to_ask] = %w[have_you_been_evicted]
+        request.env["HTTP_SMOKE_TEST"] = "true"
+        before_count = FormResponse.count
+
+        post :submit, params: { have_you_been_evicted: I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options.option_yes.label") }
+
+        expect(FormResponse.count).to eq(before_count)
+      end
+
+      it "does not save the session id or csrf token to the database" do
+        session[:questions_to_ask] = %w[have_you_been_evicted]
+
+        post :submit, params: { have_you_been_evicted: I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response["session_id"]).to be_nil
+        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/coronavirus_form/have_you_been_evicted_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/have_you_been_evicted_controller_spec.rb
@@ -5,44 +5,22 @@ require "spec_helper"
 RSpec.describe CoronavirusForm::HaveYouBeenEvictedController, type: :controller do
   describe "POST" do
     context "if have you been evicted is the last question" do
-      before do
-        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[have_you_been_evicted])
-        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
-      end
-
-      after do
-        Timecop.return
-      end
-
       it "saves the form response to the database" do
         session[:questions_to_ask] = %w[have_you_been_evicted]
-
+        before_count = FormResponse.count
         post :submit, params: { have_you_been_evicted: I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options.option_yes.label") }
 
-        expect(FormResponse.first.form_response).to eq(
-          "questions_to_ask" => %w[have_you_been_evicted],
-          "have_you_been_evicted" => I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options.option_yes.label"),
-        )
-        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+        expect(FormResponse.count).to be > before_count
       end
+    end
 
-      it "does not save the form response to the database when the SMOKE_TEST header is present" do
-        session[:questions_to_ask] = %w[have_you_been_evicted]
-        request.env["HTTP_SMOKE_TEST"] = "true"
+    context "if have you been evicted is not the last question" do
+      it "does not save the form response to the database" do
+        session[:questions_to_ask] = %w[have_you_been_evicted mental_health_worries]
         before_count = FormResponse.count
-
         post :submit, params: { have_you_been_evicted: I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options.option_yes.label") }
 
         expect(FormResponse.count).to eq(before_count)
-      end
-
-      it "does not save the session id or csrf token to the database" do
-        session[:questions_to_ask] = %w[have_you_been_evicted]
-
-        post :submit, params: { have_you_been_evicted: I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.options.option_yes.label") }
-
-        expect(FormResponse.first.form_response["session_id"]).to be_nil
-        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
       end
     end
   end

--- a/spec/controllers/coronavirus_form/have_you_been_made_unemployed_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/have_you_been_made_unemployed_controller_spec.rb
@@ -5,44 +5,22 @@ require "spec_helper"
 RSpec.describe CoronavirusForm::HaveYouBeenMadeUnemployedController, type: :controller do
   describe "POST" do
     context "if have you been made unemployed is the last question" do
-      before do
-        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[have_you_been_made_unemployed])
-        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
-      end
-
-      after do
-        Timecop.return
-      end
-
       it "saves the form response to the database" do
         session[:questions_to_ask] = %w[have_you_been_made_unemployed]
-
+        before_count = FormResponse.count
         post :submit, params: { have_you_been_made_unemployed: I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_yes.label") }
 
-        expect(FormResponse.first.form_response).to eq(
-          "questions_to_ask" => %w[have_you_been_made_unemployed],
-          "have_you_been_made_unemployed" => I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_yes.label"),
-        )
-        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+        expect(FormResponse.count).to be > before_count
       end
+    end
 
-      it "does not save the form response to the database when the SMOKE_TEST header is present" do
-        session[:questions_to_ask] = %w[have_you_been_made_unemployed]
-        request.env["HTTP_SMOKE_TEST"] = "true"
+    context "if have you been made unemployed is not the last question" do
+      it "does not save the form response to the database" do
+        session[:questions_to_ask] = %w[have_you_been_made_unemployed mental_health_worries]
         before_count = FormResponse.count
-
         post :submit, params: { have_you_been_made_unemployed: I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_yes.label") }
 
         expect(FormResponse.count).to eq(before_count)
-      end
-
-      it "does not save the session id or csrf token to the database" do
-        session[:questions_to_ask] = %w[have_you_been_made_unemployed]
-
-        post :submit, params: { have_you_been_made_unemployed: I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_yes.label") }
-
-        expect(FormResponse.first.form_response["session_id"]).to be_nil
-        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
       end
     end
   end

--- a/spec/controllers/coronavirus_form/have_you_been_made_unemployed_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/have_you_been_made_unemployed_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::HaveYouBeenMadeUnemployedController, type: :controller do
+  describe "POST" do
+    context "if have you been made unemployed is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[have_you_been_made_unemployed])
+        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "saves the form response to the database" do
+        session[:questions_to_ask] = %w[have_you_been_made_unemployed]
+
+        post :submit, params: { have_you_been_made_unemployed: I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response).to eq(
+          "questions_to_ask" => %w[have_you_been_made_unemployed],
+          "have_you_been_made_unemployed" => I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_yes.label"),
+        )
+        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+      end
+
+      it "does not save the form response to the database when the SMOKE_TEST header is present" do
+        session[:questions_to_ask] = %w[have_you_been_made_unemployed]
+        request.env["HTTP_SMOKE_TEST"] = "true"
+        before_count = FormResponse.count
+
+        post :submit, params: { have_you_been_made_unemployed: I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_yes.label") }
+
+        expect(FormResponse.count).to eq(before_count)
+      end
+
+      it "does not save the session id or csrf token to the database" do
+        session[:questions_to_ask] = %w[have_you_been_made_unemployed]
+
+        post :submit, params: { have_you_been_made_unemployed: I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response["session_id"]).to be_nil
+        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/coronavirus_form/mental_health_worries_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/mental_health_worries_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::MentalHealthWorriesController, type: :controller do
+  describe "POST" do
+    context "if mental health worries is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[mental_health_worries])
+        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "saves the form response to the database" do
+        session[:questions_to_ask] = %w[mental_health_worries]
+
+        post :submit, params: { mental_health_worries: I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response).to eq(
+          "questions_to_ask" => %w[mental_health_worries],
+          "mental_health_worries" => I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options.option_yes.label"),
+        )
+        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+      end
+
+      it "does not save the form response to the database when the SMOKE_TEST header is present" do
+        session[:questions_to_ask] = %w[mental_health_worries]
+        request.env["HTTP_SMOKE_TEST"] = "true"
+        before_count = FormResponse.count
+
+        post :submit, params: { mental_health_worries: I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options.option_yes.label") }
+
+        expect(FormResponse.count).to eq(before_count)
+      end
+
+      it "does not save the session id or csrf token to the database" do
+        session[:questions_to_ask] = %w[mental_health_worries]
+
+        post :submit, params: { mental_health_worries: I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response["session_id"]).to be_nil
+        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/coronavirus_form/mental_health_worries_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/mental_health_worries_controller_spec.rb
@@ -5,44 +5,22 @@ require "spec_helper"
 RSpec.describe CoronavirusForm::MentalHealthWorriesController, type: :controller do
   describe "POST" do
     context "if mental health worries is the last question" do
-      before do
-        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[mental_health_worries])
-        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
-      end
-
-      after do
-        Timecop.return
-      end
-
       it "saves the form response to the database" do
         session[:questions_to_ask] = %w[mental_health_worries]
-
+        before_count = FormResponse.count
         post :submit, params: { mental_health_worries: I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options.option_yes.label") }
 
-        expect(FormResponse.first.form_response).to eq(
-          "questions_to_ask" => %w[mental_health_worries],
-          "mental_health_worries" => I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options.option_yes.label"),
-        )
-        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+        expect(FormResponse.count).to be > before_count
       end
+    end
 
-      it "does not save the form response to the database when the SMOKE_TEST header is present" do
-        session[:questions_to_ask] = %w[mental_health_worries]
-        request.env["HTTP_SMOKE_TEST"] = "true"
+    context "if mental health worries is not the last question" do
+      it "does not save the form response to the database" do
+        session[:questions_to_ask] = %w[mental_health_worries self_employed]
         before_count = FormResponse.count
-
         post :submit, params: { mental_health_worries: I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options.option_yes.label") }
 
         expect(FormResponse.count).to eq(before_count)
-      end
-
-      it "does not save the session id or csrf token to the database" do
-        session[:questions_to_ask] = %w[mental_health_worries]
-
-        post :submit, params: { mental_health_worries: I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.options.option_yes.label") }
-
-        expect(FormResponse.first.form_response["session_id"]).to be_nil
-        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
       end
     end
   end

--- a/spec/controllers/coronavirus_form/self_employed_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/self_employed_controller_spec.rb
@@ -5,44 +5,22 @@ require "spec_helper"
 RSpec.describe CoronavirusForm::SelfEmployedController, type: :controller do
   describe "POST" do
     context "if have you been made unemployed is the last question" do
-      before do
-        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[self_employed])
-        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
-      end
-
-      after do
-        Timecop.return
-      end
-
       it "saves the form response to the database" do
         session[:questions_to_ask] = %w[self_employed]
-
+        before_count = FormResponse.count
         post :submit, params: { self_employed: I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label") }
 
-        expect(FormResponse.first.form_response).to eq(
-          "questions_to_ask" => %w[self_employed],
-          "self_employed" => I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
-        )
-        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+        expect(FormResponse.count).to be > before_count
       end
+    end
 
-      it "does not save the form response to the database when the SMOKE_TEST header is present" do
-        session[:questions_to_ask] = %w[self_employed]
-        request.env["HTTP_SMOKE_TEST"] = "true"
+    context "if have you been made unemployed is not the last question" do
+      it "does not save the form response to the database" do
+        session[:questions_to_ask] = %w[self_employed mental_health_worries]
         before_count = FormResponse.count
-
         post :submit, params: { self_employed: I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label") }
 
         expect(FormResponse.count).to eq(before_count)
-      end
-
-      it "does not save the session id or csrf token to the database" do
-        session[:questions_to_ask] = %w[self_employed]
-
-        post :submit, params: { self_employed: I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label") }
-
-        expect(FormResponse.first.form_response["session_id"]).to be_nil
-        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
       end
     end
   end

--- a/spec/controllers/coronavirus_form/self_employed_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/self_employed_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::SelfEmployedController, type: :controller do
+  describe "POST" do
+    context "if have you been made unemployed is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[self_employed])
+        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "saves the form response to the database" do
+        session[:questions_to_ask] = %w[self_employed]
+
+        post :submit, params: { self_employed: I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response).to eq(
+          "questions_to_ask" => %w[self_employed],
+          "self_employed" => I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
+        )
+        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+      end
+
+      it "does not save the form response to the database when the SMOKE_TEST header is present" do
+        session[:questions_to_ask] = %w[self_employed]
+        request.env["HTTP_SMOKE_TEST"] = "true"
+        before_count = FormResponse.count
+
+        post :submit, params: { self_employed: I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label") }
+
+        expect(FormResponse.count).to eq(before_count)
+      end
+
+      it "does not save the session id or csrf token to the database" do
+        session[:questions_to_ask] = %w[self_employed]
+
+        post :submit, params: { self_employed: I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response["session_id"]).to be_nil
+        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/coronavirus_form/worried_about_work_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/worried_about_work_controller_spec.rb
@@ -4,45 +4,23 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::WorriedAboutWorkController, type: :controller do
   describe "POST" do
-    context "if living with vulnerable is the last question" do
-      before do
-        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[worried_about_work])
-        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
-      end
-
-      after do
-        Timecop.return
-      end
-
+    context "if worried about work is the last question" do
       it "saves the form response to the database" do
         session[:questions_to_ask] = %w[worried_about_work]
-
-        post :submit, params: { worried_about_work: I18n.t("coronavirus_form.groups.going_in_to_work.questions.worried_about_work.options.option_yes.label") }
-
-        expect(FormResponse.first.form_response).to eq(
-          "questions_to_ask" => %w[worried_about_work],
-          "worried_about_work" => I18n.t("coronavirus_form.groups.going_in_to_work.questions.worried_about_work.options.option_yes.label"),
-        )
-        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
-      end
-
-      it "does not save the form response to the database when the SMOKE_TEST header is present" do
-        session[:questions_to_ask] = %w[worried_about_work]
-        request.env["HTTP_SMOKE_TEST"] = "true"
         before_count = FormResponse.count
-
         post :submit, params: { worried_about_work: I18n.t("coronavirus_form.groups.going_in_to_work.questions.worried_about_work.options.option_yes.label") }
+
+        expect(FormResponse.count).to be > before_count
+      end
+    end
+
+    context "if worried about work is not the last question do" do
+      it "does not save the form response to the database" do
+        session[:questions_to_ask] = %w[worried_about_work mental_health_worries]
+        before_count = FormResponse.count
+        post :submit, params: { worried_about_work: I18n.t("coronavirus_form.groups.going_in_to_work.questions.living_with_vulnerable.options.option_yes.label") }
 
         expect(FormResponse.count).to eq(before_count)
-      end
-
-      it "does not save the session id or csrf token to the database" do
-        session[:questions_to_ask] = %w[worried_about_work]
-
-        post :submit, params: { worried_about_work: I18n.t("coronavirus_form.groups.going_in_to_work.questions.worried_about_work.options.option_yes.label") }
-
-        expect(FormResponse.first.form_response["session_id"]).to be_nil
-        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
       end
     end
   end

--- a/spec/controllers/coronavirus_form/worried_about_work_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/worried_about_work_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::WorriedAboutWorkController, type: :controller do
+  describe "POST" do
+    context "if living with vulnerable is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[worried_about_work])
+        Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "saves the form response to the database" do
+        session[:questions_to_ask] = %w[worried_about_work]
+
+        post :submit, params: { worried_about_work: I18n.t("coronavirus_form.groups.going_in_to_work.questions.worried_about_work.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response).to eq(
+          "questions_to_ask" => %w[worried_about_work],
+          "worried_about_work" => I18n.t("coronavirus_form.groups.going_in_to_work.questions.worried_about_work.options.option_yes.label"),
+        )
+        expect(FormResponse.first.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+      end
+
+      it "does not save the form response to the database when the SMOKE_TEST header is present" do
+        session[:questions_to_ask] = %w[worried_about_work]
+        request.env["HTTP_SMOKE_TEST"] = "true"
+        before_count = FormResponse.count
+
+        post :submit, params: { worried_about_work: I18n.t("coronavirus_form.groups.going_in_to_work.questions.worried_about_work.options.option_yes.label") }
+
+        expect(FormResponse.count).to eq(before_count)
+      end
+
+      it "does not save the session id or csrf token to the database" do
+        session[:questions_to_ask] = %w[worried_about_work]
+
+        post :submit, params: { worried_about_work: I18n.t("coronavirus_form.groups.going_in_to_work.questions.worried_about_work.options.option_yes.label") }
+
+        expect(FormResponse.first.form_response["session_id"]).to be_nil
+        expect(FormResponse.first.form_response["_csrf_token"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature "Fill in the find support form" do
       and_is_finding_it_hard_to_afford_rent_mortgage_bills
       and_is_finding_it_hard_to_afford_food
       and_is_unable_to_get_food
+      and_is_not_able_to_leave_home_if_absolutely_necessary
       and_is_not_self_employed_or_a_sole_trader
       and_has_not_been_told_to_stop_working
       and_is_off_work_because_ill_or_self_isolating
@@ -21,7 +22,6 @@ RSpec.feature "Fill in the find support form" do
       and_has_nowhere_to_live
       and_has_been_evicted
       and_is_worried_about_mental_health
-      and_is_not_able_to_leave_home_if_absolutely_necessary
       they_view_the_results_page
       they_are_provided_with_information_about_feeling_unsafe
       they_are_provided_with_information_about_paying_bills
@@ -49,7 +49,6 @@ RSpec.feature "Fill in the find support form" do
     and_needs_help_with_being_unemployed
     and_is_not_self_employed_or_a_sole_trader
     and_has_been_told_to_stop_working
-    and_is_not_able_to_leave_home_if_absolutely_necessary
     they_view_the_results_page
     they_are_provided_with_information_about_being_unemployed
     they_are_given_a_link_for_providing_feedback
@@ -60,7 +59,6 @@ RSpec.feature "Fill in the find support form" do
     and_they_live_in_england
     and_needs_help_with_being_unemployed
     and_is_self_employed_or_a_sole_trader
-    and_is_not_able_to_leave_home_if_absolutely_necessary
     they_view_the_results_page
     they_are_provided_with_information_about_being_self_employed
     they_are_given_a_link_for_providing_feedback

--- a/spec/helpers/questions_helper_spec.rb
+++ b/spec/helpers/questions_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe QuestionsHelper, type: :helper do
   describe "#determine_user_questions" do
     it "returns questions in correct order" do
       groups = %i[paying_bills getting_food]
-      expected_questions = %w[afford_rent_mortgage_bills afford_food get_food]
+      expected_questions = %w[afford_rent_mortgage_bills afford_food get_food able_to_leave]
 
       expect(helper.determine_user_questions(groups)).to eq(expected_questions)
     end
@@ -24,10 +24,6 @@ RSpec.describe QuestionsHelper, type: :helper do
       expect(helper.next_question("get_food")).to eq("afford_food")
     end
 
-    it "returns the final compulsory question for the final item" do
-      expect(helper.next_question("afford_food")).to eq("able_to_leave")
-    end
-
     it "returns the first question for the need help with question" do
       expect(helper.next_question("need_help_with")).to eq("get_food")
     end
@@ -40,10 +36,6 @@ RSpec.describe QuestionsHelper, type: :helper do
 
     it "returns the filter question page key for the first item" do
       expect(helper.previous_question("get_food")).to eq("need_help_with")
-    end
-
-    it "returns the last question for the able to leave question" do
-      expect(helper.previous_question("able_to_leave")).to eq("afford_food")
     end
   end
 

--- a/spec/helpers/result_helper_spec.rb
+++ b/spec/helpers/result_helper_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe ResultsHelper, type: :helper do
       expect(filter_results_by_multiple_questions(test_hash.dup)[:support_and_advice_items]).to eq([{ show_to_nations: "nation 1" }])
     end
 
-    let(:vulnerable_person_label) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_high_risk.label") }
-    let(:not_vulnerable_label) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_other.label") }
+    let(:vulnerable_person_label) { I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_high_risk.label") }
+    let(:not_vulnerable_label) { I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_other.label") }
 
     it "should return show_to_vulnerable_person items if the session able_to_leave is high_risk" do
       session.merge!({

--- a/spec/helpers/write_responses_helper_spec.rb
+++ b/spec/helpers/write_responses_helper_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+RSpec.describe WriteResponsesHelper, type: :helper do
+  before do
+    Timecop.freeze(Time.utc(2020, 3, 1, 10, 43, 45))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  describe "#write_responses" do
+    context "if able to leave is the last question" do
+      it "saves the form responses to the database" do
+        session[:able_to_leave] = "Yes"
+        session[:questions_to_ask] = %w[get_food able_to_leave]
+
+        expect(helper.write_responses.form_response).to eq({ "able_to_leave" => "Yes", "questions_to_ask" => %w[get_food able_to_leave] })
+        expect(helper.write_responses.created_at).to eq(Time.utc(2020, 3, 1, 10, 0, 0))
+      end
+
+      it "does not save the form response to the database when the SMOKE_TEST header is present" do
+        allow_any_instance_of(WriteResponsesHelper).to receive(:smoke_tester?).and_return(true)
+        session[:questions_to_ask] = %w[get_food able_to_leave]
+        before_count = FormResponse.count
+        helper.write_responses
+
+        expect(FormResponse.count).to eq(before_count)
+      end
+
+      it "does not save the session id or csrf token to the database" do
+        session[:questions_to_ask] = %w[get_food able_to_leave]
+
+        expect(helper.write_responses.form_response["session_id"]).to be_nil
+        expect(helper.write_responses.form_response["_csrf_token"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/able_to_leave_spec.rb
+++ b/spec/requests/able_to_leave_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe "able-to-leave" do
-  let(:options) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options") }
+  let(:options) { I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options") }
   let(:selected_option) { options.keys.sample }
-  let(:selected_option_text) { I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.#{selected_option}.label") }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.#{selected_option}.label") }
 
   before do
-    allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[able_to_leave feel_safe])
+    allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[afford_food able_to_leave feel_safe])
   end
 
   describe "GET /able-to-leave" do
@@ -24,8 +24,8 @@ RSpec.describe "able-to-leave" do
       it "shows the form" do
         visit able_to_leave_path
 
-        expect(page).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
-        I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options").each do |_, option|
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.title"))
+        I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options").each do |_, option|
           expect(page).to have_content(option[:label])
         end
       end
@@ -39,7 +39,7 @@ RSpec.describe "able-to-leave" do
       it "shows the form without prefilled response" do
         visit able_to_leave_path
 
-        expect(page).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
@@ -52,17 +52,17 @@ RSpec.describe "able-to-leave" do
       expect(session[:able_to_leave]).to eq(selected_option_text)
     end
 
-    it "redirects to the results page" do
+    it "redirects to the next question" do
       post able_to_leave_path, params: { able_to_leave: selected_option_text }
 
-      expect(response).to redirect_to(results_path)
+      expect(response).to redirect_to(feel_safe_path)
     end
 
     it "shows an error when no radio button selected" do
       post able_to_leave_path
 
-      expect(response.body).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
-      expect(response.body).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.custom_select_error"))
+      expect(response.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.title"))
+      expect(response.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.custom_select_error"))
     end
   end
 end

--- a/spec/requests/able_to_leave_spec.rb
+++ b/spec/requests/able_to_leave_spec.rb
@@ -64,5 +64,17 @@ RSpec.describe "able-to-leave" do
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.title"))
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.custom_select_error"))
     end
+
+    context "when this is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[afford_food able_to_leave])
+      end
+
+      it "redirects to the results url" do
+        post able_to_leave_path, params: { able_to_leave: selected_option_text }
+
+        expect(response).to redirect_to(results_path)
+      end
+    end
   end
 end

--- a/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
+++ b/spec/requests/afford_rent_mortgage_bills_controller_spec.rb
@@ -76,5 +76,17 @@ RSpec.describe "afford-rent-mortgage-bills" do
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.title"))
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.paying_bills.questions.afford_rent_mortgage_bills.custom_select_error"))
     end
+
+    context "when this is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[afford_rent_mortgage_bills])
+      end
+
+      it "redirects to the results url" do
+        post afford_rent_mortgage_bills_path, params: { afford_rent_mortgage_bills: selected_option_text }
+
+        expect(response).to redirect_to(results_path)
+      end
+    end
   end
 end

--- a/spec/requests/data_export_spec.rb
+++ b/spec/requests/data_export_spec.rb
@@ -5,28 +5,28 @@ RSpec.describe "data-export", type: :request do
   before do
     FormResponse.create(
       form_response: {
-        able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
+        able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label"),
         get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_yes.label"),
       },
       created_at: "2020-04-10 10:00:00",
     )
     FormResponse.create(
       form_response: {
-        able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
+        able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label"),
         get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label"),
       },
       created_at: "2020-04-10 10:00:00",
     )
     FormResponse.create(
       form_response: {
-        able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label"),
+        able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label"),
         get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_yes.label"),
       },
       created_at: "2020-04-12 10:00:00",
     )
     FormResponse.create(
       form_response: {
-        able_to_leave: I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_other.label"),
+        able_to_leave: I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_other.label"),
         get_food: I18n.t("coronavirus_form.groups.getting_food.questions.get_food.options.option_no.label"),
       },
       created_at: "2020-04-12 10:00:00",
@@ -58,12 +58,12 @@ RSpec.describe "data-export", type: :request do
     let(:expected_partial) do
       [
         "question|answer|date|count",
-        "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.title')}|" \
-          "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label')}|" \
+        "#{I18n.t('coronavirus_form.groups.getting_food.questions.able_to_leave.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label')}|" \
           "2020-04-12|" \
           "1",
-        "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.title')}|" \
-          "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_other.label')}|" \
+        "#{I18n.t('coronavirus_form.groups.getting_food.questions.able_to_leave.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_other.label')}|" \
           "2020-04-12|" \
           "1",
         "#{I18n.t('coronavirus_form.groups.getting_food.questions.get_food.title')}|" \
@@ -80,16 +80,16 @@ RSpec.describe "data-export", type: :request do
     let(:expected_all_time) do
       [
         "question|answer|date|count",
-        "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.title')}|" \
-          "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label')}|" \
+        "#{I18n.t('coronavirus_form.groups.getting_food.questions.able_to_leave.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label')}|" \
           "2020-04-10|" \
           "2",
-        "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.title')}|" \
-          "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_yes.label')}|" \
+        "#{I18n.t('coronavirus_form.groups.getting_food.questions.able_to_leave.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_yes.label')}|" \
           "2020-04-12|" \
           "1",
-        "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.title')}|" \
-          "#{I18n.t('coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_other.label')}|" \
+        "#{I18n.t('coronavirus_form.groups.getting_food.questions.able_to_leave.title')}|" \
+          "#{I18n.t('coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_other.label')}|" \
           "2020-04-12|" \
           "1",
         "#{I18n.t('coronavirus_form.groups.getting_food.questions.get_food.title')}|" \

--- a/spec/requests/feel_safe_spec.rb
+++ b/spec/requests/feel_safe_spec.rb
@@ -76,5 +76,17 @@ RSpec.describe "feel-safe" do
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.title"))
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.feeling_unsafe.questions.feel_safe.custom_select_error"))
     end
+
+    context "when this is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[feel_safe])
+      end
+
+      it "redirects to the results url" do
+        post feel_safe_path, params: { feel_safe: selected_option_text }
+
+        expect(response).to redirect_to(results_path)
+      end
+    end
   end
 end

--- a/spec/requests/have_you_been_evicted_spec.rb
+++ b/spec/requests/have_you_been_evicted_spec.rb
@@ -76,5 +76,17 @@ RSpec.describe "have-you-been-evicted" do
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.title"))
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.somewhere_to_live.questions.have_you_been_evicted.custom_select_error"))
     end
+
+    context "when this is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[have_you_been_evicted])
+      end
+
+      it "redirects to the results url" do
+        post have_you_been_evicted_path, params: { have_you_been_evicted: selected_option_text }
+
+        expect(response).to redirect_to(results_path)
+      end
+    end
   end
 end

--- a/spec/requests/have_you_been_made_unemployed_spec.rb
+++ b/spec/requests/have_you_been_made_unemployed_spec.rb
@@ -88,5 +88,17 @@ RSpec.describe "have-you-been-made-unemployed" do
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.title"))
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.custom_select_error"))
     end
+
+    context "when this is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[have_you_been_made_unemployed])
+      end
+
+      it "redirects to the results url" do
+        post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: selected_option_text }
+
+        expect(response).to redirect_to(results_path)
+      end
+    end
   end
 end

--- a/spec/requests/mental_health_worries_spec.rb
+++ b/spec/requests/mental_health_worries_spec.rb
@@ -90,5 +90,17 @@ RSpec.describe "mental-health-worries" do
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.title"))
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.mental_health.questions.mental_health_worries.custom_select_error"))
     end
+
+    context "when this is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[mental_health_worries])
+      end
+
+      it "redirects to the results url" do
+        post mental_health_worries_path, params: { mental_health_worries: selected_option_text }
+
+        expect(response).to redirect_to(results_path)
+      end
+    end
   end
 end

--- a/spec/requests/self_employed_spec.rb
+++ b/spec/requests/self_employed_spec.rb
@@ -89,5 +89,17 @@ RSpec.describe "self-employed" do
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.title"))
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.custom_select_error"))
     end
+
+    context "when this is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[self_employed])
+      end
+
+      it "redirects to the results url" do
+        post self_employed_path, params: { self_employed: selected_option_text }
+
+        expect(response).to redirect_to(results_path)
+      end
+    end
   end
 end

--- a/spec/requests/worried_about_work_spec.rb
+++ b/spec/requests/worried_about_work_spec.rb
@@ -76,5 +76,17 @@ RSpec.describe "worried-about-work" do
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.worried_about_work.title"))
       expect(response.body).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.worried_about_work.custom_select_error"))
     end
+
+    context "when this is the last question" do
+      before do
+        allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[worried_about_work])
+      end
+
+      it "redirects to the results url" do
+        post worried_about_work_path, params: { worried_about_work: selected_option_text }
+
+        expect(response).to redirect_to(results_path)
+      end
+    end
   end
 end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -156,17 +156,17 @@ module FillInTheFormSteps
   end
 
   def and_is_not_able_to_leave_home_if_absolutely_necessary
-    expect(page).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.title"))
 
-    choose I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_has_symptoms.label")
+    choose I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_has_symptoms.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_is_not_able_to_leave_home_as_they_are_vulnerable
-    expect(page).to have_content(I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.title"))
 
-    choose I18n.t("coronavirus_form.groups.leave_home.questions.able_to_leave.options.option_high_risk.label")
+    choose I18n.t("coronavirus_form.groups.getting_food.questions.able_to_leave.options.option_high_risk.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end


### PR DESCRIPTION
What
----

The question that asks the user if they are able to leave their house has been moved alongside the food based questions. This means that it is no longer the de facto last question which has necessitated the changing of quite a lot of logic.

How to review
-------------

Probably best to review commit by commit. It may also help to run the service locally and run through it in a few different ways until you're confident that it all works as expected. 

Links
-----

Trello - https://trello.com/c/Vj3BSoYV/544-change-so-can-you-leave-your-house-question-is-only-shown-to-users-who-cant-get-food

