### PR TITLE
Archive repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# GOV.UK coronavirus - find support
+# GOV.UK coronavirus - find support (ARCHIVED ⚠️)
+
+This repository is the old Coronavirus Find Support service - https://find-coronavirus-support.service.gov.uk.
+
+**It is no longer deployed or in active development.**
+
+The service was migrated to [Smart Answers](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/find-coronavirus-support.rb) and is now available here: https://www.gov.uk/find-coronavirus-support
+
+---
 
 ![Run tests](https://github.com/alphagov/govuk-coronavirus-find-support/workflows/Run%20tests/badge.svg)
 


### PR DESCRIPTION
This repository is the old Coronavirus Find Support service - https://find-coronavirus-support.service.gov.uk.

It is no longer deployed or in active development as The service was migrated to https://github.com/alphagov/smart-answers and is now available here: https://www.gov.uk/find-coronavirus-support.

Links
-----

[Trello](https://trello.com/c/uxepiZuY/543-archive-the-govuk-coronavirus-find-support-repo)

