### PR TITLE
Add GA tracking to feedback link

### DIFF
--- a/app/views/components/_feedback.html.erb
+++ b/app/views/components/_feedback.html.erb
@@ -5,5 +5,13 @@
   title_text = t("titles.#{group_key}", scope: :feedback)
 %>
 <%= render("components/callout", title: title_text) do %>
-  <%= link_to link_text, link_href, class: "govuk-link" %>
+  <%= link_to link_text, link_href, 
+  class: "govuk-link",     
+    data: {
+      module: "track-link",
+      "track-category": "OnSite Feedback",
+      "track-action": "Open form",
+      "track-label": "Give feedback on this service"
+    }
+  %>
 <% end %>

--- a/spec/javascripts/analytics-track-feedback-link.spec.js
+++ b/spec/javascripts/analytics-track-feedback-link.spec.js
@@ -1,0 +1,25 @@
+/* eslint-env jasmine, jquery */
+
+var $ = window.jQuery
+
+describe('Feedback link tracker', function () {
+  var GOVUK = window.GOVUK || {}
+  var $feedbackLink
+
+  beforeEach(function () {
+    spyOn(window, 'ga')
+
+    $feedbackLink = $('<a data-module="track-link" data-track-category="OnSite Feedback" data-track-action="Open form" data-track-label="Give feedback on this service" href="https://www.gov.uk/done/find-coronavirus-support" onclick="event.preventDefault()">Give feedback on this service</a>')
+
+    var tracker = new GOVUK.Modules.TrackLink()
+    tracker.start($feedbackLink)
+  })
+
+  it('sends data to Google Analytics when feedback link is clicked', function () {
+    $feedbackLink.trigger('click')
+
+    expect(window.ga).toHaveBeenCalledWith(
+      'send', { hitType: 'event', eventCategory: 'OnSite Feedback', eventAction: 'Open form', eventLabel: 'Give feedback on this service' }
+    )
+  })
+})


### PR DESCRIPTION
What
----

Add Google Analytics event tracking to the feedback button on the results page.

Why
----

So we can track of which users click on feedback and their journeys. This will help us identify problems

How to review
-------------

The naming for the Event category, Action and Label is established in the linked trello card. 

I have tested the event tracking manually using Google Analytics Debugger. To test I:

Accepted cookies
Navigated to the results page
Used the Google Analytics Debugger extension to see the event fired when the 'Feedback' link was clicked
Denied cookies
Checked that the event did not fire

<img width="1438" alt="Screenshot 2020-07-30 at 17 57 54" src="https://user-images.githubusercontent.com/41922771/89012785-a7688500-d30a-11ea-8c74-87e6bbf4f8e7.png">




Links
-----

 [Trello](https://trello.com/c/B0UAHNfO/716-add-event-tracking-to-feedback-mechanism)




