### PR TITLE
Add route that redirects all GET requests to new app url if ENV present

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
 
   get "/", to: redirect("https://www.gov.uk/find-coronavirus-support")
 
+  if Rails.env.production?
+    get "*everything", to: redirect("https://www.gov.uk/find-coronavirus-support")
+  end
+
   scope module: "coronavirus_form" do
     first_question = "/need-help-with"
 


### PR DESCRIPTION
Reroutes all GET requests to https://www.gov.uk/find-coronavirus-support if app is in production mode

[Trello Ticket](https://trello.com/c/6Pf4DHwl/379-redirect-existing-triage-tool-to-smart-answer)

