### PR TITLE
Changed information to advice

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,7 +510,7 @@ en:
           text: Find specialist helplines for black and minority women (Imkaan).
           href: https://www.imkaan.org.uk/get-help
         - id: '0005'
-          text: Find additional helplines <a href="https://www.gov.uk/government/publications/coronavirus-covid-19-and-domestic-abuse/coronavirus-covid-19-support-for-victims-of-domestic-abuse"
+          text: Find additional helplines <a href="https://www.gov.uk/guidance/domestic-abuse-how-to-get-help"
             class="govuk-link">if you’re a victim of domestic abuse or feel at risk
             of abuse</a>, or if you are a <a href="https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services"
             class="govuk-link">victim or witness of a crime</a>.
@@ -766,18 +766,18 @@ en:
           text: Find out about your rights if you’ve been furloughed (Acas)
           href: https://www.acas.org.uk/coronavirus/furlough-scheme-pay/start-extend-end-furlough
         - id: '0054'
-          text: Get information on applying for Universal Credit (Citizens Advice)
+          text: Get advice on applying for Universal Credit (Citizens Advice)
           href: https://www.citizensadvice.org.uk/benefits/universal-credit/
           show_to_nations:
           - England
         - id: '0055'
-          text: Get information on applying for Universal Credit (Citizens Advice
+          text: Get advice on applying for Universal Credit (Citizens Advice
             Scotland)
           href: https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/
           show_to_nations:
           - Scotland
         - id: '0056'
-          text: Get information on applying for Universal Credit (Citizens Advice)
+          text: Get advice on applying for Universal Credit (Citizens Advice)
           href: https://www.citizensadvice.org.uk/wales/benefits/universal-credit/
           show_to_nations:
           - Wales
@@ -875,18 +875,18 @@ en:
             Service)
           href: https://www.moneyadviceservice.org.uk/en/articles/coronavirus-if-youre-self-employed
         - id: '0071'
-          text: Get information on applying for Universal Credit (Citizens Advice)
+          text: Get advice on applying for Universal Credit (Citizens Advice)
           href: https://www.citizensadvice.org.uk/benefits/universal-credit/
           show_to_nations:
           - England
         - id: '0072'
-          text: Get information on applying for Universal Credit (Citizens Advice
+          text: Get advice on applying for Universal Credit (Citizens Advice
             Scotland)
           href: https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/
           show_to_nations:
           - Scotland
         - id: '0073'
-          text: Get information on applying for Universal Credit (Citizens Advice)
+          text: Get advice on applying for Universal Credit (Citizens Advice)
           href: https://www.citizensadvice.org.uk/wales/benefits/universal-credit/
           show_to_nations:
           - Wales


### PR DESCRIPTION
Changed 'get information on applying for universal credit' to 'get advice...'

Why:
To see if users find it more helpful, you do get advice, not just info 

I noticed this as part of the review of this card https://trello.com/c/78R2O7bG/625-review-analytics-of-results-page-links

Also changed a link to the direct link, it was redirecting


What
----

Describe what you have changed and why.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Describe the steps required to review and test the changes.

Links
-----

Add links to any relevant [Trello cards](https://trello.com/b/9Pvq5z2n/govuk-coronavirus-services-team-doing-board),
Zendesk tickets or Sentry issues.

