### PR TITLE
687 Put feedback call to action under each section

### DIFF
--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -4,8 +4,9 @@ module ResultsHelper
       filtered_questions = filter_questions_by_session(group_key, session)
       unless filtered_questions.empty?
         {
-          heading: I18n.t("coronavirus_form.groups.#{group_key}.title"),
+          title: I18n.t("coronavirus_form.groups.#{group_key}.title"),
           questions: filtered_questions,
+          group_key: group_key,
         }
       end
     end

--- a/app/views/components/_actions-group.html.erb
+++ b/app/views/components/_actions-group.html.erb
@@ -1,6 +1,6 @@
 <%
   title ||= nil
-  subsections ||= []
+  questions ||= []
 %>
 <section class="app-c-actions-group">
   <div class="govuk-grid-row">
@@ -8,16 +8,16 @@
       <h2 class="govuk-heading-l"><%= title %></h2>
     </div>
     <div class="govuk-grid-column-two-thirds">
-      <% subsections.each do |subsection| %>
-        <div data-ec-list-subsection="<%= subsection[:title] %>">
-          <h3 class="govuk-heading-m"><%= subsection[:title] %></h3>
+      <% questions.each do |question| %>
+        <div data-ec-list-question="<%= question[:title] %>">
+          <h3 class="govuk-heading-m"><%= question[:title] %></h3>
           <% %i[items support_and_advice_items].each do |item_type| %>
-            <% if subsection[item_type]&.any? %>
+            <% if question[item_type]&.any? %>
               <% if item_type == :support_and_advice_items %>
                 <h4 class="govuk-heading-s"><%= t("coronavirus_form.results.support_and_advice_text") %></h4>
               <% end %>
               <ul class="govuk-list">
-              <% subsection[item_type].each do |item| %>
+              <% question[item_type].each do |item| %>
                 <li>
                   <% if item[:href] %>
                     <%= link_to item[:text], item[:href], class: "govuk-link" %>
@@ -31,6 +31,7 @@
           <% end %>
         </div>
       <% end %>
+      <%= render "components/feedback", group_key: group_key %>
     </div>
   </div>
 </section>

--- a/app/views/components/_callout.html.erb
+++ b/app/views/components/_callout.html.erb
@@ -1,9 +1,4 @@
-<%
-  title ||= nil
-%>
 <div class="app-c-callout">
-  <% if title %>
-    <h3 class="app-c-callout__title"><%= title %></h3>
-  <% end %>
+  <%= content_tag(:h3, title, class: "app-c-callout__title") if title %>
   <%= yield %>
 </div>

--- a/app/views/components/_feedback.html.erb
+++ b/app/views/components/_feedback.html.erb
@@ -1,0 +1,9 @@
+<%
+  group_key ||= :default
+  link_text = t(:link_text, scope: :feedback)
+  link_href = t(:link_href, scope: :feedback)
+  title_text = t("titles.#{group_key}", scope: :feedback)
+%>
+<%= render("components/callout", title: title_text) do %>
+  <%= link_to link_text, link_href, class: "govuk-link" %>
+<% end %>

--- a/app/views/coronavirus_form/results.html.erb
+++ b/app/views/coronavirus_form/results.html.erb
@@ -1,4 +1,5 @@
-<% title = results_title(result_groups(session)) %>
+<% session_result_groups = result_groups(session) %>
+<% title = results_title(session_result_groups) %>
 
 <% content_for :title do %>
   <%= title %>
@@ -28,24 +29,16 @@
   %>
 <% end %>
 
-<% if result_groups(session).empty? %>
+<% if session_result_groups.empty? %>
   <%= sanitize(t("coronavirus_form.results.no_results")) %>
   <%= sanitize(t("coronavirus_form.results.no_results_#{session[:nation].downcase.gsub(" ", "_")}")) %>
+  <%= render "components/feedback" %>
 <% else %>
   <div data-track-ec-list="Find coronavirus support">
-    <% result_groups(session).each do |group| %>
-      <%= render "components/actions-group", {
-        title: group[1][:heading],
-        subsections: group[1][:questions]
-      } %>
+    <% session_result_groups.values.each do |group| %>
+      <%= render "components/actions-group", group %>
     <% end %>
   </div>
-<% end %>
-
-<%= render "components/callout", {
-  title: "Help us improve"
-} do %>
-  <%= link_to t("coronavirus_form.results.feedback.link_text"), t("coronavirus_form.results.feedback.link_href"), class: "govuk-link" %>
 <% end %>
 
 <% content_for :escape_link do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -391,10 +391,6 @@ en:
         title_no_results: Information based on your answers - no specific information
         start_again_text: Start again
       support_and_advice_text: Support and advice
-      feedback:
-        text: Help us improve
-        link_text: Give feedback on this service
-        link_href: https://www.gov.uk/done/find-coronavirus-support
       no_results: |
         <p class="govuk-body">Based on your answers, there’s no specific information for you in this service at the moment. It will be updated regularly.</p>
 
@@ -1139,3 +1135,15 @@ en:
           text: Advice on supporting children’s mental health during coronavirus (Young
             Minds)
           href: https://youngminds.org.uk/find-help/for-parents/supporting-your-child-during-the-coronavirus-pandemic/
+  feedback:
+    link_text: Give feedback on this service
+    link_href: https://www.gov.uk/done/find-coronavirus-support
+    titles:
+      feeling_unsafe: Was this information on what to do if you’re feeling unsafe or worried about someone else helpful?
+      paying_bills: Was this information on paying your bills, rent, or mortgage helpful?
+      getting_food: Was this information on getting food helpful?
+      being_unemployed: Was this information on being made redundant or unemployed, or not having any work helpful?
+      going_in_to_work: Was this information on going in to work helpful?
+      somewhere_to_live: Was this information on having somewhere to live helpful?
+      mental_health: Was this information on mental health and wellbeing helpful?
+      default: What were you looking for support with?

--- a/spec/controllers/coronavirus_form/results_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/results_controller_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::ResultsController, type: :controller do
+  render_views
+
+  describe "GET /results" do
+    subject { get :show }
+
+    before do
+      session[:nation] = "England"
+    end
+
+    it "shows default feedback" do
+      expect(subject.body).to include(I18n.t("feedback.titles.default"))
+    end
+
+    context "when an answer is present" do
+      before { session[:have_you_been_evicted] = "Yes" }
+
+      it "shows the feed back for that answer" do
+        expect(expect(subject.body).to(include(I18n.t("feedback.titles.somewhere_to_live"))))
+      end
+
+      it "does not show default feedback" do
+        expect(subject.body).not_to include(I18n.t("feedback.titles.default"))
+      end
+
+      it "does not show other feedback" do
+        expect(subject.body).not_to include(I18n.t("feedback.titles.mental_health"))
+      end
+    end
+
+    context "with multiple answers" do
+      before do
+        session[:have_you_been_evicted] = "Yes"
+        session[:get_food] = "No"
+      end
+
+      it "shows the feed back for each answer" do
+        expect(expect(subject.body).to(include(I18n.t("feedback.titles.somewhere_to_live"))))
+        expect(expect(subject.body).to(include(I18n.t("feedback.titles.getting_food"))))
+      end
+
+      it "does not show default feedback" do
+        expect(subject.body).not_to include(I18n.t("feedback.titles.default"))
+      end
+
+      it "does not show other feedback" do
+        expect(subject.body).not_to include(I18n.t("feedback.titles.mental_health"))
+      end
+    end
+  end
+end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -215,6 +215,6 @@ module FillInTheFormSteps
   end
 
   def they_are_given_a_link_for_providing_feedback
-    expect(page).to have_content(I18n.t("coronavirus_form.results.feedback.link_text"))
+    expect(page).to have_content(I18n.t("feedback.link_text"))
   end
 end


### PR DESCRIPTION
What
----
- Moved feedback to dedicated section of translation file
- Added feedback title entries for each question group in file
- Moved feedback output into dedicated partial
- Rendered feedback partial within action group
- Made title labels consistent (so they are not renamed as headings
  and then renamed back to titles again)
- Added controller test so fine grained behaviour could be tested
- Prevent the hash generated by `result_groups(session)` being created three times 
  when only needed once in results view

Why
----
The triage tool doesn't get a lot of feedback - but the feedback it does get is very skewed towards users that don't get any results (and therefore find the service 'useless'). This could be because users don't see the feedback CTA unless they don't get any results. We should explore making it more visible to all users so we get a better reflection of how our users are finding the tool.

Example of change
----

![mulitple_feedback_callouts](https://user-images.githubusercontent.com/213040/88045804-0417b300-cb47-11ea-91bb-37de019b4be3.png)

Links
-----

[Trello card](https://trello.com/c/2vze3A5S/687-put-feedback-call-to-action-under-each-section)

