### PR TITLE
702 Update simplecov configuration so that both XML and HTML files ar…

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,10 @@ require "rspec/rails"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 SimpleCov.start
-SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::CoberturaFormatter,
+])
 
 Capybara.javascript_driver = :apparition
 


### PR DESCRIPTION
What
----

The current configuration generates `coverage.xml` which is used by codecov in CI, to populate a coverage report on Github.

However, for debugging coverage issues locally, the html files generated by the default configuration are easier to use.

This PR updates the configuration such that both XML and HTML files are generated on test.

How to review
-------------

If you checkout this branch locally:

- delete the contents of `/coverage`
- then run `rake` or `rspec`

The tests will run successful and the coverage folder will be repopulated, containing both `coverage.xml` and `index.html`

Links
-----
[Trello card](https://trello.com/c/aEhbXcFS/702-update-simplecov-configuration-so-both-xml-and-html-files-are-produced)
[Stackoverflow post describing solution](https://stackoverflow.com/questions/61772734/publish-test-reports-rails-with-xml-and-html-format)

