### PR TITLE
Remove link to EV service

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -669,13 +669,6 @@ en:
         - 'No'
         - Not sure
         items:
-        - id: '0112'
-          text: Find out if you can get support as a clinically extremely vulnerable
-            person.
-          href: https://www.gov.uk/coronavirus-extremely-vulnerable/
-          show_to_nations:
-          - England
-          show_to_vulnerable_person: true
         - id: '0038'
           text: Find out if you can get help if you’re clinically at high risk from
             coronavirus (Gov.scot).

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -64,30 +64,6 @@ RSpec.feature "Fill in the find support form" do
     they_are_given_a_link_for_providing_feedback
   end
 
-  scenario "Complete the form when in England, cannot get food and is high risk vulnerable" do
-    given_a_user_is_struggling_because_of_coronavirus
-    and_they_live_in_england
-    and_needs_help_with_getting_food
-    and_is_not_finding_it_hard_to_afford_food
-    and_is_unable_to_get_food
-    and_is_not_able_to_go_out_as_they_are_vulnerable
-    they_view_the_results_page
-    they_are_provided_with_information_about_getting_support_when_vulnerable
-    they_are_given_a_link_for_providing_feedback
-  end
-
-  scenario "Complete the form when in England, cannot get food and is not high risk vulnerable" do
-    given_a_user_is_struggling_because_of_coronavirus
-    and_they_live_in_england
-    and_needs_help_with_getting_food
-    and_is_not_finding_it_hard_to_afford_food
-    and_is_unable_to_get_food
-    and_is_not_able_to_go_out_if_absolutely_necessary
-    they_view_the_results_page
-    they_are_not_provided_with_information_about_getting_support_when_vulnerable
-    they_are_given_a_link_for_providing_feedback
-  end
-
   scenario "Ensure we can perform a healthcheck" do
     visit healthcheck_path
 

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -155,22 +155,6 @@ module FillInTheFormSteps
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
-  def and_is_not_able_to_go_out_if_absolutely_necessary
-    expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_go_out.title"))
-
-    choose I18n.t("coronavirus_form.groups.getting_food.questions.able_to_go_out.options.option_has_symptoms.label")
-
-    click_on I18n.t("coronavirus_form.submit_and_next")
-  end
-
-  def and_is_not_able_to_go_out_as_they_are_vulnerable
-    expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_go_out.title"))
-
-    choose I18n.t("coronavirus_form.groups.getting_food.questions.able_to_go_out.options.option_high_risk.label")
-
-    click_on I18n.t("coronavirus_form.submit_and_next")
-  end
-
   def they_view_the_results_page
     expect(page).to have_content(I18n.t("coronavirus_form.results.header.title"))
     expect(current_path).to eq "/results"
@@ -187,14 +171,6 @@ module FillInTheFormSteps
   def they_are_provided_with_information_about_getting_food
     expect(page).to have_content(I18n.t("results_link.getting_food.afford_food.title"))
     expect(page).to have_content(I18n.t("results_link.getting_food.get_food.title"))
-  end
-
-  def they_are_provided_with_information_about_getting_support_when_vulnerable
-    expect(page).to have_content(I18n.t("results_link.getting_food.get_food.items")[0][:text])
-  end
-
-  def they_are_not_provided_with_information_about_getting_support_when_vulnerable
-    expect(page).not_to have_content(I18n.t("results_link.getting_food.get_food.items")[0][:text])
   end
 
   def they_are_provided_with_information_about_being_self_employed

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -155,6 +155,22 @@ module FillInTheFormSteps
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
+  def and_is_not_able_to_go_out_if_absolutely_necessary
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_go_out.title"))
+
+    choose I18n.t("coronavirus_form.groups.getting_food.questions.able_to_go_out.options.option_has_symptoms.label")
+
+    click_on I18n.t("coronavirus_form.submit_and_next")
+  end
+
+  def and_is_not_able_to_go_out_as_they_are_vulnerable
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.getting_food.questions.able_to_go_out.title"))
+
+    choose I18n.t("coronavirus_form.groups.getting_food.questions.able_to_go_out.options.option_high_risk.label")
+
+    click_on I18n.t("coronavirus_form.submit_and_next")
+  end
+
   def they_view_the_results_page
     expect(page).to have_content(I18n.t("coronavirus_form.results.header.title"))
     expect(current_path).to eq "/results"


### PR DESCRIPTION
What
----

Trello: https://trello.com/c/3P1RBQQp/679-remove-link-to-ev-service-by-17th-july

Removed links and updated tests 

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Describe the steps required to review and test the changes.

Links
-----

Add links to any relevant [Trello cards](https://trello.com/b/9Pvq5z2n/govuk-coronavirus-services-team-doing-board),
Zendesk tickets or Sentry issues.

