### PR TITLE
Remove Scotland link

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -652,12 +652,6 @@ en:
         - 'No'
         - Not sure
         items:
-        - id: '0038'
-          text: Find out if you can sign up for supermarket delivery priority access if you’re clinically at high risk from
-            coronavirus (Gov.scot)
-          href: https://www.gov.scot/publications/covid-shielding/pages/overview/
-          show_to_nations:
-          - Scotland
         - id: '0042'
           text: Find out if you can get help from the Scottish Government
           href: https://www.gov.scot/publications/coronavirus-covid-19-help-for-vulnerable-people


### PR DESCRIPTION
Trello: 
https://trello.com/c/iyhEoiub/344-remove-link-to-scotland-shielding-advice-after-31-july

What
----

Removed link 
        - id: '0038'
          text: Find out if you can sign up for supermarket delivery priority access if you’re clinically at high risk from
            coronavirus (Gov.scot)
          href: https://www.gov.scot/publications/covid-shielding/pages/overview/
          show_to_nations:
          - Scotland

Why
Not relevant after 31 July. 

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Describe the steps required to review and test the changes.

Links
-----

Add links to any relevant [Trello cards](https://trello.com/b/9Pvq5z2n/govuk-coronavirus-services-team-doing-board),
Zendesk tickets or Sentry issues.

