### PR TITLE
Move "Are you off work ill?" question

### DIFF
--- a/app/controllers/coronavirus_form/are_you_off_work_ill_controller.rb
+++ b/app/controllers/coronavirus_form/are_you_off_work_ill_controller.rb
@@ -36,6 +36,6 @@ private
   end
 
   def group
-    "being_unemployed"
+    "going_in_to_work"
   end
 end

--- a/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
+++ b/app/controllers/coronavirus_form/have_you_been_made_unemployed_controller.rb
@@ -21,20 +21,11 @@ class CoronavirusForm::HaveYouBeenMadeUnemployedController < ApplicationControll
       render controller_path
     else
       update_session_store
-      update_questions_to_ask
       redirect_to polymorphic_url(next_question(controller_name))
     end
   end
 
 private
-
-  def update_questions_to_ask
-    session[:questions_to_ask] = if I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.skip_next_question_options").include? @form_responses[:have_you_been_made_unemployed]
-                                   remove_questions(%w[are_you_off_work_ill])
-                                 else
-                                   add_questions(%w[are_you_off_work_ill], controller_name)
-                                 end
-  end
 
   def update_session_store
     session[:have_you_been_made_unemployed] = @form_responses[:have_you_been_made_unemployed]

--- a/app/controllers/coronavirus_form/self_employed_controller.rb
+++ b/app/controllers/coronavirus_form/self_employed_controller.rb
@@ -30,9 +30,9 @@ private
 
   def update_questions_to_ask
     session[:questions_to_ask] = if I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.skip_next_question_options").include? @form_responses[:self_employed]
-                                   remove_questions(%w[have_you_been_made_unemployed are_you_off_work_ill])
+                                   remove_questions(%w[have_you_been_made_unemployed])
                                  else
-                                   add_questions(%w[have_you_been_made_unemployed are_you_off_work_ill], controller_name)
+                                   add_questions(%w[have_you_been_made_unemployed], controller_name)
                                  end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -301,16 +301,6 @@ en:
             - Yes, I’ve been put on temporary leave (on furlough), or might be soon
             custom_select_error: Select if you’ve been made redundant, put on
               temporary leave (on furlough), or you’re out of work
-          are_you_off_work_ill:
-            title: Are you off work because you’re ill or self-isolating?
-            title_caption: Going in to work
-            options:
-              option_yes:
-                label: 'Yes'
-              option_no:
-                label: 'No'
-            custom_select_error: Select yes if you’re off work because you’re ill
-              or self-isolating
       going_in_to_work:
         title: Going in to work
         questions:
@@ -324,6 +314,15 @@ en:
               not_sure:
                 label: Not sure
             custom_select_error: Select yes if you’re worried about going in to work
+          are_you_off_work_ill:
+            title: Are you off work because you’re ill or self-isolating?
+            options:
+              option_yes:
+                label: 'Yes'
+              option_no:
+                label: 'No'
+            custom_select_error: Select yes if you’re off work because you’re ill
+              or self-isolating
       somewhere_to_live:
         title: Having somewhere to live
         questions:
@@ -816,32 +815,6 @@ en:
           href: https://www.mygov.scot/help-redundancy/
           show_to_nations:
           - Scotland
-      are_you_off_work_ill:
-        title: If you’re off work because you’re ill or self isolating
-        show_options:
-        - 'Yes'
-        items:
-        - id: '0064'
-          text: What to do if you’re employed but cannot work, for example if you’re ill
-          href: https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work
-        - id: '1000'
-          text: Your employment rights if you’re self-isolating after returning to the UK
-          href: https://www.gov.uk/guidance/self-isolating-after-returning-to-the-uk-your-employment-rights
-        - id: '0067'
-          text: Check if you’re eligible for the Discretionary Assistance Fund (Welsh
-            Government)
-          href: https://gov.wales/discretionary-assistance-fund-daf
-          show_to_nations:
-          - Wales
-        support_and_advice_items:
-        - id: '0066'
-          text: Find out about the help you can get if you’re self-employed or work
-            in the gig economy (Money Advice Service)
-          href: https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you
-        - id: '0065'
-          text: Find out about getting statutory sick pay if you’re self-isolating
-            (Acas)
-          href: https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay
       self_employed:
         title: If you’re self employed, a freelancer, or a sole trader
         show_options:
@@ -991,6 +964,32 @@ en:
         - id: '0084'
           text: Your rights if you think you might have been discriminated against at work 
           href: https://www.gov.uk/discrimination-your-rights/discrimination-at-work
+      are_you_off_work_ill:
+        title: If you’re off work because you’re ill or self isolating
+        show_options:
+        - 'Yes'
+        items:
+        - id: '0064'
+          text: What to do if you’re employed but cannot work, for example if you’re ill
+          href: https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work
+        - id: '1000'
+          text: Your employment rights if you’re self-isolating after returning to the UK
+          href: https://www.gov.uk/guidance/self-isolating-after-returning-to-the-uk-your-employment-rights
+        - id: '0067'
+          text: Check if you’re eligible for the Discretionary Assistance Fund (Welsh
+            Government)
+          href: https://gov.wales/discretionary-assistance-fund-daf
+          show_to_nations:
+          - Wales
+        support_and_advice_items:
+        - id: '0066'
+          text: Find out about the help you can get if you’re self-employed or work
+            in the gig economy (Money Advice Service)
+          href: https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you
+        - id: '0065'
+          text: Find out about getting statutory sick pay if you’re self-isolating
+            (Acas)
+          href: https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay
     somewhere_to_live:
       have_somewhere_to_live:
         title: If you do not have somewhere to live or might become homeless

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,7 +302,7 @@ en:
             custom_select_error: Select if you’ve been made redundant, put on
               temporary leave (on furlough), or you’re out of work
       going_in_to_work:
-        title: Going in to work
+        title: Being worried about working, or off work because you’re self-isolating
         questions:
           worried_about_work:
             title: Are you worried about going in to work?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,10 +53,6 @@ Rails.application.routes.draw do
     get "/have-you-been-made-unemployed", to: "have_you_been_made_unemployed#show"
     post "/have-you-been-made-unemployed", to: "have_you_been_made_unemployed#submit"
 
-    # Question: Are you off work because you're ill or self-isolating?
-    get "/are-you-off-work-ill", to: "are_you_off_work_ill#show"
-    post "/are-you-off-work-ill", to: "are_you_off_work_ill#submit"
-
     # Question: Are you self-employed or a sole trader?
     get "/self-employed", to: "self_employed#show"
     post "/self-employed", to: "self_employed#submit"
@@ -64,6 +60,10 @@ Rails.application.routes.draw do
     # Question: Are you worried about going into work?
     get "/worried-about-work", to: "worried_about_work#show"
     post "/worried-about-work", to: "worried_about_work#submit"
+
+    # Question: Are you off work because you're ill or self-isolating?
+    get "/are-you-off-work-ill", to: "are_you_off_work_ill#show"
+    post "/are-you-off-work-ill", to: "are_you_off_work_ill#submit"
 
     # Question: Have you got somewhere to live?
     get "/have-somewhere-to-live", to: "have_somewhere_to_live#show"

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -15,8 +15,8 @@ RSpec.feature "Fill in the find support form" do
       and_is_unable_to_get_food
       and_is_not_self_employed_or_a_sole_trader
       and_has_not_been_told_to_stop_working
-      and_is_off_work_because_ill_or_self_isolating
       and_is_worried_about_going_to_work_because_of_living_with_someone_vulnerable
+      and_is_off_work_because_ill_or_self_isolating
       and_has_nowhere_to_live
       and_has_been_evicted
       and_is_worried_about_mental_health

--- a/spec/helpers/result_helper_spec.rb
+++ b/spec/helpers/result_helper_spec.rb
@@ -26,13 +26,11 @@ RSpec.describe ResultsHelper, type: :helper do
       session.merge!({
         "selected_groups": %i[being_unemployed],
         "have_you_been_made_unemployed": I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_might_be.label"),
-        "are_you_off_work_ill": I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_yes.label"),
         "self_employed": I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
         "nation": I18n.t("coronavirus_form.groups.location.questions.nation.options.option_england.label"),
       })
       result_array = [
         I18n.t("results_link.being_unemployed.have_you_been_made_unemployed.title"),
-        I18n.t("results_link.being_unemployed.are_you_off_work_ill.title"),
         I18n.t("results_link.being_unemployed.self_employed.title"),
       ]
       expect(result_groups(session)[:being_unemployed][:questions].map { |q| q[:title] }).to eq(result_array)
@@ -42,7 +40,7 @@ RSpec.describe ResultsHelper, type: :helper do
       session.merge!({
         "selected_groups": %i[being_unemployed getting_food],
         "have_you_been_made_unemployed": I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_might_be.label"),
-        "are_you_off_work_ill": I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_yes.label"),
+        "are_you_off_work_ill": I18n.t("coronavirus_form.groups.going_in_to_work.questions.are_you_off_work_ill.options.option_yes.label"),
         "self_employed": I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
         "afford_food": I18n.t("coronavirus_form.groups.getting_food.questions.afford_food.options.option_no.label"),
         "nation": I18n.t("coronavirus_form.groups.location.questions.nation.options.option_england.label"),
@@ -56,7 +54,7 @@ RSpec.describe ResultsHelper, type: :helper do
       session.merge!({
         "selected_groups": %i[being_unemployed],
         "have_you_been_made_unemployed": I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.option_might_be.label"),
-        "are_you_off_work_ill": I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_no.label"),
+        "are_you_off_work_ill": I18n.t("coronavirus_form.groups.going_in_to_work.questions.are_you_off_work_ill.options.option_no.label"),
         "self_employed": I18n.t("coronavirus_form.groups.being_unemployed.questions.self_employed.options.option_yes.label"),
         "nation": I18n.t("coronavirus_form.groups.location.questions.nation.options.option_england.label"),
       })

--- a/spec/requests/are_you_off_work_ill_spec.rb
+++ b/spec/requests/are_you_off_work_ill_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "still-working" do
-  let(:options) { I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options") }
+  let(:options) { I18n.t("coronavirus_form.groups.going_in_to_work.questions.are_you_off_work_ill.options") }
   let(:selected_option) { options.keys.sample }
-  let(:selected_option_text) { I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.#{selected_option}.label") }
+  let(:selected_option_text) { I18n.t("coronavirus_form.groups.going_in_to_work.questions.are_you_off_work_ill.options.#{selected_option}.label") }
 
   before do
     allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[are_you_off_work_ill feel_safe])
@@ -24,8 +24,8 @@ RSpec.describe "still-working" do
       it "shows the form" do
         visit are_you_off_work_ill_path
 
-        expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
-        I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options").each do |_, option|
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.are_you_off_work_ill.title"))
+        I18n.t("coronavirus_form.groups.going_in_to_work.questions.are_you_off_work_ill.options").each do |_, option|
           expect(page).to have_content(option[:label])
         end
       end
@@ -39,7 +39,7 @@ RSpec.describe "still-working" do
       it "shows the form without prefilled response" do
         visit are_you_off_work_ill_path
 
-        expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
+        expect(page).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.are_you_off_work_ill.title"))
         expect(page.find("input##{selected_option}")).not_to be_checked
       end
     end
@@ -73,8 +73,8 @@ RSpec.describe "still-working" do
     it "shows an error when no radio button selected" do
       post are_you_off_work_ill_path
 
-      expect(response.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
-      expect(response.body).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.custom_select_error"))
+      expect(response.body).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.are_you_off_work_ill.title"))
+      expect(response.body).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.are_you_off_work_ill.custom_select_error"))
     end
   end
 end

--- a/spec/requests/have_you_been_made_unemployed_spec.rb
+++ b/spec/requests/have_you_been_made_unemployed_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "have-you-been-made-unemployed" do
   let(:selected_option_text) { I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options.#{selected_option}.label") }
 
   before do
-    allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[have_you_been_made_unemployed are_you_off_work_ill feel_safe])
+    allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[have_you_been_made_unemployed feel_safe])
   end
 
   describe "GET /have-you-been-made-unemployed" do
@@ -59,27 +59,17 @@ RSpec.describe "have-you-been-made-unemployed" do
 
   describe "POST /still-working" do
     let(:positive_response) { I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.skip_next_question_options").sample }
-    let(:negative_response) do
-      (I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.options").map { |_, option| option[:label] } -
-        I18n.t("coronavirus_form.groups.being_unemployed.questions.have_you_been_made_unemployed.skip_next_question_options")).sample
-    end
+
     it "updates the session store" do
       post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: positive_response }
 
       expect(session[:have_you_been_made_unemployed]).to eq(positive_response)
     end
 
-    it "redirects to the next question for no response" do
-      post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: negative_response }
-
-      expect(session[:questions_to_ask]).to eq(%w[have_you_been_made_unemployed are_you_off_work_ill feel_safe])
-      expect(response).to redirect_to(are_you_off_work_ill_path)
-    end
-
-    it "removes irrelevant question for yes response" do
+    it "redirects to the next question" do
       post have_you_been_made_unemployed_path, params: { have_you_been_made_unemployed: positive_response }
 
-      expect(session[:questions_to_ask]).to eq(%w[have_you_been_made_unemployed feel_safe])
+      expect(response).to redirect_to(feel_safe_path)
     end
 
     it "shows an error when no radio button selected" do

--- a/spec/requests/self_employed_spec.rb
+++ b/spec/requests/self_employed_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "self-employed" do
     it "redirects to the next question for no response" do
       post self_employed_path, params: { self_employed: negative_response }
 
-      expect(session[:questions_to_ask]).to eq(%w[self_employed have_you_been_made_unemployed are_you_off_work_ill feel_safe])
+      expect(session[:questions_to_ask]).to eq(%w[self_employed have_you_been_made_unemployed feel_safe])
       expect(response).to redirect_to(have_you_been_made_unemployed_path)
     end
 

--- a/spec/requests/worried_about_work_spec.rb
+++ b/spec/requests/worried_about_work_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "worried-about-work" do
   let(:selected_option_text) { I18n.t("coronavirus_form.groups.going_in_to_work.questions.worried_about_work.options.#{selected_option}.label") }
 
   before do
-    allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[worried_about_work feel_safe])
+    allow_any_instance_of(QuestionsHelper).to receive(:questions_to_ask).and_return(%w[worried_about_work are_you_off_work_ill feel_safe])
   end
 
   describe "GET /worried-about-work" do
@@ -67,7 +67,7 @@ RSpec.describe "worried-about-work" do
     it "redirects to the next question" do
       post worried_about_work_path, params: { worried_about_work: selected_option_text }
 
-      expect(response).to redirect_to(feel_safe_path)
+      expect(response).to redirect_to(are_you_off_work_ill_path)
     end
 
     it "shows an error when no radio button selected" do

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -100,9 +100,9 @@ module FillInTheFormSteps
   end
 
   def and_is_off_work_because_ill_or_self_isolating
-    expect(page).to have_content(I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.groups.going_in_to_work.questions.are_you_off_work_ill.title"))
 
-    choose I18n.t("coronavirus_form.groups.being_unemployed.questions.are_you_off_work_ill.options.option_yes.label")
+    choose I18n.t("coronavirus_form.groups.going_in_to_work.questions.are_you_off_work_ill.options.option_yes.label")
 
     click_on I18n.t("coronavirus_form.submit_and_next")
   end


### PR DESCRIPTION
What
----

We are moving the "Are you off work ill?" question from the unemployed section to the going into work section. Also renaming the `Going in to work` option to `Being worried about working, or off work because you’re self-isolating` to make it easier for user's to find advice.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Selecting the "Being made redundant or unemployed, or not having any work" and the "Being worried about working, or off work because you’re self-isolating" option from the "What you need help with?" question.

You should be routed to the following question in this order:
- Are you self-employed, a freelancer, or a sole trader?
- Have you been made redundant or told to stop working? (_Having answered no to previous question_)
- Are you worried about going in to work?
- Are you off work because you’re ill or self-isolating?

Answering yes to the "Are you off work because you’re ill or self-isolating?" should show the relevant section on the results page under "Being worried about working, or off work because you’re self-isolating" group.

Links
-----

https://trello.com/c/F7VZa3kL/476-move-question-for-if-youre-off-work-ill-or-self-isolating

