### PR TITLE
Update checkbox text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,7 +285,7 @@ en:
                 label: No, I’m unable to leave my home for another reason
             custom_select_error: Select if you’re able to leave your home or not
       being_unemployed:
-        title: Being unemployed or not having any work
+        title: Being made redundant or unemployed, or not having any work
         questions:
           self_employed:
             title: Are you self-employed or a sole trader?

--- a/spec/requests/need_help_with_spec.rb
+++ b/spec/requests/need_help_with_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "need-help-with" do
   end
 
   describe "POST /need-help-with" do
-    let(:selected) { ["Being unemployed or not having any work"] }
+    let(:selected) { ["Being made redundant or unemployed, or not having any work"] }
 
     it "updates the session store" do
       post need_help_with_path, params: { need_help_with: selected }


### PR DESCRIPTION
What
----

This changes updates the checkbox text on the 'What do you nedd help with
bacause of coronavirus' page from 'Being unemployed or not having any work'
to 'Being made redundant or unemployed, or not having any work'.

The section now includes redundancy information.

Links
-----

[Trello](https://trello.com/c/UWSOJel6/672-update-what-do-you-need-help-with-checkbox)

