### PR TITLE
Fix typo in National Domestic Abuse Helpline link.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -413,7 +413,7 @@ en:
         - id: '0003'
           text: Call the National Domestic Abuse Helpline on <a href="tel:0808 2000
             247" class="govuk-link">0808 2000 247</a>, you can get advice in different
-            languages. You can also <a href="thttps://www.nationaldahelpline.org.uk/Chat-to-us-online"
+            languages. You can also <a href="https://www.nationaldahelpline.org.uk/Chat-to-us-online"
             class="govuk-link">get help online</a>.
         - id: '0004'
           text: If you’re a child or young person call Childline on <a href="tel:0800


### PR DESCRIPTION
What
----

Fix typo in National Domestic Abuse Helpline link.

How to review
-------------

Check link in results page

Links
-----

Add links to any relevant [Trello cards](https://trello.com/b/9Pvq5z2n/govuk-coronavirus-services-team-doing-board),
Zendesk tickets or Sentry issues.

