### PR TITLE
724 Fix return_path in privacy, cookies and accessibility controller

### DIFF
--- a/app/controllers/concerns/set_previous_page.rb
+++ b/app/controllers/concerns/set_previous_page.rb
@@ -1,0 +1,13 @@
+module SetPreviousPage
+  include ActionView::Helpers::UrlHelper
+
+  def set_previous_page
+    @previous_page = previous_page_from_referer
+  end
+
+  def previous_page_from_referer
+    return first_question_path if request.referer.blank? || current_page?(request.referer)
+
+    request.referer
+  end
+end

--- a/app/controllers/coronavirus_form/accessibility_statement_controller.rb
+++ b/app/controllers/coronavirus_form/accessibility_statement_controller.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::AccessibilityStatementController < ApplicationController
+  include SetPreviousPage
+
   def show
-    @previous_page = return_path
+    set_previous_page
     super
-  end
-
-private
-
-  def return_path
-    request.referer.presence ? first_question_path : request.referer
   end
 end

--- a/app/controllers/coronavirus_form/cookies_controller.rb
+++ b/app/controllers/coronavirus_form/cookies_controller.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::CookiesController < ApplicationController
+  include SetPreviousPage
+
   def show
-    @previous_page = return_path
+    set_previous_page
     super
-  end
-
-private
-
-  def return_path
-    request.referer.presence ? first_question_path : request.referer
   end
 end

--- a/app/controllers/coronavirus_form/privacy_controller.rb
+++ b/app/controllers/coronavirus_form/privacy_controller.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::PrivacyController < ApplicationController
+  include SetPreviousPage
+
   def show
-    @previous_page = return_path
+    set_previous_page
     super
-  end
-
-private
-
-  def return_path
-    request.referer.presence ? first_question_path : request.referer
   end
 end

--- a/spec/features/accessibility_statement_spec.rb
+++ b/spec/features/accessibility_statement_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.feature "Access the accessibility statement" do
+  include FillInTheFormSteps
+
+  scenario "Access accessibility statement directly and return" do
+    visit accessibility_statement_path
+    expect_to_be_on_accessibility_statement_page
+    click_on_back_link
+    expect_to_be_on_start_page
+  end
+
+  scenario "Access accessibility statement via link on form and return" do
+    given_a_user_is_struggling_because_of_coronavirus
+    and_they_live_in_england
+    expect_to_be_on_need_help_page
+    click_on_accessibility_statement_link
+    expect_to_be_on_accessibility_statement_page
+    click_on_back_link
+    expect_to_be_on_need_help_page
+  end
+
+  def expect_to_be_on_accessibility_statement_page
+    expect(page).to have_content(I18n.t("accessibility_statement.title"))
+  end
+
+  def click_on_accessibility_statement_link
+    click_on I18n.t("accessibility_statement.title")
+  end
+end

--- a/spec/features/cookies_page_spec.rb
+++ b/spec/features/cookies_page_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.feature "Access the cookies page" do
+  include FillInTheFormSteps
+
+  scenario "Access cookies page directly and return" do
+    visit cookies_path
+    expect_to_be_on_cookies_page
+    click_on_back_link
+    expect_to_be_on_start_page
+  end
+
+  scenario "Access cookies page via link on form and return" do
+    given_a_user_is_struggling_because_of_coronavirus
+    and_they_live_in_england
+    expect_to_be_on_need_help_page
+    click_on_cookies_link
+    expect_to_be_on_cookies_page
+    click_on_back_link
+    expect_to_be_on_need_help_page
+  end
+
+  def expect_to_be_on_cookies_page
+    expect(page).to have_content(I18n.t("cookies.title"))
+  end
+
+  def click_on_cookies_link
+    click_on I18n.t("cookies.title")
+  end
+end

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -69,18 +69,6 @@ RSpec.feature "Fill in the find support form" do
     expect(page).to have_content("OK")
   end
 
-  scenario "Ensure the privacy notice page is visible" do
-    visit privacy_path
-
-    expect(page).to have_content(I18n.t("privacy_page.title"))
-  end
-
-  scenario "Ensure the accessibility statement page is visible" do
-    visit accessibility_statement_path
-
-    expect(page).to have_content(I18n.t("accessibility_statement.title"))
-  end
-
   scenario "Ensure the session expired page is visible" do
     visit session_expired_path
 

--- a/spec/features/privacy_page_spec.rb
+++ b/spec/features/privacy_page_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.feature "Access the privacy page" do
+  include FillInTheFormSteps
+
+  scenario "Access privacy page directly and return" do
+    visit privacy_path
+    expect_to_be_on_privacy_page
+    click_on_back_link
+    expect_to_be_on_start_page
+  end
+
+  scenario "Access privacy page via link on form and return" do
+    given_a_user_is_struggling_because_of_coronavirus
+    and_they_live_in_england
+    expect_to_be_on_need_help_page
+    click_on_privacy_page_link
+    expect_to_be_on_privacy_page
+    click_on_back_link
+    expect_to_be_on_need_help_page
+  end
+
+  def expect_to_be_on_privacy_page
+    expect(page).to have_content(I18n.t("privacy_page.title"))
+  end
+
+  def click_on_privacy_page_link
+    click_on I18n.t("privacy_page.title")
+  end
+end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -201,4 +201,16 @@ module FillInTheFormSteps
   def they_are_given_a_link_for_providing_feedback
     expect(page).to have_content(I18n.t("feedback.link_text"))
   end
+
+  def click_on_back_link
+    click_on I18n.t("components.back_link.back")
+  end
+
+  def expect_to_be_on_start_page
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.location.questions.nation.title"))
+  end
+
+  def expect_to_be_on_need_help_page
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.filter_questions.questions.need_help_with.title"))
+  end
 end


### PR DESCRIPTION
`request.referer.presence ? first_question_path : request.referer` needs fixing as logic the wrong way around.

What
----

- Correct logic in previous page/return path logic
- Move previous page logic into shared concern
- Update logic to handle referer being same page (Chrome behaviour)
  rather than blank if no referer (Firefox behaviour)
- Create dedicated feature tests for these controllers
- Remove feature specs for these controllers from filling in form spec

Links
-----

[Trello cards](https://trello.com/c/0JPTnVXu/724-fix-returnpath-methods-in-privacy-cookies-and-accessibility-controller)

