### PR TITLE
Remove `set_session_history` as it appears it was never used

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,13 +30,6 @@ private
     raise NotImplementedError, "Define a previous path"
   end
 
-  def set_session_history
-    if session[:current_path] != request.path
-      session[:previous_path] = session[:current_path]
-    end
-    session[:current_path] = request.path
-  end
-
   def first_question_path
     nation_path
   end


### PR DESCRIPTION
What
----

Delete method `set_session_history` from application_controller
It doesn't appear to have been used and it has no tests to document it.

How to review
-------------

Check it's not used anywhere.

Links
-----

https://trello.com/c/l7i38gEh/727-remove-unused-method-setsessionhistory-in-applicationcontroller