### PR TITLE
Remove staging and prod smoke tests

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -130,42 +130,12 @@ jobs:
               Deploy to staging for the Find Support service has failed
               Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
-  - name: smoke-test-staging
-    plan:
-      - get: git-master
-        trigger: true
-        passed: [deploy-to-staging]
-      - get: tests-image
-        passed:
-          - build-tests-image
-      - task: smoke-test
-        file: git-master/concourse/tasks/smoke-test.yml
-        params:
-          URL: 'https://govuk-coronavirus-find-support-stg.cloudapps.digital/urgent-medical-help'
-          MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
-      - task: run-smoke-tests
-        image: tests-image
-        file: git-master/concourse/tasks/run-smoke-tests.yml
-        params:
-          TEST_URL: 'https://gds:((basic-auth-password))@govuk-coronavirus-find-support-stg.cloudapps.digital'
-        on_failure:
-          put: govuk-coronavirus-services-tech-slack
-          params:
-            channel: '#govuk-corona-services-tech'
-            username: 'Concourse (Find Support Service)'
-            icon_emoji: ':concourse:'
-            silent: true
-            text: |
-              :kaboom:
-              Staging smoke tests for the Find Support service have failed
-              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
-
   - name: deploy-to-prod
     serial: true
     plan:
       - get: git-master
         trigger: true
-        passed: [smoke-test-staging]
+        passed: [deploy-to-staging]
       - task: deploy-to-paas
         file: git-master/concourse/tasks/deploy-to-govuk-paas.yml
         params:
@@ -192,38 +162,6 @@ jobs:
             text: |
               :kaboom:
               Deploy to production for the Find Support service has failed
-              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
-
-  - name: smoke-test-prod
-    serial: true
-    plan:
-      - get: git-master
-        trigger: true
-        passed: [deploy-to-prod]
-      - get: tests-image
-        passed:
-          - build-tests-image
-      - task: smoke-test
-        file: git-master/concourse/tasks/smoke-test.yml
-        timeout: 5m
-        params:
-          URL: 'https://govuk-coronavirus-find-support-prod.cloudapps.digital/urgent-medical-help'
-          MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes. If this fails, you should investigate immediately."
-      - task: run-smoke-tests
-        image: tests-image
-        file: git-master/concourse/tasks/run-smoke-tests.yml
-        params:
-          TEST_URL: 'https://find-coronavirus-support.service.gov.uk'
-        on_failure:
-          put: govuk-coronavirus-services-tech-slack
-          params:
-            channel: '#govuk-corona-services-tech'
-            username: 'Concourse (Find Support Service)'
-            icon_emoji: ':concourse:'
-            silent: true
-            text: |
-              :kaboom:
-              Production smoke tests for the Find Support service have failed
               Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
   - name: run-link-checker-periodically


### PR DESCRIPTION
## What

We need to turn off smoke tests for this application.

## Why

The application is being moved to a Smart Answers version and all requests to this service are being redirected to the new Smart Answers flow version.

Running smoke tests is no longer valid.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

The only way we can test this change is to deploy the service.

Links
-----

[Trello](https://trello.com/c/6Pf4DHwl/379-redirect-existing-triage-tool-to-smart-answer)

