### PR TITLE
Update pipeline deploy commands to use the latest cli version

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -39,7 +39,7 @@ run:
       cf auth
       cf t -o "$CF_ORG" -s "$CF_SPACE"
       cf create-app govuk-coronavirus-find-support || true
-      cf v3-apply-manifest -f manifest.yml
+      cf apply-manifest -f manifest.yml
       cf set-env govuk-coronavirus-find-support CF_STARTUP_TIMEOUT "$CF_STARTUP_TIMEOUT"
 
       cf scale -i "$INSTANCES" govuk-coronavirus-find-support

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -61,5 +61,5 @@ run:
       cf set-env govuk-coronavirus-find-support AWS_ERROR_PAGES_BUCKET_NAME "$AWS_ERROR_PAGES_BUCKET_NAME"
       cf set-env govuk-coronavirus-find-support AWS_REGION "$AWS_REGION"
 
-      cf v3-zdt-push govuk-coronavirus-find-support --wait-for-deploy-complete --no-route
+      cf push govuk-coronavirus-find-support --strategy rolling
       cf map-route govuk-coronavirus-find-support cloudapps.digital --hostname "$HOSTNAME"

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -38,7 +38,7 @@ run:
       cf api "$CF_API"
       cf auth
       cf t -o "$CF_ORG" -s "$CF_SPACE"
-      cf v3-create-app govuk-coronavirus-find-support || true
+      cf create-app govuk-coronavirus-find-support || true
       cf v3-apply-manifest -f manifest.yml
       cf set-env govuk-coronavirus-find-support CF_STARTUP_TIMEOUT "$CF_STARTUP_TIMEOUT"
 

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-cli
-    tag: 5b44bd954693937ddd07ee6c9e113923bc620aed
+    tag: latest
 inputs:
   - name: git-master
     path: src


### PR DESCRIPTION
What
----

The pipeline failed when deploying to staging. 

```
'v3-create-app' is not a registered command. See 'cf help -a'
'v3-apply-manifest' is not a registered command. See 'cf help -a'
```

The reason for this is that PaaS changed the Docker image to use a newer version of the CLI.

As a quick fix, we tagged a version that we knew to work with the cli that we are currently using. 

This updates the CLI commands so that we can go back to using `tag: latest` 

https://hub.docker.com/r/governmentpaas/cf-cli/tags

The changes are taken from the [list of updated CLI v7 commands](https://docs.cloudfoundry.org/cf-cli/v7.html#table)

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

NOTE: I'm not sure how to test this locally.
Install version 7 of the CLI:
```
brew install cloudfoundry/tap/cf-cli@7
```

Links
-----

[Trello cards](https://trello.com/c/o0LxKNog)

