### PR TITLE
Fix analytics and lint JS

### DIFF
--- a/app/assets/javascripts/analytics-enhancedEcommerce.js
+++ b/app/assets/javascripts/analytics-enhancedEcommerce.js
@@ -1,3 +1,5 @@
+/* global ga:readonly */
+
 var enhancedEcommerceTracking = function (d) {
   var consentCookie = window.GOVUK.getConsentCookie()
 
@@ -15,7 +17,7 @@ var enhancedEcommerceTracking = function (d) {
   }
 
   // Start analytics only if we have user consent
-  if (consentCookie && consentCookie["usage"] === true) {
+  if (consentCookie && consentCookie.usage === true) {
     var lists = d.querySelectorAll('[data-track-ec-list]')
 
     if (lists.length === 0) {
@@ -23,7 +25,7 @@ var enhancedEcommerceTracking = function (d) {
     }
 
     for (var idx = 0; idx < lists.length; idx++) {
-      var list = lists[idx];
+      var list = lists[idx]
       var listName = list.getAttribute('data-track-ec-list')
       var positions = list.querySelectorAll('li')
 

--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -1,13 +1,3 @@
-// Start cookie banner (display settings controlled internally by cookies)
-var element = document.querySelector('[data-module="cookie-banner"]')
-
-try {
-  if (element) new GOVUK.Modules.CookieBanner().start($(element))
-}
-catch(error) {
-  console.error(error)
-}
-
 var analyticsInit = function () {
   <% if Rails.application.config.analytics_tracking_id.present? %>
     var trackingId = "<%= Rails.application.config.analytics_tracking_id %>"

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,5 @@
+/* eslint-env jquery */
+
 //= require jquery
 //= require govuk_publishing_components/modules
 //= require govuk_publishing_components/lib/cookie-functions

--- a/app/assets/javascripts/cookies.js
+++ b/app/assets/javascripts/cookies.js
@@ -1,10 +1,9 @@
 window.GOVUK = window.GOVUK || {}
 
-function CookieSettings() { }
+function CookieSettings () { }
 
 CookieSettings.start = function () {
-
-  var cookieForm = document.querySelector('form[data-module=cookie-settings]');
+  var cookieForm = document.querySelector('form[data-module=cookie-settings]')
 
   if (cookieForm) {
     cookieForm.addEventListener('submit', this.submitSettingsForm)
@@ -21,11 +20,11 @@ CookieSettings.setInitialFormValues = function () {
   var currentConsentCookieJSON = JSON.parse(currentConsentCookie)
 
   // We don't need the essential value as this cannot be changed by the user
-  delete currentConsentCookieJSON["essential"]
+  delete currentConsentCookieJSON.essential
   // We don't need the campaigns/settings values as these aren't required by
   // the service.
-  delete currentConsentCookieJSON["campaigns"]
-  delete currentConsentCookieJSON["settings"]
+  delete currentConsentCookieJSON.campaigns
+  delete currentConsentCookieJSON.settings
 
   for (var cookieType in currentConsentCookieJSON) {
     var radioButton
@@ -43,21 +42,21 @@ CookieSettings.setInitialFormValues = function () {
 CookieSettings.submitSettingsForm = function (event) {
   event.preventDefault()
 
-  var formInputs = event.target.getElementsByTagName("input")
+  var formInputs = event.target.getElementsByTagName('input')
   var options = {}
 
   for (var i = 0; i < formInputs.length; i++) {
     var input = formInputs[i]
     if (input.checked) {
       var name = input.name.replace('cookies-', '')
-      var value = input.value === "on" ? true : false
+      var value = input.value === 'on'
 
       options[name] = value
     }
   }
 
   window.GOVUK.setConsentCookie(options)
-  window.GOVUK.setCookie('cookies_preferences_set', true, { days: 365 });
+  window.GOVUK.setCookie('cookies_preferences_set', true, { days: 365 })
 
   CookieSettings.showConfirmationMessage()
 
@@ -73,5 +72,5 @@ CookieSettings.showConfirmationMessage = function () {
 
   document.body.scrollTop = document.documentElement.scrollTop = 0
 
-  confirmationMessage.style.display = "block"
+  confirmationMessage.style.display = 'block'
 }


### PR DESCRIPTION
What
----

Remove duplicate page view hit after cookie banner is accepted.
Lint JavaScript code.

Similar to https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/pull/395 and https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/pull/396 – hope I'm not stepping on toes here, Ian.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Check events sent when accepting cookies using GA Debug (or similar).

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="600" alt="Screenshot 2020-06-22 at 16 27 15" src="https://user-images.githubusercontent.com/788096/85305841-86a84680-b4a5-11ea-9b83-d2006bfe8c5c.png">

</td><td valign="top">

<img width="600" alt="Screenshot 2020-06-22 at 16 27 41" src="https://user-images.githubusercontent.com/788096/85305866-8dcf5480-b4a5-11ea-9366-d5fe8fe9456f.png">

</td></tr>
</table>


Links
-----

[Trello card](https://trello.com/c/qcLLrnqK)
