### PR TITLE
Fixes analytics on results page

### DIFF
--- a/app/views/components/_actions-group.html.erb
+++ b/app/views/components/_actions-group.html.erb
@@ -9,7 +9,7 @@
     </div>
     <div class="govuk-grid-column-two-thirds">
       <% questions.each do |question| %>
-        <div data-ec-list-question="<%= question[:title] %>">
+        <div data-ec-list-subsection="<%= question[:title] %>">
           <h3 class="govuk-heading-m"><%= question[:title] %></h3>
           <% %i[items support_and_advice_items].each do |item_type| %>
             <% if question[item_type]&.any? %>


### PR DESCRIPTION
The Analytics code was looking for `data-ec-list-subsection`, the use of `data-ec-list-question` is not documented anywhere.

This was caused by this commit: https://github.com/alphagov/govuk-coronavirus-find-support/commit/a80fab8721786ab27b97be063a32f86619716d8c#diff-d4e7ecc147ff9ecf21ade9419e00a274R12

https://trello.com/c/Fe34Ewsa/726-ga-tracking-stopped-on-results-page